### PR TITLE
Replace stick figure avatars with colored dots and spinner

### DIFF
--- a/frontend/src/dashboard/contact_avatar_row.rs
+++ b/frontend/src/dashboard/contact_avatar_row.rs
@@ -347,6 +347,28 @@ const AVATAR_ROW_STYLES: &str = r#"
     overflow: visible;
 }
 
+@keyframes contacts-fade-in {
+    0%   { opacity: 0; transform: translateY(8px); }
+    100% { opacity: 1; transform: translateY(0); }
+}
+.people-arena--loaded {
+    animation: contacts-fade-in 0.4s ease-out;
+}
+.people-arena--loaded .figure-item {
+    opacity: 0;
+    animation: contacts-fade-in 0.3s ease-out forwards;
+}
+.people-arena--loaded .figure-item:nth-child(1) { animation-delay: 0.05s; }
+.people-arena--loaded .figure-item:nth-child(2) { animation-delay: 0.1s; }
+.people-arena--loaded .figure-item:nth-child(3) { animation-delay: 0.15s; }
+.people-arena--loaded .figure-item:nth-child(4) { animation-delay: 0.2s; }
+.people-arena--loaded .figure-item:nth-child(5) { animation-delay: 0.25s; }
+.people-arena--loaded .figure-item:nth-child(6) { animation-delay: 0.3s; }
+.people-arena--loaded .figure-item:nth-child(7) { animation-delay: 0.35s; }
+.people-arena--loaded .figure-item:nth-child(8) { animation-delay: 0.4s; }
+.people-arena--loaded .figure-item:nth-child(9) { animation-delay: 0.45s; }
+.people-arena--loaded .figure-item:nth-child(10) { animation-delay: 0.5s; }
+
 .people-target {
     display: flex;
     flex-direction: column;
@@ -410,6 +432,62 @@ const AVATAR_ROW_STYLES: &str = r#"
     align-items: center;
     gap: 0;
     padding: 0.15rem 0;
+}
+.people-figures--left {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0;
+}
+.people-figures-outer--left {
+    flex: 1;
+}
+.people-figures-outer--left::after {
+    display: none;
+}
+.figure-row {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.25rem;
+}
+.figure-row-targets {
+    display: flex;
+    flex-direction: row;
+    gap: 0.2rem;
+    flex-shrink: 0;
+}
+.figure-row-target {
+    width: 22px;
+    height: 22px;
+    border-radius: 50%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.55rem;
+    cursor: pointer;
+    transition: transform 0.15s, opacity 0.15s;
+    opacity: 0.7;
+}
+.figure-row-target:hover {
+    transform: scale(1.15);
+    opacity: 1;
+}
+.figure-row-target--sms {
+    background: rgba(74,222,128,0.12);
+    border: 1px solid rgba(74,222,128,0.3);
+    color: #4ade80;
+}
+.figure-row-target--call {
+    background: rgba(251,191,36,0.12);
+    border: 1px solid rgba(251,191,36,0.3);
+    color: #fbbf24;
+}
+.people-targets-stack {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+    flex-shrink: 0;
 }
 
 .figure-item {
@@ -2201,10 +2279,20 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
         let dot = render_contact_dot(color, None);
 
         html! {
-            <div class="figure-item" onclick={on_click}>
-                {dot}
-                {flying}
-                <span class="figure-label">{nick}</span>
+            <div class="figure-row">
+                <div class="figure-item" onclick={on_click}>
+                    {dot}
+                    {flying}
+                    <span class="figure-label">{nick}</span>
+                </div>
+                <div class="figure-row-targets">
+                    <div class="figure-row-target figure-row-target--sms">
+                        <i class="fa-solid fa-comment-sms"></i>
+                    </div>
+                    <div class="figure-row-target figure-row-target--call">
+                        <i class="fa-solid fa-phone"></i>
+                    </div>
+                </div>
             </div>
         }
     };
@@ -2212,9 +2300,19 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
     let render_phone_contact_figure = {
         let on_click = on_phone_contact_click.clone();
         html! {
-            <div class="figure-item" onclick={on_click}>
-                {render_contact_dot("#555", Some("contacts"))}
-                <span class="figure-label">{"Contacts"}</span>
+            <div class="figure-row">
+                <div class="figure-item" onclick={on_click}>
+                    {render_contact_dot("#555", Some("contacts"))}
+                    <span class="figure-label">{"Contacts"}</span>
+                </div>
+                <div class="figure-row-targets">
+                    <div class="figure-row-target figure-row-target--sms">
+                        <i class="fa-solid fa-comment-sms"></i>
+                    </div>
+                    <div class="figure-row-target figure-row-target--call">
+                        <i class="fa-solid fa-phone"></i>
+                    </div>
+                </div>
             </div>
         }
     };
@@ -2222,9 +2320,19 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
     let render_unknown_figure = {
         let on_click = on_default_click.clone();
         html! {
-            <div class="figure-item" onclick={on_click}>
-                {render_contact_dot("#555", Some("unknown"))}
-                <span class="figure-label">{"Unknown"}</span>
+            <div class="figure-row">
+                <div class="figure-item" onclick={on_click}>
+                    {render_contact_dot("#555", Some("unknown"))}
+                    <span class="figure-label">{"Unknown"}</span>
+                </div>
+                <div class="figure-row-targets">
+                    <div class="figure-row-target figure-row-target--sms">
+                        <i class="fa-solid fa-comment-sms"></i>
+                    </div>
+                    <div class="figure-row-target figure-row-target--call">
+                        <i class="fa-solid fa-phone"></i>
+                    </div>
+                </div>
             </div>
         }
     };
@@ -2232,9 +2340,19 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
     let render_add_figure = {
         let on_click = on_add_click.clone();
         html! {
-            <div class="figure-item" onclick={on_click}>
-                {render_contact_dot("rgba(255,255,255,0.25)", Some("add"))}
-                <span class="figure-label">{"Add"}</span>
+            <div class="figure-row">
+                <div class="figure-item" onclick={on_click}>
+                    {render_contact_dot("rgba(255,255,255,0.25)", Some("add"))}
+                    <span class="figure-label">{"Add"}</span>
+                </div>
+                <div class="figure-row-targets">
+                    <div class="figure-row-target figure-row-target--sms">
+                        <i class="fa-solid fa-comment-sms"></i>
+                    </div>
+                    <div class="figure-row-target figure-row-target--call">
+                        <i class="fa-solid fa-phone"></i>
+                    </div>
+                </div>
             </div>
         }
     };
@@ -3857,31 +3975,17 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
     html! {
         <>
             <style>{AVATAR_ROW_STYLES}</style>
-            <div class="people-arena">
-                // SMS target - left side
-                <div class="people-target">
-                    <div class="target-circle" style="background: rgba(74,222,128,0.12); border: 1.5px solid rgba(74,222,128,0.35);">
-                        <i class="fa-solid fa-comment-sms" style="color: #4ade80;"></i>
-                    </div>
-                    <span class="target-label">{"SMS"}</span>
-                </div>
-                // Figures stacked vertically in center
-                <div class="people-figures-outer">
+            <div class="people-arena people-arena--loaded">
+                // Figures on the left
+                <div class="people-figures-outer people-figures-outer--left">
                     <div class="people-figures-wrap">
-                        <div class="people-figures">
+                        <div class="people-figures people-figures--left">
                             {profile_figures}
                             {render_phone_contact_figure}
                             {render_unknown_figure}
                             {render_add_figure}
                         </div>
                     </div>
-                </div>
-                // Call target - right side
-                <div class="people-target">
-                    <div class="target-circle" style="background: rgba(251,191,36,0.12); border: 1.5px solid rgba(251,191,36,0.35);">
-                        <i class="fa-solid fa-phone" style="color: #fbbf24;"></i>
-                    </div>
-                    <span class="target-label">{"Call"}</span>
                 </div>
             </div>
             {render_modal()}

--- a/frontend/src/dashboard/contact_avatar_row.rs
+++ b/frontend/src/dashboard/contact_avatar_row.rs
@@ -435,10 +435,81 @@ const AVATAR_ROW_STYLES: &str = r#"
     text-align: center;
 }
 
+/* Contact dot */
+.contact-dot {
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    margin-bottom: 4px;
+}
+.contact-dot--unknown {
+    background: #555;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.contact-dot__question {
+    font-size: 0.55rem;
+    font-weight: bold;
+    color: #1a1a2e;
+    line-height: 1;
+}
+.contact-dot--add {
+    background: transparent;
+    border: 1.5px dashed rgba(255,255,255,0.25);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+.contact-dot__plus {
+    font-size: 0.7rem;
+    color: rgba(255,255,255,0.25);
+    line-height: 1;
+}
+.contact-dot--contacts {
+    background: #555;
+}
+
+/* Spinning dots loader */
+.dot-spinner {
+    width: 48px;
+    height: 48px;
+    position: relative;
+    margin: 1rem auto;
+}
+.dot-spinner.dot-spinner--done .dot-spinner__dot {
+    background: radial-gradient(circle at 35% 35%, #86efac, #4ade80 40%, #16a34a) !important;
+    opacity: 1 !important;
+}
+.dot-spinner__dot {
+    position: absolute;
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: radial-gradient(circle at 35% 35%, #ccc, #888 40%, #444);
+    box-shadow: 0 1px 2px rgba(0,0,0,0.3);
+}
+.dot-spinner__dot:nth-child(1)  { top: 0;    left: 19px; animation: dot-fade 1.2s -0.0s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(2)  { top: 3px;  left: 30px; animation: dot-fade 1.2s -0.1s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(3)  { top: 12px; left: 36px; animation: dot-fade 1.2s -0.2s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(4)  { top: 23px; left: 36px; animation: dot-fade 1.2s -0.3s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(5)  { top: 32px; left: 30px; animation: dot-fade 1.2s -0.4s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(6)  { top: 38px; left: 19px; animation: dot-fade 1.2s -0.5s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(7)  { top: 32px; left: 8px;  animation: dot-fade 1.2s -0.6s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(8)  { top: 23px; left: 2px;  animation: dot-fade 1.2s -0.7s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(9)  { top: 12px; left: 2px;  animation: dot-fade 1.2s -0.8s infinite ease-in-out; }
+.dot-spinner__dot:nth-child(10) { top: 3px;  left: 8px;  animation: dot-fade 1.2s -0.9s infinite ease-in-out; }
+
+@keyframes dot-fade {
+    0%, 100% { opacity: 0.2; transform: scale(0.8); }
+    50%      { opacity: 1;   transform: scale(1.2); }
+}
+
 /* Flying icons - use CSS custom props for per-figure targeting */
 .flying-icon {
     position: absolute;
-    top: 12px;
+    top: 4px;
     left: 50%;
     margin-left: 10px;
     font-size: 0.65rem;
@@ -632,26 +703,30 @@ fn effective_mode_for_platform<'a>(profile: &'a ContactProfile, platform_key: &s
     }
 }
 
-/// Renders an SVG stick figure with one arm raised in a throwing pose.
-/// `special`: None for normal, Some("unknown") for ? head, Some("add") for dashed/plus, Some("contacts") for plain gray
-fn render_stick_figure_svg(color: &str, special: Option<&str>) -> Html {
-    let stroke = match special {
-        Some("add") => "stroke=\"rgba(255,255,255,0.25)\" stroke-dasharray=\"3,3\"".to_string(),
-        _ => format!("stroke=\"{}\"", color),
-    };
-    let head_content = match special {
-        Some("unknown") => format!(
-            r#"<text x="15" y="11" text-anchor="middle" font-size="8" fill="{}" font-weight="bold">?</text>"#,
-            color
-        ),
-        Some("add") => r#"<text x="15" y="12" text-anchor="middle" font-size="12" fill="rgba(255,255,255,0.25)" font-weight="300">+</text>"#.to_string(),
-        _ => String::new(),
-    };
-    let svg = format!(
-        r#"<svg viewBox="0 0 30 48" width="30" height="48" xmlns="http://www.w3.org/2000/svg"><circle cx="15" cy="8" r="5" fill="none" {} stroke-width="2"/>{}<line x1="15" y1="13" x2="15" y2="30" {} stroke-width="2"/><line x1="15" y1="19" x2="24" y2="12" {} stroke-width="2"/><line x1="15" y1="19" x2="6" y2="25" {} stroke-width="2"/><line x1="15" y1="30" x2="8" y2="42" {} stroke-width="2"/><line x1="15" y1="30" x2="22" y2="42" {} stroke-width="2"/></svg>"#,
-        stroke, head_content, stroke, stroke, stroke, stroke, stroke
-    );
-    Html::from_html_unchecked(AttrValue::from(svg))
+/// Renders a colored dot for a contact.
+/// `special`: None for normal, Some("unknown") for grey+?, Some("add") for dashed+, Some("contacts") for grey
+fn render_contact_dot(color: &str, special: Option<&str>) -> Html {
+    match special {
+        Some("add") => html! {
+            <div class="contact-dot contact-dot--add">
+                <span class="contact-dot__plus">{"+"}</span>
+            </div>
+        },
+        Some("unknown") => html! {
+            <div class="contact-dot contact-dot--unknown">
+                <span class="contact-dot__question">{"?"}</span>
+            </div>
+        },
+        Some("contacts") => html! {
+            <div class="contact-dot contact-dot--contacts"></div>
+        },
+        _ => {
+            let style = format!("background: {};", color);
+            html! {
+                <div class="contact-dot" style={style}></div>
+            }
+        }
+    }
 }
 
 /// Renders flying platform icons for a contact profile.
@@ -2123,11 +2198,11 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
         };
 
         let flying = render_flying_icons(profile);
-        let figure_svg = render_stick_figure_svg(color, None);
+        let dot = render_contact_dot(color, None);
 
         html! {
             <div class="figure-item" onclick={on_click}>
-                {figure_svg}
+                {dot}
                 {flying}
                 <span class="figure-label">{nick}</span>
             </div>
@@ -2138,7 +2213,7 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
         let on_click = on_phone_contact_click.clone();
         html! {
             <div class="figure-item" onclick={on_click}>
-                {render_stick_figure_svg("#555", None)}
+                {render_contact_dot("#555", Some("contacts"))}
                 <span class="figure-label">{"Contacts"}</span>
             </div>
         }
@@ -2148,7 +2223,7 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
         let on_click = on_default_click.clone();
         html! {
             <div class="figure-item" onclick={on_click}>
-                {render_stick_figure_svg("#555", Some("unknown"))}
+                {render_contact_dot("#555", Some("unknown"))}
                 <span class="figure-label">{"Unknown"}</span>
             </div>
         }
@@ -2158,7 +2233,7 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
         let on_click = on_add_click.clone();
         html! {
             <div class="figure-item" onclick={on_click}>
-                {render_stick_figure_svg("rgba(255,255,255,0.25)", Some("add"))}
+                {render_contact_dot("rgba(255,255,255,0.25)", Some("add"))}
                 <span class="figure-label">{"Add"}</span>
             </div>
         }
@@ -3759,8 +3834,19 @@ pub fn contact_avatar_row(props: &ContactAvatarRowProps) -> Html {
         return html! {
             <>
                 <style>{AVATAR_ROW_STYLES}</style>
-                <div class="people-arena">
-                    <span style="color:#666;font-size:0.8rem;">{"Loading contacts..."}</span>
+                <div class="people-arena" style="justify-content: center;">
+                    <div class="dot-spinner">
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                        <div class="dot-spinner__dot"></div>
+                    </div>
                 </div>
             </>
         };

--- a/frontend/src/dashboard/dashboard_view.rs
+++ b/frontend/src/dashboard/dashboard_view.rs
@@ -154,6 +154,29 @@ const DASHBOARD_STYLES: &str = r#"
     text-transform: uppercase;
     letter-spacing: 0.05em;
 }
+.people-tab {
+    display: flex;
+    align-items: center;
+    gap: 0.35rem;
+    background: rgba(74,222,128,0.12);
+    border: 1px solid rgba(74,222,128,0.3);
+    border-radius: 6px;
+    padding: 0.25rem 0.6rem;
+    cursor: pointer;
+    transition: background 0.2s;
+}
+.people-tab:hover {
+    background: rgba(74,222,128,0.2);
+}
+.people-tab span {
+    font-size: 0.75rem;
+    color: #4ade80;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+.people-tab i {
+    color: #4ade80;
+}
 .info-icon-btn {
     background: transparent;
     border: none;
@@ -773,6 +796,7 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
     // Chat prefill state (for digest suggestion hint)
     let prefill_chat: UseStateHandle<Option<String>> = use_state(|| None);
     let people_info_seq = use_state(|| 0u32);
+    let people_expanded = use_state(|| false);
 
     // Digest prefill callback - pre-fills chatbox with prompt from digest creator
     let on_digest_prefill = {
@@ -984,8 +1008,16 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
                 />
 
                 // People section with contact avatars
-                <div class="section-label">
-                    <span>{"People"}</span>
+                <div class="section-label" style="gap: 0.5rem;">
+                    <button class="people-tab" onclick={{
+                        let people_expanded = people_expanded.clone();
+                        Callback::from(move |_: MouseEvent| {
+                            people_expanded.set(!*people_expanded);
+                        })
+                    }}>
+                        <i class={if *people_expanded { "fa-solid fa-chevron-down" } else { "fa-solid fa-chevron-right" }} style="font-size: 0.55rem;"></i>
+                        <span>{"People"}</span>
+                    </button>
                     <button class="info-icon-btn" onclick={{
                         let people_info_seq = people_info_seq.clone();
                         Callback::from(move |e: MouseEvent| {
@@ -996,7 +1028,9 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
                         <i class="fa-solid fa-circle-info"></i>
                     </button>
                 </div>
-                <ContactAvatarRow open_info_seq={*people_info_seq} />
+                if *people_expanded {
+                    <ContactAvatarRow open_info_seq={*people_info_seq} />
+                }
 
                 <div class="peace-separator"></div>
             </div>


### PR DESCRIPTION
## Summary
- Replace SVG stick figure avatars with minimal colored dot indicators (14px circles with contact-specific colors)
- Add spinning dot circle loading animation (10 dots in a circle with staggered fade, 3D ball gradient)
- Contact dots have variants: normal (colored), unknown (grey + ?), add (dashed + +), contacts (grey)
- Flying icon positioning updated to match smaller dot size
edit one: 
<img width="622" height="306" alt="image" src="https://github.com/user-attachments/assets/338d25e3-6750-4553-beee-ae0976194129" />

## Test plan
- [ ] Verify loading spinner appears when contacts are loading
- [ ] Verify colored dots render correctly for each contact
- [ ] Verify Unknown, Contacts, and Add special dots display correctly
- [ ] Verify flying icons still animate from correct position