### PR TITLE
Add Bearer token auth and dev environment improvements

### DIFF
--- a/backend/src/ai_config.rs
+++ b/backend/src/ai_config.rs
@@ -35,12 +35,24 @@ impl AiConfig {
     }
 
     pub fn from_env() -> Self {
-        let openrouter_api_key = std::env::var("OPENROUTER_API_KEY").ok();
+        let openrouter_api_key = std::env::var("OPENROUTER_API_KEY")
+            .ok()
+            .filter(|s| !s.is_empty());
+        let tinfoil_api_key = std::env::var("TINFOIL_API_KEY")
+            .ok()
+            .filter(|s| !s.is_empty());
 
-        let tinfoil_api_key =
-            Some(std::env::var("TINFOIL_API_KEY").expect("TINFOIL_API_KEY required"));
+        let is_dev = std::env::var("ENVIRONMENT").as_deref() == Ok("development");
 
-        tracing::info!("AI config initialized: Tinfoil (primary)");
+        if !is_dev && tinfoil_api_key.is_none() {
+            panic!("TINFOIL_API_KEY required in non-development environment");
+        }
+
+        if tinfoil_api_key.is_some() {
+            tracing::info!("AI config initialized: Tinfoil (primary)");
+        } else {
+            tracing::info!("AI config initialized: OpenRouter (development fallback)");
+        }
 
         Self {
             openrouter_api_key,
@@ -48,10 +60,13 @@ impl AiConfig {
         }
     }
 
-    /// Always returns Tinfoil. The preference parameter is accepted for
-    /// backward compatibility but ignored.
+    /// Returns Tinfoil if available, otherwise OpenRouter (for development).
     pub fn provider_for_user_with_preference(&self, _preference: Option<&str>) -> AiProvider {
-        AiProvider::Tinfoil
+        if self.tinfoil_api_key.is_some() {
+            AiProvider::Tinfoil
+        } else {
+            AiProvider::OpenRouter
+        }
     }
 
     /// Get the endpoint URL for a provider

--- a/backend/src/handlers/auth_middleware.rs
+++ b/backend/src/handlers/auth_middleware.rs
@@ -136,36 +136,48 @@ pub async fn require_admin(
     Ok(next.run(request).await)
 }
 
-pub async fn require_auth(request: Request<Body>, next: Next) -> Result<Response, AuthError> {
-    // Extract token from cookies
-    let cookie_header = request
-        .headers()
+/// Extract token from cookies (access_token) or Authorization: Bearer header.
+fn extract_token_from_headers(headers: &axum::http::HeaderMap) -> Result<&str, AuthError> {
+    // Try cookies first
+    if let Some(cookie_header) = headers
         .get(axum::http::header::COOKIE)
-        .and_then(|header| header.to_str().ok());
-
-    let token = if let Some(cookies) = cookie_header {
-        // Parse cookies to find access_token
-        cookies
+        .and_then(|h| h.to_str().ok())
+    {
+        if let Some(token) = cookie_header
             .split(';')
             .map(|s| s.trim())
             .find_map(|cookie| {
-                let cookie_parts: Vec<&str> = cookie.splitn(2, '=').collect();
-                if cookie_parts.len() == 2 && cookie_parts[0] == "access_token" {
-                    Some(cookie_parts[1])
+                let parts: Vec<&str> = cookie.splitn(2, '=').collect();
+                if parts.len() == 2 && parts[0] == "access_token" {
+                    Some(parts[1])
                 } else {
                     None
                 }
             })
-            .ok_or(AuthError {
-                status: StatusCode::UNAUTHORIZED,
-                message: "No authorization token provided".to_string(),
-            })?
-    } else {
-        return Err(AuthError {
-            status: StatusCode::UNAUTHORIZED,
-            message: "No authorization token provided".to_string(),
-        });
-    };
+        {
+            return Ok(token);
+        }
+    }
+
+    // Fall back to Authorization: Bearer header
+    if let Some(auth_header) = headers
+        .get(axum::http::header::AUTHORIZATION)
+        .and_then(|h| h.to_str().ok())
+    {
+        if let Some(token) = auth_header.strip_prefix("Bearer ") {
+            return Ok(token);
+        }
+    }
+
+    Err(AuthError {
+        status: StatusCode::UNAUTHORIZED,
+        message: "No authorization token provided".to_string(),
+    })
+}
+
+pub async fn require_auth(request: Request<Body>, next: Next) -> Result<Response, AuthError> {
+    // Extract token from cookies or Authorization header
+    let token = extract_token_from_headers(request.headers())?;
 
     // Validate the token
     decode::<Claims>(
@@ -208,42 +220,8 @@ impl FromRequestParts<Arc<AppState>> for AuthUser {
         parts: &mut Parts,
         state: &Arc<AppState>,
     ) -> Result<Self, Self::Rejection> {
-        // Extract the token from cookies
-        // Note: header names are case-insensitive in HTTP
-        let cookie_header = parts
-            .headers
-            .get(axum::http::header::COOKIE)
-            .and_then(|header| header.to_str().ok())
-            .ok_or_else(|| {
-                tracing::debug!("No cookie header found");
-                AuthError {
-                    status: StatusCode::UNAUTHORIZED,
-                    message: "No authorization token provided".to_string(),
-                }
-            })?;
-
-        tracing::debug!("Cookie header: {}", cookie_header);
-
-        // Parse cookies to find access_token
-        let token = cookie_header
-            .split(';')
-            .map(|s| s.trim())
-            .find_map(|cookie| {
-                let cookie_parts: Vec<&str> = cookie.splitn(2, '=').collect();
-                tracing::debug!("Parsing cookie part: {:?}", cookie_parts);
-                if cookie_parts.len() == 2 && cookie_parts[0] == "access_token" {
-                    Some(cookie_parts[1])
-                } else {
-                    None
-                }
-            })
-            .ok_or_else(|| {
-                tracing::debug!("No access_token found in cookies");
-                AuthError {
-                    status: StatusCode::UNAUTHORIZED,
-                    message: "No authorization token provided".to_string(),
-                }
-            })?;
+        // Extract token from cookies or Authorization header
+        let token = extract_token_from_headers(&parts.headers)?;
 
         // Decode the token
         let claims = decode::<Claims>(

--- a/backend/src/handlers/profile_handlers.rs
+++ b/backend/src/handlers/profile_handlers.rs
@@ -1980,7 +1980,9 @@ pub async fn web_chat_stream(
             }
         };
 
-        if user.sub_tier.is_none() {
+        let is_dev = std::env::var("ENVIRONMENT").as_deref() == Ok("development");
+
+        if !is_dev && user.sub_tier.is_none() {
             yield Ok(axum::response::sse::Event::default().data(
                 serde_json::json!({"step": "error", "message": "Please subscribe to use the web chat feature"}).to_string(),
             ));
@@ -1994,7 +1996,7 @@ pub async fn web_chat_stream(
             (WEB_CHAT_COST_EUR, WEB_CHAT_COST_EUR)
         };
 
-        let has_credits = user.credits_left >= credits_left_cost || user.credits >= credits_cost;
+        let has_credits = is_dev || user.credits_left >= credits_left_cost || user.credits >= credits_cost;
         if !has_credits {
             yield Ok(axum::response::sse::Event::default().data(
                 serde_json::json!({"step": "error", "message": "Insufficient credits. Please add more credits to continue."}).to_string(),
@@ -2003,7 +2005,9 @@ pub async fn web_chat_stream(
         }
 
         // Deduct credits
-        let charged_amount = if user.credits_left >= credits_left_cost {
+        let charged_amount = if is_dev {
+            0.0
+        } else if user.credits_left >= credits_left_cost {
             let new_credits_left = user.credits_left - credits_left_cost;
             if let Err(e) = state.user_repository.update_user_credits_left(auth_user.user_id, new_credits_left) {
                 yield Ok(axum::response::sse::Event::default().data(

--- a/backend/src/utils/usage.rs
+++ b/backend/src/utils/usage.rs
@@ -25,7 +25,9 @@ pub async fn check_user_credits(
     }
 
     // Check if user has an active subscription (tier 2 required)
-    if user.sub_tier.as_deref() != Some("tier 2") {
+    // Skip in development environment
+    let is_dev = std::env::var("ENVIRONMENT").as_deref() == Ok("development");
+    if !is_dev && user.sub_tier.as_deref() != Some("tier 2") {
         return Err(
             "Active subscription required. Please subscribe to continue using the service."
                 .to_string(),
@@ -33,7 +35,7 @@ pub async fn check_user_credits(
     }
 
     // BYOT users pay Twilio directly - no credit check
-    if state.user_core.is_byot_user(user.id) {
+    if is_dev || state.user_core.is_byot_user(user.id) {
         return Ok(());
     }
 

--- a/docker/core/Dockerfile
+++ b/docker/core/Dockerfile
@@ -84,6 +84,7 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     libsqlite3-0 \
     libssl3 \
+    libpq5 \
     curl \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION

<img width="425" height="826" alt="image" src="https://github.com/user-attachments/assets/d2d450e1-f7cc-47b2-b182-f8847936e774" />

❯## Summary
- Auth middleware now accepts both cookies and `Authorization: Bearer` header (needed for iOS app)
- Tinfoil API key is optional, falls back to OpenRouter in development
- Skip subscription/credit checks in development environment
- Add libpq5 to Docker runtime dependencies

## Test plan
- [ ] Verify cookie-based auth still works (web frontend)
- [ ] Verify Bearer token auth works (iOS app)
- [ ] Verify dev environment skips subscription checks