### PR TITLE
Skip follow-up LLM call for create_item

### DIFF
--- a/backend/src/api/twilio_sms.rs
+++ b/backend/src/api/twilio_sms.rs
@@ -1244,7 +1244,11 @@ Respond in plain text only. User information: {}. Use tools to fetch latest info
 
                     match state
                         .ai_config
-                        .chat_completion_streaming(ctx.provider, &follow_up_req, reasoning_tx.clone())
+                        .chat_completion_streaming(
+                            ctx.provider,
+                            &follow_up_req,
+                            reasoning_tx.clone(),
+                        )
                         .await
                     {
                         Ok(result) => {
@@ -1284,21 +1288,24 @@ Respond in plain text only. User information: {}. Use tools to fetch latest info
 
                         // If we got an empty response, fall back to the tool answer
                         if response.trim().is_empty() {
-                            tracing::warn!("Follow-up response was empty, using tool answer directly");
+                            tracing::warn!(
+                                "Follow-up response was empty, using tool answer directly"
+                            );
                             // Check if direct_response - don't return internal hint
                             let was_direct_response = result.choices[0]
                                 .message
                                 .tool_calls
                                 .as_ref()
                                 .map(|calls| {
-                                    calls
-                                        .iter()
-                                        .any(|c| c.function.name.as_deref() == Some("direct_response"))
+                                    calls.iter().any(|c| {
+                                        c.function.name.as_deref() == Some("direct_response")
+                                    })
                                 })
                                 .unwrap_or(false);
 
                             if was_direct_response {
-                                "I processed your request but couldn't generate a response.".to_string()
+                                "I processed your request but couldn't generate a response."
+                                    .to_string()
                             } else {
                                 tool_answers
                                     .values()

--- a/backend/src/api/twilio_sms.rs
+++ b/backend/src/api/twilio_sms.rs
@@ -1162,39 +1162,6 @@ Respond in plain text only. User information: {}. Use tools to fetch latest info
                 }
             }
 
-            let mut follow_up_messages = completion_messages.clone();
-            // Add the assistant's message with tool calls
-            follow_up_messages.push(chat_completion::ChatCompletionMessage {
-                role: chat_completion::MessageRole::assistant,
-                content: chat_completion::Content::Text(
-                    result.choices[0]
-                        .message
-                        .content
-                        .clone()
-                        .unwrap_or_default(),
-                ),
-                name: None,
-                tool_calls: result.choices[0].message.tool_calls.clone(),
-                tool_call_id: None,
-            });
-
-            // Add the tool response
-            if let Some(tool_calls) = &result.choices[0].message.tool_calls {
-                for tool_call in tool_calls {
-                    let tool_answer = match tool_answers.get(&tool_call.id) {
-                        Some(ans) => ans.clone(),
-                        None => "".to_string(),
-                    };
-                    follow_up_messages.push(chat_completion::ChatCompletionMessage {
-                        role: chat_completion::MessageRole::tool,
-                        content: chat_completion::Content::Text(tool_answer),
-                        name: None,
-                        tool_calls: None,
-                        tool_call_id: Some(tool_call.id.clone()),
-                    });
-                }
-            }
-
             let current_time = std::time::SystemTime::now()
                 .duration_since(std::time::UNIX_EPOCH)
                 .unwrap()
@@ -1218,64 +1185,142 @@ Respond in plain text only. User information: {}. Use tools to fetch latest info
                 }
             }
 
-            tracing::debug!("Making follow-up request to model with tool call answers");
-            options.emit_status(ChatStatus::Thinking);
+            // Skip follow-up LLM call for create_item - the tool already returns
+            // a good confirmation message and the frontend shows the item preview
+            if created_item_id.is_some() {
+                tracing::debug!("Skipping follow-up LLM call for create_item");
+                if let Some(msg) = tool_answers.values().next() {
+                    msg.clone()
+                } else {
+                    "Item created.".to_string()
+                }
+            } else {
+                let mut follow_up_messages = completion_messages.clone();
+                // Add the assistant's message with tool calls
+                follow_up_messages.push(chat_completion::ChatCompletionMessage {
+                    role: chat_completion::MessageRole::assistant,
+                    content: chat_completion::Content::Text(
+                        result.choices[0]
+                            .message
+                            .content
+                            .clone()
+                            .unwrap_or_default(),
+                    ),
+                    name: None,
+                    tool_calls: result.choices[0].message.tool_calls.clone(),
+                    tool_call_id: None,
+                });
 
-            // Retry logic for follow-up call
-            const FOLLOWUP_MAX_RETRIES: u32 = 3;
-            let mut followup_last_error = String::new();
-            let mut followup_result = None;
-
-            for attempt in 1..=FOLLOWUP_MAX_RETRIES {
-                let follow_up_req = chat_completion::ChatCompletionRequest::new(
-                    model.clone(),
-                    follow_up_messages.clone(),
-                );
-
-                match state
-                    .ai_config
-                    .chat_completion_streaming(ctx.provider, &follow_up_req, reasoning_tx.clone())
-                    .await
-                {
-                    Ok(result) => {
-                        followup_result = Some(result);
-                        break;
+                // Add the tool response
+                if let Some(tool_calls) = &result.choices[0].message.tool_calls {
+                    for tool_call in tool_calls {
+                        let tool_answer = match tool_answers.get(&tool_call.id) {
+                            Some(ans) => ans.clone(),
+                            None => "".to_string(),
+                        };
+                        follow_up_messages.push(chat_completion::ChatCompletionMessage {
+                            role: chat_completion::MessageRole::tool,
+                            content: chat_completion::Content::Text(tool_answer),
+                            name: None,
+                            tool_calls: None,
+                            tool_call_id: Some(tool_call.id.clone()),
+                        });
                     }
-                    Err(e) => {
-                        followup_last_error = format!("{}", e);
-                        tracing::warn!(
-                            "Follow-up completion attempt {}/{} failed: {}",
-                            attempt,
-                            FOLLOWUP_MAX_RETRIES,
-                            e
-                        );
-                        if attempt < FOLLOWUP_MAX_RETRIES {
-                            options.emit_status(ChatStatus::RetryingFollowup {
-                                attempt: attempt + 1,
-                                max: FOLLOWUP_MAX_RETRIES,
-                            });
-                            tokio::time::sleep(tokio::time::Duration::from_millis(
-                                500 * attempt as u64,
-                            ))
-                            .await;
+                }
+
+                tracing::debug!("Making follow-up request to model with tool call answers");
+                options.emit_status(ChatStatus::Thinking);
+
+                // Retry logic for follow-up call
+                const FOLLOWUP_MAX_RETRIES: u32 = 3;
+                let mut followup_last_error = String::new();
+                let mut followup_result = None;
+
+                for attempt in 1..=FOLLOWUP_MAX_RETRIES {
+                    let follow_up_req = chat_completion::ChatCompletionRequest::new(
+                        model.clone(),
+                        follow_up_messages.clone(),
+                    );
+
+                    match state
+                        .ai_config
+                        .chat_completion_streaming(ctx.provider, &follow_up_req, reasoning_tx.clone())
+                        .await
+                    {
+                        Ok(result) => {
+                            followup_result = Some(result);
+                            break;
+                        }
+                        Err(e) => {
+                            followup_last_error = format!("{}", e);
+                            tracing::warn!(
+                                "Follow-up completion attempt {}/{} failed: {}",
+                                attempt,
+                                FOLLOWUP_MAX_RETRIES,
+                                e
+                            );
+                            if attempt < FOLLOWUP_MAX_RETRIES {
+                                options.emit_status(ChatStatus::RetryingFollowup {
+                                    attempt: attempt + 1,
+                                    max: FOLLOWUP_MAX_RETRIES,
+                                });
+                                tokio::time::sleep(tokio::time::Duration::from_millis(
+                                    500 * attempt as u64,
+                                ))
+                                .await;
+                            }
                         }
                     }
                 }
-            }
 
-            match followup_result {
-                Some(follow_up_result) => {
-                    tracing::debug!("Received follow-up response from model");
-                    let response = follow_up_result.choices[0]
-                        .message
-                        .content
-                        .clone()
-                        .unwrap_or_default();
+                match followup_result {
+                    Some(follow_up_result) => {
+                        tracing::debug!("Received follow-up response from model");
+                        let response = follow_up_result.choices[0]
+                            .message
+                            .content
+                            .clone()
+                            .unwrap_or_default();
 
-                    // If we got an empty response, fall back to the tool answer
-                    if response.trim().is_empty() {
-                        tracing::warn!("Follow-up response was empty, using tool answer directly");
-                        // Check if direct_response - don't return internal hint
+                        // If we got an empty response, fall back to the tool answer
+                        if response.trim().is_empty() {
+                            tracing::warn!("Follow-up response was empty, using tool answer directly");
+                            // Check if direct_response - don't return internal hint
+                            let was_direct_response = result.choices[0]
+                                .message
+                                .tool_calls
+                                .as_ref()
+                                .map(|calls| {
+                                    calls
+                                        .iter()
+                                        .any(|c| c.function.name.as_deref() == Some("direct_response"))
+                                })
+                                .unwrap_or(false);
+
+                            if was_direct_response {
+                                "I processed your request but couldn't generate a response.".to_string()
+                            } else {
+                                tool_answers
+                                    .values()
+                                    .next()
+                                    .map(|ans| truncate_nicely(ans, SmsResponse::MAX_LENGTH))
+                                    .unwrap_or_else(|| {
+                                        "I processed your request but couldn't generate a response."
+                                            .to_string()
+                                    })
+                            }
+                        } else {
+                            response
+                        }
+                    }
+                    None => {
+                        tracing::error!(
+                            "Failed to get follow-up completion after {} attempts: {}",
+                            FOLLOWUP_MAX_RETRIES,
+                            followup_last_error
+                        );
+
+                        // Check if this was a direct_response tool - don't return the internal hint
                         let was_direct_response = result.choices[0]
                             .message
                             .tool_calls
@@ -1288,51 +1333,17 @@ Respond in plain text only. User information: {}. Use tools to fetch latest info
                             .unwrap_or(false);
 
                         if was_direct_response {
-                            "I processed your request but couldn't generate a response.".to_string()
+                            "I apologize, but I encountered an error. Please try again.".to_string()
                         } else {
+                            // Return the tool answer directly, truncated to SMS limit
                             tool_answers
                                 .values()
                                 .next()
                                 .map(|ans| truncate_nicely(ans, SmsResponse::MAX_LENGTH))
                                 .unwrap_or_else(|| {
-                                    "I processed your request but couldn't generate a response."
-                                        .to_string()
+                                    "I apologize, but I encountered an error processing your request. Please try again.".to_string()
                                 })
                         }
-                    } else {
-                        response
-                    }
-                }
-                None => {
-                    tracing::error!(
-                        "Failed to get follow-up completion after {} attempts: {}",
-                        FOLLOWUP_MAX_RETRIES,
-                        followup_last_error
-                    );
-
-                    // Check if this was a direct_response tool - don't return the internal hint
-                    let was_direct_response = result.choices[0]
-                        .message
-                        .tool_calls
-                        .as_ref()
-                        .map(|calls| {
-                            calls
-                                .iter()
-                                .any(|c| c.function.name.as_deref() == Some("direct_response"))
-                        })
-                        .unwrap_or(false);
-
-                    if was_direct_response {
-                        "I apologize, but I encountered an error. Please try again.".to_string()
-                    } else {
-                        // Return the tool answer directly, truncated to SMS limit
-                        tool_answers
-                            .values()
-                            .next()
-                            .map(|ans| truncate_nicely(ans, SmsResponse::MAX_LENGTH))
-                            .unwrap_or_else(|| {
-                                "I apologize, but I encountered an error processing your request. Please try again.".to_string()
-                            })
                     }
                 }
             }

--- a/frontend/src/dashboard/chat_box.rs
+++ b/frontend/src/dashboard/chat_box.rs
@@ -490,6 +490,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
         let focused_item = props.focused_item.clone();
         let on_item_cleared = props.on_item_cleared.clone();
         let on_item_created = props.on_item_created.clone();
+        let on_preview_close = props.on_preview_close.clone();
         let chat_input_ref = chat_input_ref.clone();
 
         Callback::from(move |_| {
@@ -537,6 +538,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
             chat_status.set("Thinking...".to_string());
             chat_error.set(None);
             chat_input.set(String::new());
+            on_preview_close.emit(());
 
             // Use SSE streaming for text-only messages and item edits (POST only for image uploads)
             let use_sse = is_item_edit || image_file.is_none();
@@ -552,6 +554,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                 let media_playing = media_playing.clone();
                 let on_item_created = on_item_created.clone();
                 let focused_item_sse = focused_item.clone();
+                let chat_input_ref_sse = chat_input_ref.clone();
                 spawn_local(async move {
                 use wasm_bindgen::JsCast;
                 use wasm_bindgen::closure::Closure;
@@ -587,6 +590,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                         let detected_media = detected_media.clone();
                         let media_playing = media_playing.clone();
                         let on_item_created = on_item_created.clone();
+                        let chat_input_ref_post = chat_input_ref_sse.clone();
                         spawn_local(async move {
                             match Api::post("/api/chat/web")
                                 .json(&json!({ "message": message })).unwrap()
@@ -613,6 +617,9 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                                 }
                             }
                             chat_loading.set(false);
+                            if let Some(input) = chat_input_ref_post.cast::<web_sys::HtmlTextAreaElement>() {
+                                let _ = input.focus();
+                            }
                         });
                         return;
                     }
@@ -627,6 +634,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                 let detected_media_msg = detected_media.clone();
                 let media_playing_msg = media_playing.clone();
                 let on_item_created_msg = on_item_created.clone();
+                let chat_input_ref_msg = chat_input_ref_sse.clone();
                 let es_ref = es.clone();
 
                 let onmessage = Closure::wrap(Box::new(move |event: web_sys::MessageEvent| {
@@ -675,12 +683,18 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                                     }
 
                                     chat_loading_msg.set(false);
+                                    if let Some(input) = chat_input_ref_msg.cast::<web_sys::HtmlTextAreaElement>() {
+                                        let _ = input.focus();
+                                    }
                                     es_ref.close();
                                 }
                                 "error" => {
                                     let msg = data["message"].as_str().unwrap_or("An error occurred").to_string();
                                     chat_error_msg.set(Some(msg));
                                     chat_loading_msg.set(false);
+                                    if let Some(input) = chat_input_ref_msg.cast::<web_sys::HtmlTextAreaElement>() {
+                                        let _ = input.focus();
+                                    }
                                     es_ref.close();
                                 }
                                 _ => {}
@@ -803,6 +817,9 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                         }
                     }
                     chat_loading.set(false);
+                    if let Some(input) = chat_input_ref.cast::<web_sys::HtmlTextAreaElement>() {
+                        let _ = input.focus();
+                    }
                 });
             }
         })


### PR DESCRIPTION
## Summary
- When `create_item` tool is triggered, skip the second LLM call that rephrases the tool result
- The tool already returns a clear confirmation message (e.g. "Reminder set for Mar 10 05:20PM: remind about ice hockey match") and the frontend shows an item preview card
- Saves 30-60s of latency per create_item request

## Test plan
- [x] `cargo test` passes (all 40 lib tests + all integration tests)
- [ ] Test in web chat: send "remind me tomorrow at 5pm to buy groceries" - should respond faster
- [ ] Verify item preview card still appears
- [ ] Test non-create_item tool calls (e.g. web search) still do the follow-up call