### PR TITLE
Add system-level important message notifications

### DIFF
--- a/SYSTEM_BEHAVIORS_NEXT.md
+++ b/SYSTEM_BEHAVIORS_NEXT.md
@@ -1,0 +1,91 @@
+# System Behaviors - Next Steps
+
+## Current state (shipped)
+
+The importance evaluation system gets:
+- Conversation history (last 10 messages) with timestamps in user's timezone
+- Each message marked [seen]/[unseen] from bridge read receipts
+- Sender signals: 30-day message frequency, last contact recency, user reply rate, avg response time
+- Cross-platform escalation: detects when a known person also messaged on another platform in the last hour
+- 30-minute per-room cooldown to prevent duplicate notifications
+- Group messages blocked entirely (no LLM call)
+
+## Feedback loop
+
+### Confirmed positive signals (reliable)
+
+These indicate the notification was useful:
+
+1. **User asks Lightfriend to reply** - User gets notification about Alice, then tells LF "reply to Alice saying I'll be there." Unambiguous - they acted through our system.
+2. **User replies in the chat app** - A "You" message appears in the room within 30 minutes of our notification.
+3. **User calls via the chat app** - Voice/video call event in the bridged room shortly after notification.
+4. **User asks LF about the person** - "What did Alice say?" or "summarize messages from Alice" within 30 minutes.
+
+### Unreliable / neutral signals
+
+These do NOT indicate the notification was useless:
+
+- User doesn't reply in chat (might have called IRL, handled in person, or just noted the info)
+- User doesn't open the app (might have read the SMS notification and acted outside the app)
+- Message stays "unseen" (dumbphone users, or user saw SMS but didn't open bridge app)
+
+**Key principle: you can confirm a positive but never confirm a negative.** A notification with no observable response is unknown, not negative. Palantir handles intelligence tips the same way.
+
+### Storage
+
+Table: `system_notify_log`
+- user_id, room_id, person_id, notified_at, acted_at (nullable)
+
+Only track confirmed positives (acted_at gets set). No "ignored" state - unknowns stay NULL.
+
+### Usage in prompt
+
+Inject alongside existing sender signals:
+
+> "You've notified about Alice 5 times in the last 30 days. User acted on 3 of those."
+
+Not "ignored 2" - just the positive count and total. The LLM calibrates from the ratio without penalizing unknowns.
+
+### Cold start
+
+New contacts with zero notification history still get evaluated normally. Sender signals (rare contact + fast reply rate) carry the weight. PIRs (below) handle the "always notify about Mom" case explicitly.
+
+## PIRs (Priority Intelligence Requirements)
+
+User-defined standing rules that override LLM judgment:
+
+- "Always notify about [person]" - bypasses evaluation entirely, always sends notification
+- "Never notify about [person]" - suppresses notification for this person
+- "Notify about any message mentioning [topic/keyword]"
+
+These are the escape valve when automated judgment fails. Palantir calls them Standing Requirements - analysts always define what matters before relying on automated alerting.
+
+Implementation: simple per-user list stored in DB. Checked before the LLM call - if a PIR matches, skip evaluation and act directly.
+
+## Relationship classification
+
+Explicit semantic tags on persons: family, boss/work, friend, acquaintance, service/bot.
+
+Currently the LLM infers relationship importance from frequency and reply patterns, but this is lossy:
+- A bot you auto-reply to looks like an important contact
+- A family member you rarely text but always call looks unimportant
+- Your boss who messages once a month looks like a casual acquaintance
+
+Options:
+- User manually tags contacts (most accurate, most friction)
+- LLM classifies from message content patterns (automatic, less accurate)
+- Hybrid: auto-suggest, user confirms
+
+Store as an ont_person_edit (property: "relationship", value: "family"/"work"/"friend"/etc). Inject into sender context for the importance prompt.
+
+## Temporal anomaly detection
+
+"This person never messages at 2am - a 2am message is anomalous and probably important."
+
+Compute from message history: what hours/days does this person typically message? If the current message falls outside their normal pattern, flag it as anomalous.
+
+Implementation: bucket the person's last 30 days of messages by hour-of-day. If the current message's hour has zero or very few historical messages, add to sender context:
+
+> "This person typically messages between 9am-6pm. This message at 2:17am is outside their usual pattern."
+
+Cheap to compute from data we already load in `compute_sender_signals`. The LLM naturally weighs anomalous timing as a signal.

--- a/backend/migrations/2026-03-28-120000_add_system_behavior_fields/down.sql
+++ b/backend/migrations/2026-03-28-120000_add_system_behavior_fields/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_settings DROP COLUMN system_important_notify;

--- a/backend/migrations/2026-03-28-120000_add_system_behavior_fields/up.sql
+++ b/backend/migrations/2026-03-28-120000_add_system_behavior_fields/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_settings ADD COLUMN system_important_notify BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/pg_migrations/00000000000016_add_system_important_notify/down.sql
+++ b/backend/pg_migrations/00000000000016_add_system_important_notify/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_settings DROP COLUMN IF EXISTS system_important_notify;

--- a/backend/pg_migrations/00000000000016_add_system_important_notify/up.sql
+++ b/backend/pg_migrations/00000000000016_add_system_important_notify/up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE user_settings ADD COLUMN IF NOT EXISTS system_important_notify BOOLEAN NOT NULL DEFAULT TRUE;

--- a/backend/src/handlers/profile_handlers.rs
+++ b/backend/src/handlers/profile_handlers.rs
@@ -95,10 +95,11 @@ pub struct ProfileResponse {
     estimated_monitoring_cost: f32,
     location: Option<String>,
     nearby_places: Option<String>,
-    plan_type: Option<String>,    // "assistant", "autopilot", or "byot"
-    phone_service_active: bool,   // whether phone service is active - can be disabled for security
+    plan_type: Option<String>,     // "assistant", "autopilot", or "byot"
+    phone_service_active: bool,    // whether phone service is active - can be disabled for security
     llm_provider: Option<String>, // "openai" (default) or "tinfoil" - user's LLM provider preference
     auto_create_items: bool, // whether to auto-detect and create trackable items from emails/messages
+    system_important_notify: bool, // whether system auto-notifies for important messages
     has_any_connection: bool, // whether user has connected any service (email, bridges)
 }
 use crate::handlers::auth_middleware::AuthUser;
@@ -236,6 +237,7 @@ pub async fn get_profile(
                 phone_service_active: user_settings.phone_service_active,
                 llm_provider: user_settings.llm_provider,
                 auto_create_items: user_settings.auto_create_items,
+                system_important_notify: user_settings.system_important_notify,
                 has_any_connection,
             }))
         }
@@ -624,6 +626,23 @@ pub async fn patch_profile_field(
             state
                 .user_core
                 .update_auto_create_items(user_id, value)
+                .map_err(|e| {
+                    (
+                        StatusCode::INTERNAL_SERVER_ERROR,
+                        Json(json!({"error": format!("Database error: {}", e)})),
+                    )
+                })?;
+        }
+        "system_important_notify" => {
+            let value = request.value.as_bool().ok_or_else(|| {
+                (
+                    StatusCode::BAD_REQUEST,
+                    Json(json!({"error": "system_important_notify must be a boolean"})),
+                )
+            })?;
+            state
+                .user_core
+                .update_system_important_notify(user_id, value)
                 .map_err(|e| {
                     (
                         StatusCode::INTERNAL_SERVER_ERROR,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -50,6 +50,7 @@ pub mod utils {
 }
 pub mod proactive {
     pub mod rules;
+    pub mod system_behaviors;
     pub mod utils;
 }
 pub mod tool_call_utils {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -228,6 +228,8 @@ pub struct AppState {
     pub tool_registry: tools::registry::ToolRegistry,
     pub pending_rule_tests: Arc<DashMap<String, handlers::rule_handlers::PendingRuleTest>>,
     pub maintenance_mode: Arc<AtomicBool>,
+    // (user_id, room_id) -> unix timestamp of last system_important notification
+    pub system_notify_cooldowns: DashMap<(i32, String), i32>,
 }
 
 /// Build the tool registry with all static tool handlers.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -431,6 +431,7 @@ async fn main() {
         tool_registry: backend::build_tool_registry(),
         pending_rule_tests: Arc::new(DashMap::new()),
         maintenance_mode: Arc::new(AtomicBool::new(false)),
+        system_notify_cooldowns: DashMap::new(),
     });
     // SMS server route - validates signature using user lookup
     let twilio_sms_routes = Router::new()

--- a/backend/src/models/ontology_models.rs
+++ b/backend/src/models/ontology_models.rs
@@ -242,6 +242,90 @@ pub struct NewOntRule {
     pub flow_config: Option<String>,
 }
 
+// -- Sender signals for importance evaluation --
+
+pub struct SenderSignals {
+    pub message_count_30d: i64,
+    pub last_contact_ago_secs: Option<i64>,
+    pub user_reply_rate: f32,
+    pub avg_response_secs: Option<i64>,
+}
+
+impl SenderSignals {
+    pub fn empty() -> Self {
+        Self {
+            message_count_30d: 0,
+            last_contact_ago_secs: None,
+            user_reply_rate: 0.0,
+            avg_response_secs: None,
+        }
+    }
+
+    pub fn format_for_prompt(&self, sender_name: &str) -> String {
+        if self.message_count_30d == 0 {
+            return format!(
+                "No message history with {} in the last 30 days.",
+                sender_name
+            );
+        }
+
+        let mut parts = Vec::new();
+
+        // Frequency description
+        let freq = if self.message_count_30d >= 100 {
+            "very frequently (multiple times per day)".to_string()
+        } else if self.message_count_30d >= 30 {
+            "about once per day".to_string()
+        } else if self.message_count_30d >= 8 {
+            format!("about {} times per week", self.message_count_30d / 4)
+        } else if self.message_count_30d >= 2 {
+            format!("about {} times per month", self.message_count_30d)
+        } else {
+            "rarely (once in the last 30 days)".to_string()
+        };
+        parts.push(format!("{} messages you {}.", sender_name, freq));
+
+        // Last contact
+        if let Some(ago) = self.last_contact_ago_secs {
+            let desc = if ago < 3600 {
+                "less than an hour ago".to_string()
+            } else if ago < 86400 {
+                format!("{} hours ago", ago / 3600)
+            } else {
+                format!("{} days ago", ago / 86400)
+            };
+            parts.push(format!("Their previous message was {}.", desc));
+        }
+
+        // Reply pattern
+        if self.message_count_30d >= 3 {
+            let pct = (self.user_reply_rate * 100.0) as i32;
+            if pct >= 80 {
+                parts.push(format!("You reply to {}% of their messages.", pct));
+            } else if pct >= 30 {
+                parts.push(format!("You reply to about {}% of their messages.", pct));
+            } else {
+                parts.push("You rarely reply to their messages.".to_string());
+            }
+
+            if let Some(avg) = self.avg_response_secs {
+                let resp_desc = if avg < 120 {
+                    "within a couple minutes".to_string()
+                } else if avg < 900 {
+                    format!("within about {} minutes", avg / 60)
+                } else if avg < 3600 {
+                    "within an hour".to_string()
+                } else {
+                    format!("within about {} hours", avg / 3600)
+                };
+                parts.push(format!("You typically respond {}.", resp_desc));
+            }
+        }
+
+        parts.join(" ")
+    }
+}
+
 // -- Composite view types for API responses --
 
 #[derive(Debug, Clone, Serialize)]

--- a/backend/src/models/user_models.rs
+++ b/backend/src/models/user_models.rs
@@ -59,6 +59,7 @@ pub struct UserSettings {
     pub phone_contact_notification_type: Option<String>,
     pub phone_contact_notify_on_call: i32,
     pub auto_create_items: bool,
+    pub system_important_notify: bool,
 }
 
 #[derive(Insertable)]

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -263,6 +263,7 @@ diesel::table! {
         phone_contact_notification_type -> Nullable<Text>,
         phone_contact_notify_on_call -> Int4,
         auto_create_items -> Bool,
+        system_important_notify -> Bool,
     }
 }
 

--- a/backend/src/proactive/rules.rs
+++ b/backend/src/proactive/rules.rs
@@ -1191,7 +1191,11 @@ pub async fn emit_ontology_change(
     }
 
     // === System behaviors (automatic, no user rules needed) ===
-    if entity_type == "Message" {
+    let is_group = entity_snapshot
+        .get("is_group")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    if entity_type == "Message" && !is_group {
         let state_sys = Arc::clone(state);
         let snap_sys = entity_snapshot.clone();
         let platform_sys = entity_snapshot

--- a/backend/src/proactive/rules.rs
+++ b/backend/src/proactive/rules.rs
@@ -1076,7 +1076,7 @@ fn parse_hhmm(s: &str) -> Option<(u32, u32)> {
 
 /// Check if the user has already seen a message (via read receipts or email
 /// Seen flag). Returns true if the message was seen and should be skipped.
-async fn check_message_seen(
+pub(crate) async fn check_message_seen(
     state: &Arc<AppState>,
     user_id: i32,
     platform: &str,
@@ -1190,6 +1190,51 @@ pub async fn emit_ontology_change(
         }
     }
 
+    // === System behaviors (automatic, no user rules needed) ===
+    if entity_type == "Message" {
+        let state_sys = Arc::clone(state);
+        let snap_sys = entity_snapshot.clone();
+        let platform_sys = entity_snapshot
+            .get("platform")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let room_id_sys = entity_snapshot
+            .get("room_id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+        let created_at_sys = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i32;
+
+        tokio::spawn(async move {
+            tokio::time::sleep(tokio::time::Duration::from_secs(300)).await;
+
+            if check_message_seen(
+                &state_sys,
+                user_id,
+                &platform_sys,
+                &room_id_sys,
+                created_at_sys,
+            )
+            .await
+            {
+                return;
+            }
+
+            if let Err(e) = crate::proactive::system_behaviors::run_system_behaviors(
+                &state_sys, user_id, &snap_sys,
+            )
+            .await
+            {
+                error!("System behaviors failed for user {}: {}", user_id, e);
+            }
+        });
+    }
+
+    // === Custom rules ===
     let rules = match state.ontology_repository.get_ontology_change_rules(user_id) {
         Ok(r) => r,
         Err(e) => {

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -1,11 +1,15 @@
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use chrono::{TimeZone, Utc};
+
 use crate::context::ContextBuilder;
 use crate::proactive::utils::send_notification;
 use crate::repositories::user_core::UserCoreOps;
 use crate::AppState;
 use openai_api_rs::v1::{chat_completion, types};
+
+const COOLDOWN_SECS: i32 = 1800; // 30 minutes per room
 
 pub async fn run_system_behaviors(
     state: &Arc<AppState>,
@@ -33,17 +37,58 @@ pub async fn run_system_behaviors(
         .get("room_id")
         .and_then(|v| v.as_str())
         .unwrap_or("");
+    let person_id = entity_snapshot
+        .get("person_id")
+        .and_then(|v| v.as_i64())
+        .map(|v| v as i32);
 
-    // Compute sender signals from message history
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap_or_default()
         .as_secs() as i32;
+
+    // Per-room cooldown: skip if we already notified for this room recently
+    let cooldown_key = (user_id, room_id.to_string());
+    if let Some(last_notify) = state.system_notify_cooldowns.get(&cooldown_key) {
+        if now - *last_notify < COOLDOWN_SECS {
+            return Ok(());
+        }
+    }
+
+    // Compute sender signals from message history
     let signals =
         state
             .ontology_repository
             .compute_sender_signals(user_id, room_id, sender_name, now);
     let sender_context = signals.format_for_prompt(sender_name);
+
+    // Cross-platform escalation: check if this person also messaged on other platforms recently
+    let cross_platform_ctx = if let Some(pid) = person_id {
+        let one_hour_ago = now - 3600;
+        match state.ontology_repository.get_cross_platform_messages(
+            user_id,
+            pid,
+            platform,
+            one_hour_ago,
+        ) {
+            Ok(msgs) if !msgs.is_empty() => {
+                let platforms: Vec<_> = msgs
+                    .iter()
+                    .map(|m| m.platform.as_str())
+                    .collect::<std::collections::HashSet<_>>()
+                    .into_iter()
+                    .collect();
+                format!(
+                    "{} also messaged you on {} in the last hour.",
+                    sender_name,
+                    platforms.join(", ")
+                )
+            }
+            _ => String::new(),
+        }
+    } else {
+        String::new()
+    };
 
     // Build context
     let ctx = ContextBuilder::for_user(state, user_id)
@@ -51,34 +96,120 @@ pub async fn run_system_behaviors(
         .build()
         .await?;
 
-    let tz_info = ctx
-        .timezone
-        .as_ref()
-        .map(|t| format!("Current time: {}", t.formatted_now))
+    // Fetch recent conversation history for this room (last 10 messages)
+    let recent_messages = state
+        .ontology_repository
+        .get_messages_for_room(user_id, room_id, 10)
         .unwrap_or_default();
 
+    // Get room seen timestamp for marking messages as seen/unseen
+    let seen_ts = get_room_seen_ts(state, user_id, room_id, platform).await;
+
+    // Format conversation with timestamps in user's timezone
+    let tz_offset = ctx
+        .timezone
+        .as_ref()
+        .map(|t| t.fixed_offset)
+        .unwrap_or_else(|| chrono::FixedOffset::east_opt(0).unwrap());
+
+    let fmt_ts = |unix: i32| -> String {
+        Utc.timestamp_opt(unix as i64, 0)
+            .single()
+            .map(|dt| {
+                dt.with_timezone(&tz_offset)
+                    .format("%b %d %H:%M")
+                    .to_string()
+            })
+            .unwrap_or_else(|| "??:??".to_string())
+    };
+
+    let now_formatted = fmt_ts(now);
+
+    let conversation = if recent_messages.len() > 1 {
+        // Messages come DESC, reverse for chronological order
+        let mut chronological: Vec<_> = recent_messages.iter().collect();
+        chronological.reverse();
+
+        // Find the last "You" message index - everything at or before it is seen
+        let last_you_idx = chronological.iter().rposition(|m| m.sender_name == "You");
+
+        let lines: Vec<String> = chronological
+            .iter()
+            .enumerate()
+            .map(|(i, m)| {
+                let ts = fmt_ts(m.created_at);
+
+                // Determine seen status
+                let is_seen = if m.sender_name == "You" {
+                    true
+                } else if let Some(you_idx) = last_you_idx {
+                    i <= you_idx
+                } else {
+                    // No "You" messages - use bridge read receipt
+                    seen_ts
+                        .map(|st| (m.created_at as i64) <= st)
+                        .unwrap_or(false)
+                };
+
+                let seen_marker = if is_seen { "seen" } else { "unseen" };
+                let eval_marker = if i == chronological.len() - 1 {
+                    " <-- evaluate this"
+                } else {
+                    ""
+                };
+                format!(
+                    "[{}] [{}] {}: {}{}",
+                    ts, seen_marker, m.sender_name, m.content, eval_marker
+                )
+            })
+            .collect();
+
+        format!(
+            "Conversation on {} (latest message is being evaluated):\n{}",
+            platform,
+            lines.join("\n")
+        )
+    } else {
+        format!(
+            "[{}] [unseen] Message from {} on {}:\n{}",
+            fmt_ts(now),
+            sender_name,
+            platform,
+            content
+        )
+    };
+
+    // Build full sender context with cross-platform signal
+    let full_sender_ctx = if cross_platform_ctx.is_empty() {
+        sender_context
+    } else {
+        format!("{}\n{}", sender_context, cross_platform_ctx)
+    };
+
     let system_prompt = format!(
-        "You are evaluating whether an incoming message is important enough to notify the user.\n\
+        "You are evaluating whether an incoming message requires the user's immediate attention.\n\
+        The user has muted all phone notifications and relies on you to catch time-critical messages. \
+        If you miss something important, they won't see it for hours.\n\
         \n\
-        {}\n\
+        Current time: {}\n\
         \n\
         Sender context:\n\
         {}\n\
         \n\
-        Only set should_notify=true if delaying this message over 2 hours could cause harm, \
-        financial loss, or miss a time-sensitive opportunity. Examples: emergencies, someone \
-        asking to meet now, immediate decisions needed. Routine updates, casual messages, \
-        and vague requests are NOT important.\n\
+        The last message in the conversation is being evaluated. Each message is marked [seen] or \
+        [unseen] - unseen messages have not been read by the user yet. Use the conversation history, \
+        timestamps, and seen status to understand context and urgency. Compare mentioned times against \
+        the current time.\n\
         \n\
-        Use the sender context to calibrate: a rare contact reaching out is more likely important \
-        than a frequent chatter. If you typically respond fast to this person, they matter to you.\n\
+        should_notify=true only if a 2-hour delay would cause real consequences for the user. \
+        Use the sender context to calibrate - who this person is to the user matters.\n\
         \n\
         If should_notify=false, set notification_message to empty string.\n\
         If should_notify=true, write a concise notification (max 480 chars, second person).",
-        tz_info, sender_context
+        now_formatted, full_sender_ctx
     );
 
-    let user_msg = format!("Message from {} on {}:\n{}", sender_name, platform, content);
+    let user_msg = conversation;
 
     let messages = vec![
         chat_completion::ChatCompletionMessage {
@@ -182,6 +313,11 @@ pub async fn run_system_behaviors(
                         .unwrap_or("");
 
                     if !notification_message.is_empty() {
+                        // Record cooldown before sending
+                        state
+                            .system_notify_cooldowns
+                            .insert((user_id, room_id.to_string()), now);
+
                         send_notification(
                             state,
                             user_id,
@@ -199,4 +335,23 @@ pub async fn run_system_behaviors(
     }
 
     Ok(())
+}
+
+/// Get the room's seen-up-to timestamp from bridge read receipts.
+/// Returns None for email or if the lookup fails.
+async fn get_room_seen_ts(
+    state: &Arc<AppState>,
+    user_id: i32,
+    room_id: &str,
+    platform: &str,
+) -> Option<i64> {
+    if platform == "email" {
+        return None;
+    }
+    let client = crate::utils::matrix_auth::get_cached_client(user_id, state)
+        .await
+        .ok()?;
+    let matrix_room_id = matrix_sdk::ruma::OwnedRoomId::try_from(room_id).ok()?;
+    let room = client.get_room(&matrix_room_id)?;
+    crate::utils::bridge::get_room_seen_timestamp(&room, &client).await
 }

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use crate::context::ContextBuilder;
+use crate::proactive::utils::send_notification;
+use crate::repositories::user_core::UserCoreOps;
+use crate::AppState;
+use openai_api_rs::v1::{chat_completion, types};
+
+pub async fn run_system_behaviors(
+    state: &Arc<AppState>,
+    user_id: i32,
+    entity_snapshot: &serde_json::Value,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let settings = state.user_core.get_user_settings(user_id)?;
+    if !settings.system_important_notify {
+        return Ok(());
+    }
+
+    // Skip group messages - too noisy for system defaults
+    if entity_snapshot
+        .get("is_group")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return Ok(());
+    }
+
+    let ctx = ContextBuilder::for_user(state, user_id)
+        .with_user_context()
+        .build()
+        .await?;
+
+    let tz_info = ctx
+        .timezone
+        .as_ref()
+        .map(|t| format!("Current time: {}", t.formatted_now))
+        .unwrap_or_default();
+
+    // Build contacts context from persons
+    let contacts_ctx = ctx
+        .persons
+        .as_ref()
+        .map(|persons| {
+            let names: Vec<String> = persons
+                .iter()
+                .filter_map(|p| {
+                    let name = &p.person.name;
+                    Some(name.clone())
+                })
+                .take(20)
+                .collect();
+            if names.is_empty() {
+                String::new()
+            } else {
+                format!("Known contacts: {}", names.join(", "))
+            }
+        })
+        .unwrap_or_default();
+
+    let system_prompt = format!(
+        "You are evaluating whether an incoming message is important enough to notify the user.\n\
+        \n\
+        {}\n\
+        {}\n\
+        \n\
+        Only set should_notify=true if delaying this message over 2 hours could cause harm, \
+        financial loss, or miss a time-sensitive opportunity. Examples: emergencies, someone \
+        asking to meet now, immediate decisions needed. Routine updates, casual messages, \
+        and vague requests are NOT important.\n\
+        \n\
+        If should_notify=false, set notification_message to empty string.\n\
+        If should_notify=true, write a concise notification (max 480 chars, second person).",
+        tz_info, contacts_ctx
+    );
+
+    let sender_name = entity_snapshot
+        .get("sender_name")
+        .and_then(|v| v.as_str())
+        .unwrap_or("Unknown");
+    let platform = entity_snapshot
+        .get("platform")
+        .and_then(|v| v.as_str())
+        .unwrap_or("unknown");
+    let content = entity_snapshot
+        .get("content")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    let user_msg = format!("Message from {} on {}:\n{}", sender_name, platform, content);
+
+    let messages = vec![
+        chat_completion::ChatCompletionMessage {
+            role: chat_completion::MessageRole::system,
+            content: chat_completion::Content::Text(system_prompt),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        },
+        chat_completion::ChatCompletionMessage {
+            role: chat_completion::MessageRole::user,
+            content: chat_completion::Content::Text(user_msg),
+            name: None,
+            tool_calls: None,
+            tool_call_id: None,
+        },
+    ];
+
+    let mut properties = HashMap::new();
+    properties.insert(
+        "should_notify".to_string(),
+        Box::new(types::JSONSchemaDefine {
+            schema_type: Some(types::JSONSchemaType::Boolean),
+            description: Some(
+                "true if this message is important enough to notify the user immediately"
+                    .to_string(),
+            ),
+            ..Default::default()
+        }),
+    );
+    properties.insert(
+        "notification_message".to_string(),
+        Box::new(types::JSONSchemaDefine {
+            schema_type: Some(types::JSONSchemaType::String),
+            description: Some(
+                "Concise notification text (max 480 chars, second person). Empty string if should_notify=false."
+                    .to_string(),
+            ),
+            ..Default::default()
+        }),
+    );
+
+    let tool = chat_completion::Tool {
+        r#type: chat_completion::ToolType::Function,
+        function: types::Function {
+            name: "system_behavior_result".to_string(),
+            description: Some("Return importance evaluation result".to_string()),
+            parameters: types::FunctionParameters {
+                schema_type: types::JSONSchemaType::Object,
+                properties: Some(properties),
+                required: Some(vec![
+                    "should_notify".to_string(),
+                    "notification_message".to_string(),
+                ]),
+            },
+        },
+    };
+
+    let request = chat_completion::ChatCompletionRequest::new(ctx.model.clone(), messages)
+        .tools(vec![tool])
+        .tool_choice(chat_completion::ToolChoiceType::Required)
+        .temperature(0.0);
+
+    let result = ctx
+        .client
+        .chat_completion(request)
+        .await
+        .map_err(|e| format!("System behavior LLM call failed: {}", e))?;
+
+    crate::ai_config::log_llm_usage(
+        &state.llm_usage_repository,
+        user_id,
+        match ctx.provider {
+            crate::AiProvider::Tinfoil => "tinfoil",
+            crate::AiProvider::OpenRouter => "openrouter",
+        },
+        &ctx.model,
+        "system_important",
+        &result,
+    );
+
+    let choice = result.choices.first().ok_or("No choices in LLM response")?;
+
+    if let Some(ref tool_calls) = choice.message.tool_calls {
+        for tc in tool_calls {
+            let fn_name = tc.function.name.as_deref().unwrap_or("");
+            if fn_name == "system_behavior_result" {
+                let args = tc.function.arguments.as_deref().unwrap_or("{}");
+                let parsed: serde_json::Value = serde_json::from_str(args)
+                    .map_err(|e| format!("Failed to parse system_behavior_result: {}", e))?;
+
+                let should_notify = parsed
+                    .get("should_notify")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false);
+
+                if should_notify {
+                    let notification_message = parsed
+                        .get("notification_message")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("");
+
+                    if !notification_message.is_empty() {
+                        send_notification(
+                            state,
+                            user_id,
+                            notification_message,
+                            "system_important".to_string(),
+                            None,
+                        )
+                        .await;
+                    }
+                }
+
+                return Ok(());
+            }
+        }
+    }
+
+    Ok(())
+}

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -44,10 +44,7 @@ pub async fn run_system_behaviors(
         .map(|persons| {
             let names: Vec<String> = persons
                 .iter()
-                .filter_map(|p| {
-                    let name = &p.person.name;
-                    Some(name.clone())
-                })
+                .map(|p| p.person.name.clone())
                 .take(20)
                 .collect();
             if names.is_empty() {

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -17,60 +17,6 @@ pub async fn run_system_behaviors(
         return Ok(());
     }
 
-    // Skip group messages - too noisy for system defaults
-    if entity_snapshot
-        .get("is_group")
-        .and_then(|v| v.as_bool())
-        .unwrap_or(false)
-    {
-        return Ok(());
-    }
-
-    let ctx = ContextBuilder::for_user(state, user_id)
-        .with_user_context()
-        .build()
-        .await?;
-
-    let tz_info = ctx
-        .timezone
-        .as_ref()
-        .map(|t| format!("Current time: {}", t.formatted_now))
-        .unwrap_or_default();
-
-    // Build contacts context from persons
-    let contacts_ctx = ctx
-        .persons
-        .as_ref()
-        .map(|persons| {
-            let names: Vec<String> = persons
-                .iter()
-                .map(|p| p.person.name.clone())
-                .take(20)
-                .collect();
-            if names.is_empty() {
-                String::new()
-            } else {
-                format!("Known contacts: {}", names.join(", "))
-            }
-        })
-        .unwrap_or_default();
-
-    let system_prompt = format!(
-        "You are evaluating whether an incoming message is important enough to notify the user.\n\
-        \n\
-        {}\n\
-        {}\n\
-        \n\
-        Only set should_notify=true if delaying this message over 2 hours could cause harm, \
-        financial loss, or miss a time-sensitive opportunity. Examples: emergencies, someone \
-        asking to meet now, immediate decisions needed. Routine updates, casual messages, \
-        and vague requests are NOT important.\n\
-        \n\
-        If should_notify=false, set notification_message to empty string.\n\
-        If should_notify=true, write a concise notification (max 480 chars, second person).",
-        tz_info, contacts_ctx
-    );
-
     let sender_name = entity_snapshot
         .get("sender_name")
         .and_then(|v| v.as_str())
@@ -83,6 +29,54 @@ pub async fn run_system_behaviors(
         .get("content")
         .and_then(|v| v.as_str())
         .unwrap_or("");
+    let room_id = entity_snapshot
+        .get("room_id")
+        .and_then(|v| v.as_str())
+        .unwrap_or("");
+
+    // Compute sender signals from message history
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i32;
+    let signals =
+        state
+            .ontology_repository
+            .compute_sender_signals(user_id, room_id, sender_name, now);
+    let sender_context = signals.format_for_prompt(sender_name);
+
+    // Build context
+    let ctx = ContextBuilder::for_user(state, user_id)
+        .with_user_context()
+        .build()
+        .await?;
+
+    let tz_info = ctx
+        .timezone
+        .as_ref()
+        .map(|t| format!("Current time: {}", t.formatted_now))
+        .unwrap_or_default();
+
+    let system_prompt = format!(
+        "You are evaluating whether an incoming message is important enough to notify the user.\n\
+        \n\
+        {}\n\
+        \n\
+        Sender context:\n\
+        {}\n\
+        \n\
+        Only set should_notify=true if delaying this message over 2 hours could cause harm, \
+        financial loss, or miss a time-sensitive opportunity. Examples: emergencies, someone \
+        asking to meet now, immediate decisions needed. Routine updates, casual messages, \
+        and vague requests are NOT important.\n\
+        \n\
+        Use the sender context to calibrate: a rare contact reaching out is more likely important \
+        than a frequent chatter. If you typically respond fast to this person, they matter to you.\n\
+        \n\
+        If should_notify=false, set notification_message to empty string.\n\
+        If should_notify=true, write a concise notification (max 480 chars, second person).",
+        tz_info, sender_context
+    );
 
     let user_msg = format!("Message from {} on {}:\n{}", sender_name, platform, content);
 

--- a/backend/src/repositories/ontology_repository.rs
+++ b/backend/src/repositories/ontology_repository.rs
@@ -1097,6 +1097,27 @@ impl OntologyRepository {
         }
     }
 
+    /// Get recent messages from a known person on OTHER platforms (cross-platform escalation).
+    /// Returns messages from the given person_id on platforms != exclude_platform, since since_ts.
+    pub fn get_cross_platform_messages(
+        &self,
+        user_id: i32,
+        person_id: i32,
+        exclude_platform: &str,
+        since_ts: i32,
+    ) -> Result<Vec<OntMessage>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        ont_messages::table
+            .filter(ont_messages::user_id.eq(user_id))
+            .filter(ont_messages::person_id.eq(person_id))
+            .filter(ont_messages::platform.ne(exclude_platform))
+            .filter(ont_messages::sender_name.ne("You"))
+            .filter(ont_messages::created_at.gt(since_ts))
+            .order(ont_messages::created_at.desc())
+            .limit(5)
+            .load::<OntMessage>(&mut conn)
+    }
+
     /// Purge messages older than max_age_secs.
     pub fn purge_old_messages(&self, max_age_secs: i32) -> Result<usize, DieselError> {
         let mut conn = self.pool.get().expect("Failed to get DB connection");

--- a/backend/src/repositories/ontology_repository.rs
+++ b/backend/src/repositories/ontology_repository.rs
@@ -1023,6 +1023,80 @@ impl OntologyRepository {
         .execute(&mut conn)
     }
 
+    /// Compute sender signals from message history for importance evaluation.
+    /// Returns empty signals on any error - never fails.
+    pub fn compute_sender_signals(
+        &self,
+        user_id: i32,
+        room_id: &str,
+        sender_name: &str,
+        now: i32,
+    ) -> crate::models::ontology_models::SenderSignals {
+        use crate::models::ontology_models::SenderSignals;
+
+        let messages = match self.get_messages_for_room(user_id, room_id, 500) {
+            Ok(msgs) => msgs,
+            Err(_) => return SenderSignals::empty(),
+        };
+
+        let thirty_days_ago = now - 30 * 86400;
+
+        // Messages are returned DESC, filter to last 30 days
+        let recent: Vec<_> = messages
+            .iter()
+            .filter(|m| m.created_at >= thirty_days_ago)
+            .collect();
+
+        // Separate sender messages and user replies
+        let sender_msgs: Vec<_> = recent
+            .iter()
+            .filter(|m| m.sender_name == sender_name)
+            .collect();
+        let user_msgs: Vec<_> = recent.iter().filter(|m| m.sender_name == "You").collect();
+
+        let message_count_30d = sender_msgs.len() as i64;
+        if message_count_30d == 0 {
+            return SenderSignals::empty();
+        }
+
+        // Last contact: second-most-recent sender message (since newest is the current one)
+        // Messages are DESC so index 1 is second-most-recent
+        let last_contact_ago_secs = sender_msgs.get(1).map(|m| (now - m.created_at) as i64);
+
+        // Reply analysis: for each sender message, check if user replied within 2 hours
+        let mut replied_count = 0i64;
+        let mut total_response_secs = 0i64;
+
+        for sender_msg in &sender_msgs {
+            // Find earliest "You" message after this sender message within 7200s
+            if let Some(reply) = user_msgs.iter().find(|u| {
+                u.created_at > sender_msg.created_at && u.created_at <= sender_msg.created_at + 7200
+            }) {
+                replied_count += 1;
+                total_response_secs += (reply.created_at - sender_msg.created_at) as i64;
+            }
+        }
+
+        let user_reply_rate = if message_count_30d > 0 {
+            replied_count as f32 / message_count_30d as f32
+        } else {
+            0.0
+        };
+
+        let avg_response_secs = if replied_count > 0 {
+            Some(total_response_secs / replied_count)
+        } else {
+            None
+        };
+
+        SenderSignals {
+            message_count_30d,
+            last_contact_ago_secs,
+            user_reply_rate,
+            avg_response_secs,
+        }
+    }
+
     /// Purge messages older than max_age_secs.
     pub fn purge_old_messages(&self, max_age_secs: i32) -> Result<usize, DieselError> {
         let mut conn = self.pool.get().expect("Failed to get DB connection");

--- a/backend/src/repositories/user_core.rs
+++ b/backend/src/repositories/user_core.rs
@@ -104,6 +104,10 @@ pub trait UserCoreOps: Send + Sync {
     fn update_auto_create_items(&self, user_id: i32, value: bool) -> Result<(), DieselError>;
     fn get_auto_create_items(&self, user_id: i32) -> Result<bool, DieselError>;
 
+    // System important notify
+    fn update_system_important_notify(&self, user_id: i32, value: bool) -> Result<(), DieselError>;
+    fn get_system_important_notify(&self, user_id: i32) -> Result<bool, DieselError>;
+
     // Notification settings
     fn get_default_notification_mode(&self, user_id: i32) -> Result<String, DieselError>;
     fn set_default_notification_mode(&self, user_id: i32, mode: &str) -> Result<(), DieselError>;
@@ -799,6 +803,25 @@ impl UserCoreOps for UserCore {
         let result = user_settings::table
             .filter(user_settings::user_id.eq(user_id))
             .select(user_settings::auto_create_items)
+            .first::<bool>(&mut pg_conn)?;
+        Ok(result)
+    }
+
+    fn update_system_important_notify(&self, user_id: i32, value: bool) -> Result<(), DieselError> {
+        let mut pg_conn = self.pg_pool.get().expect("Failed to get PG connection");
+        self.ensure_user_settings_exist(user_id)?;
+        diesel::update(user_settings::table.filter(user_settings::user_id.eq(user_id)))
+            .set(user_settings::system_important_notify.eq(value))
+            .execute(&mut pg_conn)?;
+        Ok(())
+    }
+
+    fn get_system_important_notify(&self, user_id: i32) -> Result<bool, DieselError> {
+        let mut pg_conn = self.pg_pool.get().expect("Failed to get PG connection");
+        self.ensure_user_settings_exist(user_id)?;
+        let result = user_settings::table
+            .filter(user_settings::user_id.eq(user_id))
+            .select(user_settings::system_important_notify)
             .first::<bool>(&mut pg_conn)?;
         Ok(result)
     }

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -966,6 +966,18 @@ pub mod mock_user_core {
             Ok(false)
         }
 
+        fn update_system_important_notify(
+            &self,
+            _user_id: i32,
+            _value: bool,
+        ) -> Result<(), DieselError> {
+            Ok(())
+        }
+
+        fn get_system_important_notify(&self, _user_id: i32) -> Result<bool, DieselError> {
+            Ok(true)
+        }
+
         fn get_default_notification_mode(&self, _user_id: i32) -> Result<String, DieselError> {
             Ok("critical".to_string())
         }

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -160,6 +160,7 @@ pub fn create_test_state() -> Arc<crate::AppState> {
         tool_registry: crate::build_tool_registry(),
         pending_rule_tests: Arc::new(dashmap::DashMap::new()),
         maintenance_mode: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        system_notify_cooldowns: dashmap::DashMap::new(),
     })
 }
 

--- a/frontend/src/dashboard/rule_builder.rs
+++ b/frontend/src/dashboard/rule_builder.rs
@@ -1042,13 +1042,6 @@ pub fn rule_template_picker(props: &TemplatePickerProps) -> Html {
                 })
                 .unwrap_or(false)
     });
-    let has_tracking = existing_rules.iter().any(|r| {
-        r.trigger_type == "ontology_change"
-            && r.status == "active"
-            && (r.action_config.contains("create_event")
-                || r.action_config.contains("update_event"))
-    });
-
     // For digest, find existing schedule times to suggest alternatives
     let existing_digest_times: Vec<String> = existing_rules
         .iter()
@@ -1117,13 +1110,6 @@ pub fn rule_template_picker(props: &TemplatePickerProps) -> Html {
             },
             digest_label.to_string(),
             digest_desc.to_string(),
-        ));
-    }
-    if !has_tracking {
-        templates.push((
-            RuleTemplate::TrackItems,
-            RuleTemplate::TrackItems.label().to_string(),
-            RuleTemplate::TrackItems.description().to_string(),
         ));
     }
     templates.push((

--- a/frontend/src/profile/billing_models.rs
+++ b/frontend/src/profile/billing_models.rs
@@ -55,6 +55,7 @@ pub struct UserProfile {
     pub phone_service_active: Option<bool>, // whether phone service is active - can be disabled for security
     pub llm_provider: Option<String>, // "openai" (default) or "tinfoil" - user's LLM provider preference
     pub auto_create_items: Option<bool>, // whether to auto-detect and create trackable items from emails/messages
+    pub system_important_notify: Option<bool>, // whether system auto-notifies for important messages
     pub has_any_connection: bool, // whether user has connected any service (for onboarding modal)
 }
 

--- a/frontend/src/profile/settings.rs
+++ b/frontend/src/profile/settings.rs
@@ -259,6 +259,7 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
     let save_context = use_state(|| (*user_profile).save_context.unwrap_or(0));
     let feature_updates = use_state(|| (*user_profile).notify);
     let auto_create_items = use_state(|| (*user_profile).auto_create_items.unwrap_or(false));
+    let system_important_notify = use_state(|| (*user_profile).system_important_notify.unwrap_or(true));
     // Sending number selector state (for notification-only countries)
     let show_sending_number_selector = use_state(|| false);
     let available_sending_numbers = use_state(|| Vec::<serde_json::Value>::new());
@@ -283,6 +284,7 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
     let save_context_save_state = use_state(|| FieldSaveState::Idle);
     let feature_updates_save_state = use_state(|| FieldSaveState::Idle);
     let auto_create_items_save_state = use_state(|| FieldSaveState::Idle);
+    let system_important_notify_save_state = use_state(|| FieldSaveState::Idle);
     let sending_number_save_state = use_state(|| FieldSaveState::Idle);
 
     // Confirmation dialog states for sensitive fields
@@ -313,6 +315,7 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
         let timezone_auto = timezone_auto.clone();
         let phone_service_active = phone_service_active.clone();
         let auto_create_items = auto_create_items.clone();
+        let system_important_notify = system_important_notify.clone();
         let user_profile_state = user_profile.clone();
         let agent_language = agent_language.clone();
         let notification_type = notification_type.clone();
@@ -340,6 +343,7 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
                 timezone_auto.set(props_profile.timezone_auto.unwrap_or(true));
                 phone_service_active.set(props_profile.phone_service_active.unwrap_or(true));
                 auto_create_items.set(props_profile.auto_create_items.unwrap_or(false));
+                system_important_notify.set(props_profile.system_important_notify.unwrap_or(true));
                 agent_language.set(props_profile.agent_language.clone());
                 notification_type.set(props_profile.notification_type.clone());
                 location.set(props_profile.location.clone().unwrap_or_default());
@@ -1159,6 +1163,53 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
                     Ok(response) if response.ok() => {
                         let mut profile = (*user_profile).clone();
                         profile.auto_create_items = Some(new_val);
+                        on_profile_update.emit(profile);
+                        save_state.set(FieldSaveState::Success);
+                        let save_state_clone = save_state.clone();
+                        spawn_local(async move {
+                            gloo_timers::future::TimeoutFuture::new(3_000).await;
+                            save_state_clone.set(FieldSaveState::Idle);
+                        });
+                    }
+                    Ok(_) => {
+                        save_state.set(FieldSaveState::Error("Failed to save".to_string()));
+                    }
+                    Err(_) => {
+                        save_state.set(FieldSaveState::Error("Network error".to_string()));
+                    }
+                }
+            });
+        })
+    };
+
+    // System important notify toggle handler
+    let on_system_important_notify_toggle = {
+        let system_important_notify = system_important_notify.clone();
+        let save_state = system_important_notify_save_state.clone();
+        let user_profile = user_profile.clone();
+        let on_profile_update = props.on_profile_update.clone();
+        Callback::from(move |e: Event| {
+            let input: HtmlInputElement = e.target_unchecked_into();
+            let new_val = input.checked();
+            system_important_notify.set(new_val);
+            let save_state = save_state.clone();
+            let user_profile = user_profile.clone();
+            let on_profile_update = on_profile_update.clone();
+            save_state.set(FieldSaveState::Saving);
+            spawn_local(async move {
+                let request = PatchFieldRequest {
+                    field: "system_important_notify".to_string(),
+                    value: serde_json::Value::Bool(new_val),
+                };
+                match Api::patch("/api/profile/field")
+                    .json(&request)
+                    .unwrap()
+                    .send()
+                    .await
+                {
+                    Ok(response) if response.ok() => {
+                        let mut profile = (*user_profile).clone();
+                        profile.system_important_notify = Some(new_val);
                         on_profile_update.emit(profile);
                         save_state.set(FieldSaveState::Success);
                         let save_state_clone = save_state.clone();
@@ -2284,14 +2335,14 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
                 </div>
             </div>
 
-            // Auto-create items field
+            // Important message alerts field
             <div class="profile-field">
                 <div class="field-label-group">
-                    <span class="field-label">{"Auto-create Items"}</span>
+                    <span class="field-label">{"Important Message Alerts"}</span>
                     <div class="tooltip">
                         <span class="tooltip-icon">{"?"}</span>
                         <span class="tooltip-text">
-                            {"Automatically detect and create trackable items (invoices, shipments, deadlines) from your emails and messages."}
+                            {"Automatically notify you when an incoming message is time-sensitive or important (e.g. emergencies, urgent requests)."}
                         </span>
                     </div>
                 </div>
@@ -2299,13 +2350,13 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
                     <label class="custom-checkbox">
                         <input
                             type="checkbox"
-                            checked={*auto_create_items}
-                            onchange={on_auto_create_items_toggle.clone()}
+                            checked={*system_important_notify}
+                            onchange={on_system_important_notify_toggle.clone()}
                         />
                         <span class="checkmark"></span>
-                        {if *auto_create_items { "Enabled" } else { "Disabled" }}
+                        {if *system_important_notify { "Enabled" } else { "Disabled" }}
                     </label>
-                    {render_save_indicator(&*auto_create_items_save_state)}
+                    {render_save_indicator(&*system_important_notify_save_state)}
                 </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Adds automatic important message detection as a system behavior that runs for every user by default (5-min delay + seen-check, skips group messages)
- New `system_important_notify` setting (default true) with "Important Message Alerts" toggle in settings UI
- Removes TrackItems template from rule picker and auto_create_items toggle from settings (both superseded)

## Test plan
- [ ] Run `diesel migration run` to apply new column
- [ ] Verify "Important Message Alerts" toggle appears in settings and persists on/off
- [ ] Send a WhatsApp message, confirm notification fires after 5 min for urgent messages
- [ ] Toggle setting off, verify no system notification
- [ ] Verify custom rules still fire independently
- [ ] Verify TrackItems no longer appears in rule template picker