### PR TITLE
Add temporal anomaly detection and sleep-aware notifications

### DIFF
--- a/backend/src/models/ontology_models.rs
+++ b/backend/src/models/ontology_models.rs
@@ -249,6 +249,7 @@ pub struct SenderSignals {
     pub last_contact_ago_secs: Option<i64>,
     pub user_reply_rate: f32,
     pub avg_response_secs: Option<i64>,
+    pub temporal_anomaly: Option<String>,
 }
 
 impl SenderSignals {
@@ -258,6 +259,7 @@ impl SenderSignals {
             last_contact_ago_secs: None,
             user_reply_rate: 0.0,
             avg_response_secs: None,
+            temporal_anomaly: None,
         }
     }
 
@@ -320,6 +322,11 @@ impl SenderSignals {
                 };
                 parts.push(format!("You typically respond {}.", resp_desc));
             }
+        }
+
+        // Temporal anomaly
+        if let Some(ref anomaly) = self.temporal_anomaly {
+            parts.push(anomaly.clone());
         }
 
         parts.join(" ")

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -55,12 +55,34 @@ pub async fn run_system_behaviors(
         }
     }
 
-    // Compute sender signals from message history
-    let signals =
-        state
-            .ontology_repository
-            .compute_sender_signals(user_id, room_id, sender_name, now);
+    // Build context early so we have the user's timezone for sender signals
+    let ctx = ContextBuilder::for_user(state, user_id)
+        .with_user_context()
+        .build()
+        .await?;
+
+    let tz_offset = ctx
+        .timezone
+        .as_ref()
+        .map(|t| t.fixed_offset)
+        .unwrap_or_else(|| chrono::FixedOffset::east_opt(0).unwrap());
+    let tz_offset_secs = tz_offset.local_minus_utc();
+
+    // Compute sender signals from message history (includes temporal anomaly detection)
+    let signals = state.ontology_repository.compute_sender_signals(
+        user_id,
+        room_id,
+        sender_name,
+        now,
+        tz_offset_secs,
+    );
     let sender_context = signals.format_for_prompt(sender_name);
+
+    // Detect if user is likely sleeping based on their activity patterns
+    let sleep_context = state
+        .ontology_repository
+        .compute_user_sleep_context(user_id, now, tz_offset_secs)
+        .unwrap_or_default();
 
     // Cross-platform escalation: check if this person also messaged on other platforms recently
     let cross_platform_ctx = if let Some(pid) = person_id {
@@ -90,12 +112,6 @@ pub async fn run_system_behaviors(
         String::new()
     };
 
-    // Build context
-    let ctx = ContextBuilder::for_user(state, user_id)
-        .with_user_context()
-        .build()
-        .await?;
-
     // Fetch recent conversation history for this room (last 10 messages)
     let recent_messages = state
         .ontology_repository
@@ -104,13 +120,6 @@ pub async fn run_system_behaviors(
 
     // Get room seen timestamp for marking messages as seen/unseen
     let seen_ts = get_room_seen_ts(state, user_id, room_id, platform).await;
-
-    // Format conversation with timestamps in user's timezone
-    let tz_offset = ctx
-        .timezone
-        .as_ref()
-        .map(|t| t.fixed_offset)
-        .unwrap_or_else(|| chrono::FixedOffset::east_opt(0).unwrap());
 
     let fmt_ts = |unix: i32| -> String {
         Utc.timestamp_opt(unix as i64, 0)
@@ -180,11 +189,14 @@ pub async fn run_system_behaviors(
     };
 
     // Build full sender context with cross-platform signal
-    let full_sender_ctx = if cross_platform_ctx.is_empty() {
-        sender_context
-    } else {
-        format!("{}\n{}", sender_context, cross_platform_ctx)
-    };
+    let mut context_parts = vec![sender_context];
+    if !cross_platform_ctx.is_empty() {
+        context_parts.push(cross_platform_ctx);
+    }
+    if !sleep_context.is_empty() {
+        context_parts.push(sleep_context);
+    }
+    let full_context = context_parts.join("\n");
 
     let system_prompt = format!(
         "You are evaluating whether an incoming message requires the user's immediate attention.\n\
@@ -193,7 +205,7 @@ pub async fn run_system_behaviors(
         \n\
         Current time: {}\n\
         \n\
-        Sender context:\n\
+        Context:\n\
         {}\n\
         \n\
         The last message in the conversation is being evaluated. Each message is marked [seen] or \
@@ -206,7 +218,7 @@ pub async fn run_system_behaviors(
         \n\
         If should_notify=false, set notification_message to empty string.\n\
         If should_notify=true, write a concise notification (max 480 chars, second person).",
-        now_formatted, full_sender_ctx
+        now_formatted, full_context
     );
 
     let user_msg = conversation;

--- a/backend/src/repositories/ontology_repository.rs
+++ b/backend/src/repositories/ontology_repository.rs
@@ -29,6 +29,76 @@ struct SuggestionCandidate {
     msg_count: i64,
 }
 
+fn format_hour(h: usize) -> String {
+    match h {
+        0 => "12am".to_string(),
+        1..=11 => format!("{}am", h),
+        12 => "12pm".to_string(),
+        13..=23 => format!("{}pm", h - 12),
+        _ => format!("{}:00", h),
+    }
+}
+
+/// Compute temporal anomaly score using Laplace-smoothed surprisal with confidence gating.
+/// Returns (score, current_hour) where score scales with both how unusual the hour is AND
+/// how much data we have. Handles wildly different message volumes correctly:
+/// - 30-msg sender, hour=0: score ~3.2 (not enough data to be confident)
+/// - 3000-msg sender, hour=0: score ~12.4 (genuinely anomalous)
+fn compute_temporal_score(hour_buckets: &[u32; 24], total: u32, current_hour: usize) -> f64 {
+    let total_f = total as f64;
+    // Laplace smoothing: add 0.5 pseudocount per bucket (Jeffreys prior)
+    let smoothed = (hour_buckets[current_hour] as f64 + 0.5) / (total_f + 12.0);
+    let surprisal = -smoothed.log2();
+    // Confidence ramps from 0 toward 1; reaches 0.5 at 30 messages
+    let confidence = total_f / (total_f + 30.0);
+    surprisal * confidence
+}
+
+/// Bucket timestamps into 24 hourly bins in the given timezone.
+fn bucket_by_hour(timestamps: &[i32], tz_offset_secs: i32) -> [u32; 24] {
+    let mut buckets = [0u32; 24];
+    for &ts in timestamps {
+        let local_ts = ts as i64 + tz_offset_secs as i64;
+        let hour = ((local_ts % 86400 + 86400) % 86400 / 3600) as usize;
+        if hour < 24 {
+            buckets[hour] += 1;
+        }
+    }
+    buckets
+}
+
+fn current_local_hour(now: i32, tz_offset_secs: i32) -> usize {
+    let local_ts = now as i64 + tz_offset_secs as i64;
+    ((local_ts % 86400 + 86400) % 86400 / 3600) as usize
+}
+
+/// Find active hours (top hours covering ~80% of activity) for context string.
+fn active_hour_range(hour_buckets: &[u32; 24], total: u32) -> Option<(usize, usize)> {
+    let mut indexed: Vec<(usize, u32)> = hour_buckets
+        .iter()
+        .enumerate()
+        .filter(|(_, &c)| c > 0)
+        .map(|(h, &c)| (h, c))
+        .collect();
+    if indexed.len() < 2 {
+        return None;
+    }
+    // Sort by count descending, accumulate until 80%
+    indexed.sort_by(|a, b| b.1.cmp(&a.1));
+    let threshold = (total as f64 * 0.8) as u32;
+    let mut acc = 0u32;
+    let mut active: Vec<usize> = Vec::new();
+    for (h, c) in &indexed {
+        acc += c;
+        active.push(*h);
+        if acc >= threshold {
+            break;
+        }
+    }
+    active.sort();
+    Some((active[0], active[active.len() - 1]))
+}
+
 pub struct OntologyRepository {
     pub pool: PgDbPool,
 }
@@ -1031,6 +1101,7 @@ impl OntologyRepository {
         room_id: &str,
         sender_name: &str,
         now: i32,
+        tz_offset_secs: i32,
     ) -> crate::models::ontology_models::SenderSignals {
         use crate::models::ontology_models::SenderSignals;
 
@@ -1089,11 +1160,120 @@ impl OntologyRepository {
             None
         };
 
+        // Temporal anomaly: Laplace-smoothed surprisal with confidence gating.
+        // Scales naturally with message volume - low-volume senders don't produce
+        // false anomalies, high-volume senders with zero activity at an hour do.
+        let temporal_anomaly = {
+            let timestamps: Vec<i32> = sender_msgs.iter().map(|m| m.created_at).collect();
+            let hour_buckets = bucket_by_hour(&timestamps, tz_offset_secs);
+            let current_hour = current_local_hour(now, tz_offset_secs);
+
+            if current_hour < 24 {
+                let score =
+                    compute_temporal_score(&hour_buckets, message_count_30d as u32, current_hour);
+                let range_ctx = active_hour_range(&hour_buckets, message_count_30d as u32)
+                    .map(|(first, last)| {
+                        format!(
+                            " Their {} messages are typically between {}-{}.",
+                            message_count_30d,
+                            format_hour(first),
+                            format_hour(last),
+                        )
+                    })
+                    .unwrap_or_default();
+
+                if score > 10.0 {
+                    Some(format!(
+                        "This person messaging at {} is highly unusual.{}",
+                        format_hour(current_hour),
+                        range_ctx,
+                    ))
+                } else if score > 7.0 {
+                    Some(format!(
+                        "This person messaging at {} is somewhat unusual.{}",
+                        format_hour(current_hour),
+                        range_ctx,
+                    ))
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
+
         SenderSignals {
             message_count_30d,
             last_contact_ago_secs,
             user_reply_rate,
             avg_response_secs,
+            temporal_anomaly,
+        }
+    }
+
+    /// Detect if user is likely sleeping based on their sent-message activity patterns.
+    /// Uses Laplace-smoothed surprisal with confidence gating - same math as sender
+    /// temporal anomaly, applied to the user's own "You" messages across all rooms.
+    pub fn compute_user_sleep_context(
+        &self,
+        user_id: i32,
+        now: i32,
+        tz_offset_secs: i32,
+    ) -> Option<String> {
+        use crate::pg_schema::ont_messages;
+
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let thirty_days_ago = now - 30 * 86400;
+
+        let user_messages: Vec<OntMessage> = ont_messages::table
+            .filter(ont_messages::user_id.eq(user_id))
+            .filter(ont_messages::sender_name.eq("You"))
+            .filter(ont_messages::created_at.ge(thirty_days_ago))
+            .select(OntMessage::as_select())
+            .load(&mut conn)
+            .unwrap_or_default();
+
+        if user_messages.is_empty() {
+            return None;
+        }
+
+        let timestamps: Vec<i32> = user_messages.iter().map(|m| m.created_at).collect();
+        let total = timestamps.len() as u32;
+        let hour_buckets = bucket_by_hour(&timestamps, tz_offset_secs);
+        let current_hour = current_local_hour(now, tz_offset_secs);
+        if current_hour >= 24 {
+            return None;
+        }
+
+        let score = compute_temporal_score(&hour_buckets, total, current_hour);
+
+        let range_ctx = active_hour_range(&hour_buckets, total)
+            .map(|(first, last)| {
+                format!(
+                    "The user is typically active between {}-{}. ",
+                    format_hour(first),
+                    format_hour(last),
+                )
+            })
+            .unwrap_or_default();
+
+        if score > 10.0 {
+            Some(format!(
+                "{}Current time is {} - the user is almost certainly sleeping. \
+                 Only notify for genuinely urgent messages where a delay until morning \
+                 would cause real harm.",
+                range_ctx,
+                format_hour(current_hour),
+            ))
+        } else if score > 7.0 {
+            Some(format!(
+                "{}Current time is {} - the user is likely sleeping. \
+                 Apply a higher bar for notification urgency.",
+                range_ctx,
+                format_hour(current_hour),
+            ))
+        } else {
+            None
         }
     }
 

--- a/enclave/entrypoint.sh
+++ b/enclave/entrypoint.sh
@@ -9,7 +9,7 @@ mkdir -p /data/seed
 exec > >(tee "$BOOT_TRACE") 2>&1
 
 send_boot_trace() {
-    local exit_code="${1:-$?}"
+    local exit_code="${1:-0}"
     echo ""
     echo "=== BOOT TRACE END (exit=$exit_code, $(date -u +%Y-%m-%dT%H:%M:%SZ)) ==="
     # Small delay to let tee flush its buffer to the file
@@ -71,7 +71,7 @@ if [ -e /dev/vsock ]; then
             while IFS= read -r line || [[ -n "$line" ]]; do
                 [[ -z "$line" || "$line" == \#* ]] && continue
                 if [[ "$line" =~ ^[A-Za-z_][A-Za-z_0-9]*= ]]; then
-                    export "$line"
+                    export "${line?}"
                     ENV_COUNT=$((ENV_COUNT + 1))
                 fi
             done < /tmp/host_env
@@ -243,7 +243,7 @@ else
 fi
 
 # Kill temporary restore bridge (step 0f starts its own)
-[ -n "${RESTORE_BRIDGE_PID:-}" ] && kill "$RESTORE_BRIDGE_PID" 2>/dev/null && wait "$RESTORE_BRIDGE_PID" 2>/dev/null || true
+if [ -n "${RESTORE_BRIDGE_PID:-}" ]; then kill "$RESTORE_BRIDGE_PID" 2>/dev/null && wait "$RESTORE_BRIDGE_PID" 2>/dev/null; fi || true
 
 # ── 0f. Fetch one-time SQL seed from host (first bootstrap only) ─────────────
 # Host runs python3 http.server on port 9080 serving /opt/lightfriend/seed/.
@@ -1174,7 +1174,7 @@ echo "  Entrypoint setup complete at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 send_boot_trace 0
 
 # Kill entrypoint bridges so supervisord can bind the same ports
-[ -n "${SEED_BRIDGE_PID:-}" ] && kill "$SEED_BRIDGE_PID" 2>/dev/null || true
+if [ -n "${SEED_BRIDGE_PID:-}" ]; then kill "$SEED_BRIDGE_PID" 2>/dev/null; fi || true
 sleep 0.2
 
 # Startup script runs via supervisord's post-boot-verify program (see supervisord.conf).


### PR DESCRIPTION
## Summary
- Sender temporal anomaly detection: flags when a person messages at an unusual hour based on their 30-day history
- User sleep detection: infers likely sleep hours from the user's own sent-message patterns, raises the notification bar during sleep
- Both use Laplace-smoothed surprisal with confidence gating (Palantir-inspired) so scoring scales correctly across wildly different message volumes (30 msgs/month vs 3000 msgs/month)
- No new tables or migrations - piggybacks on existing message data

## How it works
- `compute_temporal_score()`: shared scoring function using Jeffreys prior smoothing, information-theoretic surprisal, and confidence ramp
- Score >10 = "highly unusual", 7-10 = "somewhat unusual", <7 = silent
- Sleep context is a prompt signal only, no hard gates on notifications

## Test plan
- [ ] Verify compilation passes
- [ ] Test with high-volume sender (1000+ msgs) with zero activity at current hour - should trigger "highly unusual"
- [ ] Test with low-volume sender (30 msgs) - should stay silent regardless of hour
- [ ] Test sleep detection during user's inactive hours vs active hours
- [ ] Verify no regression in existing notification behavior