### PR TITLE
Log screened messages in activity feed

### DIFF
--- a/backend/src/handlers/dashboard_handlers.rs
+++ b/backend/src/handlers/dashboard_handlers.rs
@@ -633,6 +633,11 @@ pub async fn get_activity_feed(
         };
 
         let (title, icon, detail) = match log.activity_type.as_str() {
+            "system_screened" => (
+                "Screened message".to_string(),
+                "fa-shield-halved",
+                log.reason.clone(),
+            ),
             "noti_msg" => (
                 "Sent you an SMS notification".to_string(),
                 "fa-comment-sms",
@@ -728,9 +733,15 @@ pub async fn get_activity_feed(
             ),
         };
 
+        let entry_type = if log.activity_type == "system_screened" {
+            "screened"
+        } else {
+            "notification"
+        };
+
         entries.push(ActivityFeedEntry {
             id: format!("usage-{}", log.id),
-            entry_type: "notification".to_string(),
+            entry_type: entry_type.to_string(),
             timestamp: log.created_at,
             title,
             detail,

--- a/backend/src/handlers/imap_handlers.rs
+++ b/backend/src/handlers/imap_handlers.rs
@@ -233,7 +233,10 @@ pub async fn respond_to_email(
             ))
         }
     };
-    let server = imap_server.as_deref().unwrap_or("imap.gmail.com").to_string();
+    let server = imap_server
+        .as_deref()
+        .unwrap_or("imap.gmail.com")
+        .to_string();
     let port = imap_port.unwrap_or(993);
     // Connect to IMAP server using spawn_blocking to prevent blocking the Tokio runtime.
     // In the enclave, outbound TCP is unavailable so imap::connect would hang forever
@@ -551,7 +554,10 @@ pub async fn fetch_emails_imap(
     let tls = TlsConnector::builder().build().map_err(|e| {
         ImapError::ConnectionError(format!("Failed to create TLS connector: {}", e))
     })?;
-    let server = imap_server.as_deref().unwrap_or("imap.gmail.com").to_string();
+    let server = imap_server
+        .as_deref()
+        .unwrap_or("imap.gmail.com")
+        .to_string();
     let port = imap_port.unwrap_or(993);
     // Connect to IMAP server using spawn_blocking with timeout to prevent blocking Tokio runtime
     let server_clone = server.clone();
@@ -561,7 +567,9 @@ pub async fn fetch_emails_imap(
         std::time::Duration::from_secs(15),
         tokio::task::spawn_blocking(move || -> Result<_, ImapError> {
             let client = imap::connect((&*server_clone, port as u16), &server_clone, &tls)
-                .map_err(|e| ImapError::ConnectionError(format!("Failed to connect to IMAP server: {}", e)))?;
+                .map_err(|e| {
+                    ImapError::ConnectionError(format!("Failed to connect to IMAP server: {}", e))
+                })?;
             let session = client
                 .login(&email_clone, &password_clone)
                 .map_err(|(e, _)| ImapError::CredentialsError(format!("Failed to login: {}", e)))?;
@@ -570,8 +578,7 @@ pub async fn fetch_emails_imap(
     )
     .await
     .map_err(|_| ImapError::ConnectionError("IMAP connection timed out (15s)".to_string()))?
-    .map_err(|e| ImapError::ConnectionError(format!("IMAP task failed: {}", e)))?
-    ?;
+    .map_err(|e| ImapError::ConnectionError(format!("IMAP task failed: {}", e)))??;
     // Select INBOX
     let mailbox = imap_session
         .select("INBOX")
@@ -770,7 +777,10 @@ pub async fn fetch_single_email_imap(
     let tls = TlsConnector::builder().build().map_err(|e| {
         ImapError::ConnectionError(format!("Failed to create TLS connector: {}", e))
     })?;
-    let server = imap_server.as_deref().unwrap_or("imap.gmail.com").to_string();
+    let server = imap_server
+        .as_deref()
+        .unwrap_or("imap.gmail.com")
+        .to_string();
     let port = imap_port.unwrap_or(993);
     // Connect to IMAP server using spawn_blocking with timeout
     let server_clone = server.clone();
@@ -780,7 +790,9 @@ pub async fn fetch_single_email_imap(
         std::time::Duration::from_secs(15),
         tokio::task::spawn_blocking(move || -> Result<_, ImapError> {
             let client = imap::connect((&*server_clone, port as u16), &server_clone, &tls)
-                .map_err(|e| ImapError::ConnectionError(format!("Failed to connect to IMAP server: {}", e)))?;
+                .map_err(|e| {
+                    ImapError::ConnectionError(format!("Failed to connect to IMAP server: {}", e))
+                })?;
             let mut session = client
                 .login(&email_clone, &password_clone)
                 .map_err(|(e, _)| ImapError::CredentialsError(format!("Failed to login: {}", e)))?;
@@ -792,8 +804,7 @@ pub async fn fetch_single_email_imap(
     )
     .await
     .map_err(|_| ImapError::ConnectionError("IMAP connection timed out (15s)".to_string()))?
-    .map_err(|e| ImapError::ConnectionError(format!("IMAP task failed: {}", e)))?
-    ?;
+    .map_err(|e| ImapError::ConnectionError(format!("IMAP task failed: {}", e)))??;
     // Fetch specific message with body structure for attachments
     // Using BODY.PEEK[] to avoid marking the email as read
     let messages =

--- a/backend/src/jobs/scheduler.rs
+++ b/backend/src/jobs/scheduler.rs
@@ -28,9 +28,17 @@ async fn initialize_matrix_clients(state: Arc<AppState>) {
             // Setup clients and sync tasks for active users.
             // Stagger initialization to avoid overwhelming tuwunel with 229+ concurrent syncs
             let user_count = users.len();
-            tracing::info!("Initializing Matrix clients for {} users (staggered)", user_count);
+            tracing::info!(
+                "Initializing Matrix clients for {} users (staggered)",
+                user_count
+            );
             for (idx, user_id) in users.into_iter().enumerate() {
-                tracing::debug!("Setting up Matrix client {}/{} for user {}", idx + 1, user_count, user_id);
+                tracing::debug!(
+                    "Setting up Matrix client {}/{} for user {}",
+                    idx + 1,
+                    user_count,
+                    user_id
+                );
 
                 // Create and initialize client
                 match crate::utils::matrix_auth::get_client(user_id, &state).await {

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -6,6 +6,7 @@ use chrono::{TimeZone, Utc};
 use crate::context::ContextBuilder;
 use crate::proactive::utils::send_notification;
 use crate::repositories::user_core::UserCoreOps;
+use crate::repositories::user_repository::LogUsageParams;
 use crate::AppState;
 use openai_api_rs::v1::{chat_completion, types};
 
@@ -339,6 +340,19 @@ pub async fn run_system_behaviors(
                         )
                         .await;
                     }
+                } else {
+                    let _ = state.user_repository.log_usage(LogUsageParams {
+                        user_id,
+                        sid: None,
+                        activity_type: "system_screened".to_string(),
+                        credits: None,
+                        time_consumed: None,
+                        success: Some(true),
+                        reason: Some(format!("{} on {} - not urgent", sender_name, platform)),
+                        status: None,
+                        recharge_threshold_timestamp: None,
+                        zero_credits_timestamp: None,
+                    });
                 }
 
                 return Ok(());

--- a/frontend/src/dashboard/activity_feed.rs
+++ b/frontend/src/dashboard/activity_feed.rs
@@ -76,6 +76,10 @@ const FEED_STYLES: &str = r#"
     color: #a78bfa;
     background: rgba(167, 139, 250, 0.1);
 }
+.feed-icon.type-screened {
+    color: #6b7280;
+    background: rgba(107, 114, 128, 0.1);
+}
 .feed-body {
     flex: 1;
     min-width: 0;
@@ -383,6 +387,7 @@ fn render_entry(
     let type_label = match entry.entry_type.as_str() {
         "changelog" => "System change",
         "notification" => "Notification",
+        "screened" => "Screened",
         "message" => "Message",
         _ => "Event",
     };


### PR DESCRIPTION
## Summary
- When the critical notification system screens a message and decides it's not urgent, log a `system_screened` usage entry
- Show these in the activity feed with a muted shield icon so users can see every decision the system makes
- Includes minor formatting fixes in imap_handlers and scheduler

## Test plan
- [ ] Trigger a non-urgent incoming message, verify "Screened message" entry appears in activity feed
- [ ] Verify critical notifications still show with green notification icon
- [ ] Check expanded view shows "Screened" type label and reason detail