### PR TITLE
Fix Tesla proxy, Telegram connection, bridge room search, and misc improvements

### DIFF
--- a/backend/pg_migrations/00000000000023_multi_email_support/down.sql
+++ b/backend/pg_migrations/00000000000023_multi_email_support/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE imap_connection DROP CONSTRAINT IF EXISTS unique_user_email;
+ALTER TABLE processed_emails DROP COLUMN IF EXISTS imap_connection_id;

--- a/backend/pg_migrations/00000000000023_multi_email_support/up.sql
+++ b/backend/pg_migrations/00000000000023_multi_email_support/up.sql
@@ -1,0 +1,6 @@
+-- Support multiple email connections per user
+-- Add connection_id to processed_emails for per-account UID scoping
+ALTER TABLE processed_emails ADD COLUMN imap_connection_id INTEGER REFERENCES imap_connection(id) ON DELETE CASCADE;
+
+-- Prevent duplicate email addresses per user
+ALTER TABLE imap_connection ADD CONSTRAINT unique_user_email UNIQUE (user_id, description);

--- a/backend/src/agent_core.rs
+++ b/backend/src/agent_core.rs
@@ -121,7 +121,7 @@ pub async fn build_tools(
     user_id: i32,
     include_mcp: bool,
 ) -> Vec<chat_completion::Tool> {
-    let mut tools = state.tool_registry.definitions();
+    let mut tools = state.tool_registry.definitions_for_user(state, user_id);
 
     // Ontology query tools (dynamically built with user-specific enum values)
     let ontology_user_data = {

--- a/backend/src/api/elevenlabs.rs
+++ b/backend/src/api/elevenlabs.rs
@@ -1374,6 +1374,7 @@ pub async fn handle_email_send(
                 to: cloned_to,
                 subject: cloned_subject,
                 body: cloned_body,
+                from: None,
             };
             match crate::handlers::imap_handlers::send_email(
                 State(cloned_state.clone()),
@@ -1524,6 +1525,7 @@ pub async fn handle_respond_to_email(
             let request = crate::handlers::imap_handlers::EmailResponseRequest {
                 email_id: cloned_email_id,
                 response_text: cloned_response_text,
+                from: None,
             };
             match crate::handlers::imap_handlers::respond_to_email(
                 State(cloned_state.clone()),

--- a/backend/src/api/elevenlabs.rs
+++ b/backend/src/api/elevenlabs.rs
@@ -456,15 +456,8 @@ pub async fn handle_email_fetch_tool_call(
     };
     tracing::debug!("Received email fetch request for user: {}", user_id);
 
-    match crate::handlers::imap_handlers::fetch_emails_imap(
-        &state,
-        user_id,
-        true,
-        Some(10),
-        false,
-        false,
-    )
-    .await
+    match crate::handlers::imap_handlers::fetch_emails_imap(&state, user_id, Some(10), false, false)
+        .await
     {
         Ok(emails) => {
             if emails.is_empty() {
@@ -776,7 +769,7 @@ pub async fn handle_email_search_tool_call(
     };
 
     // First fetch recent emails with increased limit
-    match fetch_emails_imap(&state, user_id, true, Some(50), false, false).await {
+    match fetch_emails_imap(&state, user_id, Some(50), false, false).await {
         Ok(emails) => {
             let search_term = payload.search_term.to_lowercase();
             let search_type = payload.search_type.as_deref().unwrap_or("all");

--- a/backend/src/api/voice_pipeline.rs
+++ b/backend/src/api/voice_pipeline.rs
@@ -62,8 +62,7 @@ fn mulaw_encode(sample: i16) -> u8 {
     }
 
     let mantissa = ((magnitude >> (exponent + 3)) & 0x0F) as u8;
-    let byte = !(sign | (exponent << 4) | mantissa);
-    byte
+    !(sign | (exponent << 4) | mantissa)
 }
 
 /// Encode raw PCM samples as a WAV file (16-bit mono).

--- a/backend/src/context.rs
+++ b/backend/src/context.rs
@@ -340,7 +340,10 @@ impl ContextBuilder {
 
         // 4. Tools (opt-in)
         let tools = if self.want_tools {
-            let mut tool_defs = self.state.tool_registry.definitions();
+            let mut tool_defs = self
+                .state
+                .tool_registry
+                .definitions_for_user(&self.state, user_id);
             if self.want_mcp_tools {
                 let mcp =
                     crate::tool_call_utils::mcp::get_mcp_tools_for_user(&self.state, user_id).await;

--- a/backend/src/handlers/dashboard_handlers.rs
+++ b/backend/src/handlers/dashboard_handlers.rs
@@ -892,10 +892,10 @@ pub async fn get_rule_sources(
     // Email: available if user has IMAP credentials
     let has_email = state
         .user_repository
-        .get_imap_credentials(user_id)
+        .get_all_imap_credentials(user_id)
         .ok()
-        .flatten()
-        .is_some();
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
     sources.push(RuleSourceOption {
         source_type: "email".to_string(),
         label: "Email".to_string(),

--- a/backend/src/handlers/dashboard_handlers.rs
+++ b/backend/src/handlers/dashboard_handlers.rs
@@ -1,9 +1,11 @@
 use axum::{
     extract::{Path, Query, State},
     http::StatusCode,
+    response::sse::{Event, KeepAlive, Sse},
     Json,
 };
 use chrono::Datelike;
+use futures::stream::Stream;
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 
@@ -1301,4 +1303,37 @@ pub async fn confirm_event(
             )
         })?;
     Ok(Json(serde_json::json!({"confirmed": event_id})))
+}
+
+/// GET /api/dashboard/activity-feed/stream
+/// SSE endpoint that pushes a refresh signal whenever new activity occurs for the user.
+pub async fn activity_feed_stream(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+) -> Sse<impl Stream<Item = Result<Event, std::convert::Infallible>>> {
+    let user_id = auth_user.user_id;
+    let mut rx = state.activity_feed_tx.subscribe();
+
+    let stream = async_stream::stream! {
+        loop {
+            match rx.recv().await {
+                Ok(changed_user_id) if changed_user_id == user_id => {
+                    yield Ok(Event::default().event("refresh").data("{}"));
+                }
+                Ok(_) => {
+                    // Different user, ignore
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                    tracing::debug!("Activity feed SSE lagged {} messages for user {}", n, user_id);
+                    // Send a refresh anyway since we missed events
+                    yield Ok(Event::default().event("refresh").data("{}"));
+                }
+                Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                    break;
+                }
+            }
+        }
+    };
+
+    Sse::new(stream).keep_alive(KeepAlive::default())
 }

--- a/backend/src/handlers/imap_auth.rs
+++ b/backend/src/handlers/imap_auth.rs
@@ -157,11 +157,281 @@ pub fn detect_imap_server(email: &str) -> (&'static str, u16) {
     }
 }
 
-// Struct to serialize the IMAP status response
+// ─── Provider auto-detection ────────────────────────────────────────────────
+
+#[derive(Deserialize)]
+pub struct DetectProviderRequest {
+    pub email: String,
+}
+
+#[derive(Serialize)]
+pub struct DetectedProvider {
+    /// Provider key (e.g. "gmail", "outlook", "privateemail", "unknown")
+    pub provider: String,
+    /// Human-readable label
+    pub label: String,
+    /// IMAP server (empty if unknown)
+    pub imap_server: String,
+    /// IMAP port
+    pub imap_port: u16,
+    /// Instructions for the user (e.g. "Create an App Password")
+    pub instructions: Option<String>,
+    /// Link for creating app password
+    pub instructions_url: Option<String>,
+}
+
+/// Detect email provider from the email address using domain matching and MX record lookup.
+pub async fn detect_provider(
+    _auth_user: AuthUser,
+    Json(payload): Json<DetectProviderRequest>,
+) -> Result<AxumJson<DetectedProvider>, (StatusCode, AxumJson<serde_json::Value>)> {
+    let email = payload.email.trim().to_lowercase();
+
+    if !is_valid_email(&email) {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            AxumJson(json!({"error": "Invalid email address"})),
+        ));
+    }
+
+    let domain = extract_email_domain(&email).unwrap_or("");
+
+    // Step 1: Try direct domain match
+    if let Some(provider) = detect_provider_from_domain(domain) {
+        return Ok(AxumJson(provider));
+    }
+
+    // Step 2: MX record lookup for custom domains
+    if let Some(provider) = detect_provider_from_mx(domain).await {
+        return Ok(AxumJson(provider));
+    }
+
+    // Step 3: Unknown - user will need to pick manually
+    Ok(AxumJson(DetectedProvider {
+        provider: "unknown".to_string(),
+        label: "Unknown Provider".to_string(),
+        imap_server: String::new(),
+        imap_port: 993,
+        instructions: None,
+        instructions_url: None,
+    }))
+}
+
+fn detect_provider_from_domain(domain: &str) -> Option<DetectedProvider> {
+    let domain = domain.to_lowercase();
+    match domain.as_str() {
+        "gmail.com" | "googlemail.com" => Some(DetectedProvider {
+            provider: "gmail".to_string(),
+            label: "Gmail".to_string(),
+            imap_server: "imap.gmail.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Gmail requires an App Password (2FA must be enabled).".to_string()),
+            instructions_url: Some("https://myaccount.google.com/apppasswords".to_string()),
+        }),
+        "icloud.com" | "me.com" | "mac.com" => Some(DetectedProvider {
+            provider: "icloud".to_string(),
+            label: "iCloud".to_string(),
+            imap_server: "imap.mail.me.com".to_string(),
+            imap_port: 993,
+            instructions: Some("iCloud requires an App-Specific Password. Go to Apple ID Settings > Sign-In and Security > App-Specific Passwords.".to_string()),
+            instructions_url: Some("https://appleid.apple.com/account/manage".to_string()),
+        }),
+        "outlook.com" | "hotmail.com" | "live.com" | "msn.com" => Some(DetectedProvider {
+            provider: "outlook".to_string(),
+            label: "Outlook / Hotmail".to_string(),
+            imap_server: "outlook.office365.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Use your regular password, or create an app password if 2FA is enabled.".to_string()),
+            instructions_url: Some("https://account.microsoft.com/security".to_string()),
+        }),
+        "yahoo.com" | "yahoo.co.uk" | "yahoo.fr" | "yahoo.de" => Some(DetectedProvider {
+            provider: "yahoo".to_string(),
+            label: "Yahoo Mail".to_string(),
+            imap_server: "imap.mail.yahoo.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Yahoo requires an App Password (2FA must be enabled).".to_string()),
+            instructions_url: Some("https://login.yahoo.com/myaccount/security/app-password".to_string()),
+        }),
+        "aol.com" => Some(DetectedProvider {
+            provider: "aol".to_string(),
+            label: "AOL".to_string(),
+            imap_server: "imap.aol.com".to_string(),
+            imap_port: 993,
+            instructions: Some("AOL requires an App Password (2FA must be enabled).".to_string()),
+            instructions_url: Some("https://login.aol.com/myaccount/security/app-password".to_string()),
+        }),
+        "zoho.com" | "zohomail.com" => Some(DetectedProvider {
+            provider: "zoho".to_string(),
+            label: "Zoho Mail".to_string(),
+            imap_server: "imap.zoho.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Make sure IMAP is enabled in your Zoho settings.".to_string()),
+            instructions_url: None,
+        }),
+        "fastmail.com" | "fastmail.fm" => Some(DetectedProvider {
+            provider: "fastmail".to_string(),
+            label: "Fastmail".to_string(),
+            imap_server: "imap.fastmail.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Fastmail recommends using an App Password.".to_string()),
+            instructions_url: Some("https://www.fastmail.com/settings/security/devicekeys".to_string()),
+        }),
+        "yandex.com" | "yandex.ru" => Some(DetectedProvider {
+            provider: "yandex".to_string(),
+            label: "Yandex".to_string(),
+            imap_server: "imap.yandex.com".to_string(),
+            imap_port: 993,
+            instructions: None,
+            instructions_url: None,
+        }),
+        "gmx.com" | "gmx.net" => Some(DetectedProvider {
+            provider: "gmx".to_string(),
+            label: "GMX".to_string(),
+            imap_server: "imap.gmx.com".to_string(),
+            imap_port: 993,
+            instructions: None,
+            instructions_url: None,
+        }),
+        _ => None,
+    }
+}
+
+/// Look up MX records for a domain and try to match against known providers.
+async fn detect_provider_from_mx(domain: &str) -> Option<DetectedProvider> {
+    let output = tokio::process::Command::new("dig")
+        .args(["MX", domain, "+short"])
+        .output()
+        .await
+        .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let mx_output = String::from_utf8_lossy(&output.stdout).to_lowercase();
+    tracing::debug!("MX lookup for {}: {}", domain, mx_output.trim());
+
+    // Match MX records to known providers
+    if mx_output.contains("google.com") || mx_output.contains("googlemail.com") {
+        Some(DetectedProvider {
+            provider: "gmail".to_string(),
+            label: "Google Workspace".to_string(),
+            imap_server: "imap.gmail.com".to_string(),
+            imap_port: 993,
+            instructions: Some(
+                "Google Workspace requires an App Password (2FA must be enabled).".to_string(),
+            ),
+            instructions_url: Some("https://myaccount.google.com/apppasswords".to_string()),
+        })
+    } else if mx_output.contains("outlook.com")
+        || mx_output.contains("protection.outlook.com")
+        || mx_output.contains("microsoft.com")
+    {
+        Some(DetectedProvider {
+            provider: "outlook".to_string(),
+            label: "Microsoft 365".to_string(),
+            imap_server: "outlook.office365.com".to_string(),
+            imap_port: 993,
+            instructions: Some(
+                "Use your regular password, or create an app password if 2FA is enabled."
+                    .to_string(),
+            ),
+            instructions_url: Some("https://account.microsoft.com/security".to_string()),
+        })
+    } else if mx_output.contains("zoho.com") {
+        Some(DetectedProvider {
+            provider: "zoho".to_string(),
+            label: "Zoho Mail".to_string(),
+            imap_server: "imap.zoho.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Make sure IMAP is enabled in your Zoho settings.".to_string()),
+            instructions_url: None,
+        })
+    } else if mx_output.contains("yahoodns.net") || mx_output.contains("yahoo.com") {
+        Some(DetectedProvider {
+            provider: "yahoo".to_string(),
+            label: "Yahoo Mail".to_string(),
+            imap_server: "imap.mail.yahoo.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Yahoo requires an App Password (2FA must be enabled).".to_string()),
+            instructions_url: Some(
+                "https://login.yahoo.com/myaccount/security/app-password".to_string(),
+            ),
+        })
+    } else if mx_output.contains("icloud.com") || mx_output.contains("apple.com") {
+        Some(DetectedProvider {
+            provider: "icloud".to_string(),
+            label: "iCloud".to_string(),
+            imap_server: "imap.mail.me.com".to_string(),
+            imap_port: 993,
+            instructions: Some("iCloud requires an App-Specific Password.".to_string()),
+            instructions_url: Some("https://appleid.apple.com/account/manage".to_string()),
+        })
+    } else if mx_output.contains("fastmail.com") || mx_output.contains("messagingengine.com") {
+        Some(DetectedProvider {
+            provider: "fastmail".to_string(),
+            label: "Fastmail".to_string(),
+            imap_server: "imap.fastmail.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Fastmail recommends using an App Password.".to_string()),
+            instructions_url: Some(
+                "https://www.fastmail.com/settings/security/devicekeys".to_string(),
+            ),
+        })
+    } else if mx_output.contains("privateemail.com") {
+        Some(DetectedProvider {
+            provider: "privateemail".to_string(),
+            label: "PrivateEmail (Namecheap)".to_string(),
+            imap_server: "mail.privateemail.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Use your email password.".to_string()),
+            instructions_url: None,
+        })
+    } else if mx_output.contains("secureserver.net") {
+        Some(DetectedProvider {
+            provider: "godaddy".to_string(),
+            label: "GoDaddy".to_string(),
+            imap_server: "imap.secureserver.net".to_string(),
+            imap_port: 993,
+            instructions: Some("Use your email password.".to_string()),
+            instructions_url: None,
+        })
+    } else if mx_output.contains("hostinger.com") {
+        Some(DetectedProvider {
+            provider: "hostinger".to_string(),
+            label: "Hostinger".to_string(),
+            imap_server: "imap.hostinger.com".to_string(),
+            imap_port: 993,
+            instructions: Some("Use your email password.".to_string()),
+            instructions_url: None,
+        })
+    } else {
+        None
+    }
+}
+
+// Struct to serialize the IMAP status response (single - kept for backwards compat)
 #[derive(Serialize)]
 pub struct ImapStatus {
     connected: bool,
     email: Option<String>,
+}
+
+// Multi-account status response
+#[derive(Serialize)]
+pub struct ImapAccountStatus {
+    pub email: String,
+    pub connected: bool,
+}
+
+#[derive(Serialize)]
+pub struct ImapStatusMulti {
+    pub connections: Vec<ImapAccountStatus>,
+}
+
+#[derive(Deserialize)]
+pub struct DeleteImapRequest {
+    pub email: String,
 }
 
 use native_tls::TlsStream;
@@ -282,16 +552,16 @@ pub async fn imap_login(
     }
 }
 
-// Handler to check the IMAP connection status
+// Handler to check the IMAP connection status (returns all connections)
 pub async fn imap_status(
     State(state): State<Arc<AppState>>,
     auth_user: AuthUser,
-) -> Result<AxumJson<ImapStatus>, (StatusCode, AxumJson<serde_json::Value>)> {
+) -> Result<AxumJson<ImapStatusMulti>, (StatusCode, AxumJson<serde_json::Value>)> {
     tracing::info!("Checking IMAP status for user {}", auth_user.user_id);
 
-    let credentials = state
+    let connections = state
         .user_repository
-        .get_imap_credentials(auth_user.user_id)
+        .get_all_imap_credentials(auth_user.user_id)
         .map_err(|e| {
             tracing::error!("Failed to fetch IMAP credentials: {}", e);
             (
@@ -300,68 +570,35 @@ pub async fn imap_status(
             )
         })?;
 
-    match credentials {
-        Some((email, password, imap_server, imap_port)) => {
-            // Actually test the connection instead of just checking if credentials exist
-            tracing::debug!("Testing IMAP connection for user {}", auth_user.user_id);
+    // Return status based on DB state (no live IMAP testing to avoid N connections per page load)
+    let accounts: Vec<ImapAccountStatus> = connections
+        .into_iter()
+        .map(|c| ImapAccountStatus {
+            email: c.email,
+            connected: true, // active in DB = connected
+        })
+        .collect();
 
-            match connect_imap(
-                &email,
-                &password,
-                imap_server.as_deref(),
-                imap_port.map(|val| val as u16),
-            )
-            .await
-            {
-                Ok(mut session) => {
-                    // Logout immediately after verification
-                    if let Err(e) = session.logout() {
-                        tracing::warn!("Failed to logout IMAP session during status check: {}", e);
-                    }
-
-                    tracing::info!(
-                        "IMAP connection test successful for user {}",
-                        auth_user.user_id
-                    );
-                    Ok(Json(ImapStatus {
-                        connected: true,
-                        email: Some(email),
-                    }))
-                }
-                Err(e) => {
-                    tracing::error!(
-                        "IMAP connection test failed for user {}: {}",
-                        auth_user.user_id,
-                        e
-                    );
-                    // Return connected: false if test fails, so frontend shows accurate status
-                    Ok(Json(ImapStatus {
-                        connected: false,
-                        email: Some(email),
-                    }))
-                }
-            }
-        }
-        None => Ok(Json(ImapStatus {
-            connected: false,
-            email: None,
-        })),
-    }
+    Ok(Json(ImapStatusMulti {
+        connections: accounts,
+    }))
 }
 
-// Handler to delete the IMAP connection
+// Handler to delete a specific IMAP connection by email address
 pub async fn delete_imap_connection(
     State(state): State<Arc<AppState>>,
     auth_user: AuthUser,
+    Json(payload): Json<DeleteImapRequest>,
 ) -> Result<AxumJson<serde_json::Value>, (StatusCode, AxumJson<serde_json::Value>)> {
     tracing::info!(
-        "Received request to delete IMAP connection for user {}",
+        "Received request to delete IMAP connection {} for user {}",
+        payload.email,
         auth_user.user_id
     );
 
     if let Err(e) = state
         .user_repository
-        .delete_imap_credentials(auth_user.user_id)
+        .delete_imap_connection_by_email(auth_user.user_id, &payload.email)
     {
         tracing::error!("Failed to delete IMAP credentials: {}", e);
         return Err((
@@ -371,7 +608,8 @@ pub async fn delete_imap_connection(
     }
 
     tracing::info!(
-        "Successfully deleted IMAP connection for user {}",
+        "Successfully deleted IMAP connection {} for user {}",
+        payload.email,
         auth_user.user_id
     );
     Ok(AxumJson(

--- a/backend/src/handlers/imap_handlers.rs
+++ b/backend/src/handlers/imap_handlers.rs
@@ -88,7 +88,7 @@ pub async fn fetch_imap_previews(
         auth_user.user_id,
         params.limit
     );
-    match fetch_emails_imap(&state, auth_user.user_id, true, params.limit, false, false).await {
+    match fetch_emails_imap(&state, auth_user.user_id, params.limit, false, false).await {
         Ok(previews) => {
             tracing::info!("Fetched {} IMAP previews", previews.len());
 
@@ -140,7 +140,7 @@ pub async fn fetch_full_imap_emails(
     if limit.is_none() {
         limit = Some(5);
     }
-    match fetch_emails_imap(&state, auth_user.user_id, false, limit, false, false).await {
+    match fetch_emails_imap(&state, auth_user.user_id, limit, false, false).await {
         Ok(previews) => {
             tracing::info!("Fetched {} IMAP full emails", previews.len());
 
@@ -568,13 +568,16 @@ pub async fn fetch_single_imap_email(
 pub async fn fetch_emails_imap(
     state: &AppState,
     user_id: i32,
-    preview_only: bool,
     limit: Option<u32>,
     unprocessed: bool,
     unread_only: bool,
 ) -> Result<Vec<ImapEmailPreview>, ImapError> {
-    tracing::debug!("Starting fetch_emails_imap for user {} with preview_only: {}, limit: {:?}, unprocessed: {}",
-        user_id, preview_only, limit, unprocessed);
+    tracing::debug!(
+        "Starting fetch_emails_imap for user {} with limit: {:?}, unprocessed: {}",
+        user_id,
+        limit,
+        unprocessed
+    );
 
     // Fetch from all connected accounts and merge results
     let accounts = state
@@ -595,7 +598,6 @@ pub async fn fetch_emails_imap(
             &account.password,
             account.imap_server.as_deref(),
             account.imap_port,
-            preview_only,
             limit,
             unprocessed,
             unread_only,
@@ -635,6 +637,7 @@ pub async fn fetch_emails_imap(
 }
 
 /// Fetch emails from a single IMAP account
+#[allow(clippy::too_many_arguments)]
 async fn fetch_emails_imap_for_account(
     state: &AppState,
     user_id: i32,
@@ -642,7 +645,6 @@ async fn fetch_emails_imap_for_account(
     password: &str,
     imap_server: Option<&str>,
     imap_port: Option<i32>,
-    preview_only: bool,
     limit: Option<u32>,
     unprocessed: bool,
     unread_only: bool,

--- a/backend/src/handlers/imap_handlers.rs
+++ b/backend/src/handlers/imap_handlers.rs
@@ -183,6 +183,8 @@ pub async fn fetch_full_imap_emails(
 pub struct EmailResponseRequest {
     pub email_id: String,
     pub response_text: String,
+    #[serde(default)]
+    pub from: Option<String>,
 }
 // this is not used yet since it didn't work and not my priority rn
 pub async fn respond_to_email(
@@ -203,25 +205,60 @@ pub async fn respond_to_email(
             AxumJson(json!({ "error": "Invalid email ID format" })),
         ));
     }
-    // Get IMAP credentials
-    let (email, password, imap_server, imap_port) = match state
-        .user_repository
-        .get_imap_credentials(auth_user.user_id)
-    {
-        Ok(Some(creds)) => creds,
-        Ok(None) => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                AxumJson(json!({ "error": "No IMAP connection found" })),
-            ))
+    // Resolve which email account to use
+    let cred = if let Some(ref from_email) = request.from {
+        match state
+            .user_repository
+            .get_imap_credentials_by_email(auth_user.user_id, from_email)
+        {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    AxumJson(
+                        json!({ "error": format!("No connected email account for '{}'", from_email) }),
+                    ),
+                ))
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    AxumJson(json!({ "error": format!("Failed to get IMAP credentials: {}", e) })),
+                ))
+            }
         }
-        Err(e) => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                AxumJson(json!({ "error": format!("Failed to get IMAP credentials: {}", e) })),
-            ))
+    } else {
+        match state
+            .user_repository
+            .get_imap_credentials(auth_user.user_id)
+        {
+            Ok(Some((email, password, imap_server, imap_port))) => {
+                crate::repositories::user_repository::ImapConnectionInfo {
+                    id: 0,
+                    email,
+                    password,
+                    imap_server,
+                    imap_port,
+                }
+            }
+            Ok(None) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    AxumJson(json!({ "error": "No IMAP connection found" })),
+                ))
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    AxumJson(json!({ "error": format!("Failed to get IMAP credentials: {}", e) })),
+                ))
+            }
         }
     };
+    let email = cred.email;
+    let password = cred.password;
+    let imap_server = cred.imap_server;
+    let imap_port = cred.imap_port;
     tracing::info!("setting up tls");
     // Set up TLS
     let tls = match TlsConnector::builder().build() {
@@ -538,12 +575,80 @@ pub async fn fetch_emails_imap(
 ) -> Result<Vec<ImapEmailPreview>, ImapError> {
     tracing::debug!("Starting fetch_emails_imap for user {} with preview_only: {}, limit: {:?}, unprocessed: {}",
         user_id, preview_only, limit, unprocessed);
-    // Get IMAP credentials
-    let (email, password, imap_server, imap_port) = state
+
+    // Fetch from all connected accounts and merge results
+    let accounts = state
         .user_repository
-        .get_imap_credentials(user_id)
-        .map_err(|e| ImapError::CredentialsError(e.to_string()))?
-        .ok_or(ImapError::NoConnection)?;
+        .get_all_imap_credentials(user_id)
+        .map_err(|e| ImapError::CredentialsError(e.to_string()))?;
+
+    if accounts.is_empty() {
+        return Err(ImapError::NoConnection);
+    }
+
+    let mut all_previews = Vec::new();
+    for account in &accounts {
+        match fetch_emails_imap_for_account(
+            state,
+            user_id,
+            &account.email,
+            &account.password,
+            account.imap_server.as_deref(),
+            account.imap_port,
+            preview_only,
+            limit,
+            unprocessed,
+            unread_only,
+        )
+        .await
+        {
+            Ok(mut previews) => {
+                // Tag each preview's account source in the from field
+                for p in &mut previews {
+                    if p.from.is_none() || p.from.as_deref() == Some("") {
+                        p.from = Some(account.email.clone());
+                    }
+                }
+                all_previews.extend(previews);
+            }
+            Err(e) => {
+                tracing::error!(
+                    "Failed to fetch emails from {} for user {}: {:?}",
+                    account.email,
+                    user_id,
+                    e
+                );
+                // Continue with other accounts
+            }
+        }
+    }
+
+    // Sort by date descending (newest first)
+    all_previews.sort_by(|a, b| b.date.cmp(&a.date));
+
+    // Apply limit across all accounts
+    if let Some(lim) = limit {
+        all_previews.truncate(lim as usize);
+    }
+
+    Ok(all_previews)
+}
+
+/// Fetch emails from a single IMAP account
+async fn fetch_emails_imap_for_account(
+    state: &AppState,
+    user_id: i32,
+    email: &str,
+    password: &str,
+    imap_server: Option<&str>,
+    imap_port: Option<i32>,
+    preview_only: bool,
+    limit: Option<u32>,
+    unprocessed: bool,
+    unread_only: bool,
+) -> Result<Vec<ImapEmailPreview>, ImapError> {
+    let email = email.to_string();
+    let password = password.to_string();
     // Add logging for debugging (remove in production)
     tracing::debug!(
         "Fetching IMAP emails for user {} with email {}",
@@ -554,10 +659,7 @@ pub async fn fetch_emails_imap(
     let tls = TlsConnector::builder().build().map_err(|e| {
         ImapError::ConnectionError(format!("Failed to create TLS connector: {}", e))
     })?;
-    let server = imap_server
-        .as_deref()
-        .unwrap_or("imap.gmail.com")
-        .to_string();
+    let server = imap_server.unwrap_or("imap.gmail.com").to_string();
     let port = imap_port.unwrap_or(993);
     // Connect to IMAP server using spawn_blocking with timeout to prevent blocking Tokio runtime
     let server_clone = server.clone();
@@ -603,7 +705,7 @@ pub async fn fetch_emails_imap(
         // Check if email is already processed using repository method
         let is_processed = state
             .user_repository
-            .is_email_processed(user_id, &uid)
+            .is_email_processed(user_id, &uid, None)
             .map_err(|e| {
                 ImapError::FetchError(format!("Failed to check email processed status: {}", e))
             })?;
@@ -745,7 +847,10 @@ pub async fn fetch_emails_imap(
         });
         // Mark email as processed if unprocessed is true
         if unprocessed {
-            match state.user_repository.mark_email_as_processed(user_id, &uid) {
+            match state
+                .user_repository
+                .mark_email_as_processed(user_id, &uid, None)
+            {
                 Ok(_) => {}
                 Err(e) => {
                     tracing::error!("Failed to mark email {} as processed: {}", uid, e);
@@ -767,20 +872,61 @@ pub async fn fetch_single_email_imap(
     user_id: i32,
     email_id: &str,
 ) -> Result<ImapEmail, ImapError> {
-    // Get IMAP credentials
-    let (email, password, imap_server, imap_port) = state
+    // Try all connected accounts to find the email
+    let accounts = state
         .user_repository
-        .get_imap_credentials(user_id)
-        .map_err(|e| ImapError::CredentialsError(e.to_string()))?
-        .ok_or(ImapError::NoConnection)?;
+        .get_all_imap_credentials(user_id)
+        .map_err(|e| ImapError::CredentialsError(e.to_string()))?;
+
+    if accounts.is_empty() {
+        return Err(ImapError::NoConnection);
+    }
+
+    // Try each account - return first success
+    let mut last_err = ImapError::NoConnection;
+    for account in &accounts {
+        match fetch_single_email_from_account(
+            state,
+            user_id,
+            email_id,
+            &account.email,
+            &account.password,
+            account.imap_server.as_deref(),
+            account.imap_port,
+        )
+        .await
+        {
+            Ok(email) => return Ok(email),
+            Err(e) => {
+                tracing::debug!(
+                    "Email {} not found in account {} for user {}",
+                    email_id,
+                    account.email,
+                    user_id
+                );
+                last_err = e;
+            }
+        }
+    }
+    Err(last_err)
+}
+
+async fn fetch_single_email_from_account(
+    state: &AppState,
+    user_id: i32,
+    email_id: &str,
+    email: &str,
+    password: &str,
+    imap_server: Option<&str>,
+    imap_port: Option<i32>,
+) -> Result<ImapEmail, ImapError> {
+    let email = email.to_string();
+    let password = password.to_string();
     // Set up TLS
     let tls = TlsConnector::builder().build().map_err(|e| {
         ImapError::ConnectionError(format!("Failed to create TLS connector: {}", e))
     })?;
-    let server = imap_server
-        .as_deref()
-        .unwrap_or("imap.gmail.com")
-        .to_string();
+    let server = imap_server.unwrap_or("imap.gmail.com").to_string();
     let port = imap_port.unwrap_or(993);
     // Connect to IMAP server using spawn_blocking with timeout
     let server_clone = server.clone();
@@ -974,6 +1120,8 @@ pub struct SendEmailRequest {
     pub to: String,
     pub subject: String,
     pub body: String,
+    #[serde(default)]
+    pub from: Option<String>,
 }
 pub async fn send_email(
     State(state): State<Arc<AppState>>,
@@ -985,25 +1133,61 @@ pub async fn send_email(
         request.to,
         auth_user.user_id
     );
-    // Get user's email credentials (assuming same as IMAP for SMTP)
-    let (email, password, imap_server, _) = match state
-        .user_repository
-        .get_imap_credentials(auth_user.user_id)
-    {
-        Ok(Some(creds)) => creds,
-        Ok(None) => {
-            return Err((
-                StatusCode::BAD_REQUEST,
-                AxumJson(json!({ "error": "No email credentials found" })),
-            ))
+    // Resolve which email account to use
+    let cred = if let Some(ref from_email) = request.from {
+        // Use specific account
+        match state
+            .user_repository
+            .get_imap_credentials_by_email(auth_user.user_id, from_email)
+        {
+            Ok(Some(c)) => c,
+            Ok(None) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    AxumJson(
+                        json!({ "error": format!("No connected email account for '{}'", from_email) }),
+                    ),
+                ))
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    AxumJson(json!({ "error": format!("Failed to get email credentials: {}", e) })),
+                ))
+            }
         }
-        Err(e) => {
-            return Err((
-                StatusCode::INTERNAL_SERVER_ERROR,
-                AxumJson(json!({ "error": format!("Failed to get email credentials: {}", e) })),
-            ))
+    } else {
+        // Fall back to first active account
+        match state
+            .user_repository
+            .get_imap_credentials(auth_user.user_id)
+        {
+            Ok(Some((email, password, imap_server, imap_port))) => {
+                crate::repositories::user_repository::ImapConnectionInfo {
+                    id: 0,
+                    email,
+                    password,
+                    imap_server,
+                    imap_port,
+                }
+            }
+            Ok(None) => {
+                return Err((
+                    StatusCode::BAD_REQUEST,
+                    AxumJson(json!({ "error": "No email credentials found" })),
+                ))
+            }
+            Err(e) => {
+                return Err((
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    AxumJson(json!({ "error": format!("Failed to get email credentials: {}", e) })),
+                ))
+            }
         }
     };
+    let email = cred.email;
+    let password = cred.password;
+    let imap_server = cred.imap_server;
     // Derive SMTP server from IMAP server (common pattern, e.g., imap.gmail.com -> smtp.gmail.com)
     let smtp_server = imap_server
         .as_deref()

--- a/backend/src/handlers/profile_handlers.rs
+++ b/backend/src/handlers/profile_handlers.rs
@@ -189,10 +189,10 @@ pub async fn get_profile(
             // Check if user has any connected services (for onboarding modal)
             let has_any_connection = state
                 .user_repository
-                .get_imap_credentials(auth_user.user_id)
+                .get_all_imap_credentials(auth_user.user_id)
                 .ok()
-                .flatten()
-                .is_some()
+                .map(|v| !v.is_empty())
+                .unwrap_or(false)
                 || state
                     .user_repository
                     .get_bridge(auth_user.user_id, "whatsapp")

--- a/backend/src/handlers/signal_auth.rs
+++ b/backend/src/handlers/signal_auth.rs
@@ -271,7 +271,7 @@ async fn connect_signal(client: &MatrixClient, bridge_bot: &str) -> Result<(Owne
                                         &image_content.source
                                     {
                                         qr_code_url = Some(url.to_string());
-                                        tracing::info!("🔑 Found QR code URL: {:#?}", qr_code_url);
+                                        tracing::info!("Found Signal QR code URL for linking");
                                         break;
                                     } else {
                                         // Handle unexpected encrypted case, e.g., log an error and continue

--- a/backend/src/handlers/telegram_auth.rs
+++ b/backend/src/handlers/telegram_auth.rs
@@ -473,7 +473,7 @@ async fn monitor_telegram_connection(
     state: Arc<AppState>,
 ) -> Result<(), anyhow::Error> {
     tracing::info!(
-        "👀 Starting Telegram connection monitoring for user {} in room {}",
+        "Starting Telegram connection monitoring for user {} in room {}",
         user_id,
         room_id
     );
@@ -481,24 +481,43 @@ async fn monitor_telegram_connection(
 
     let sync_settings = MatrixSyncSettings::default().timeout(Duration::from_secs(10));
 
-    for attempt in 1..=120 {
-        // Increase to 10 minutes (120 * 5 seconds)
-        tracing::info!("🔄 Monitoring attempt #{} for user {}", attempt, user_id);
+    // Do NOT send any messages during monitoring - the user is completing the
+    // web auth flow and sending messages floods the room, pushing the bridge's
+    // "Logged in" response out of the message check window.
 
-        // Send login command to trigger a response
-        if let Some(room) = client.get_room(room_id) {
-            tracing::debug!("📤 Sending login command to verify connection");
-            room.send(RoomMessageEventContent::text_plain("login"))
-                .await?;
+    for attempt in 1..=120 {
+        if attempt <= 3 || attempt % 10 == 0 {
+            tracing::info!("Telegram monitor attempt #{} for user {}", attempt, user_id);
         }
 
-        let _ = client.sync_once(sync_settings.clone()).await?;
+        // Sync Matrix events - tolerate transient errors
+        if let Err(e) = client.sync_once(sync_settings.clone()).await {
+            tracing::warn!(
+                "Telegram monitor sync error for user {} (attempt {}): {}",
+                user_id,
+                attempt,
+                e
+            );
+            sleep(Duration::from_secs(5)).await;
+            continue;
+        }
 
         if let Some(room) = client.get_room(room_id) {
             let mut options =
                 matrix_sdk::room::MessagesOptions::new(matrix_sdk::ruma::api::Direction::Backward);
-            options.limit = matrix_sdk::ruma::UInt::new(20).unwrap(); // Increase to 20 messages
-            let messages = room.messages(options).await?;
+            options.limit = matrix_sdk::ruma::UInt::new(50).unwrap();
+            let messages = match room.messages(options).await {
+                Ok(m) => m,
+                Err(e) => {
+                    tracing::warn!(
+                        "Telegram monitor messages error for user {}: {}",
+                        user_id,
+                        e
+                    );
+                    sleep(Duration::from_secs(5)).await;
+                    continue;
+                }
+            };
 
             for msg in messages.chunk {
                 let raw_event = msg.raw();
@@ -527,15 +546,15 @@ async fn monitor_telegram_connection(
                             if content.contains("Logged in")
                                 || content.contains("You are already logged in")
                             {
-                                tracing::debug!(
-                                    "🎉 Telegram successfully connected for user {}",
+                                tracing::info!(
+                                    "Telegram successfully connected for user {}",
                                     user_id
                                 );
 
                                 // Extract the connected account (username or phone)
                                 let connected_account = extract_connected_account(&content);
                                 if let Some(ref account) = connected_account {
-                                    tracing::info!("📱 Connected as: {}", account);
+                                    tracing::info!("Connected as: {}", account);
                                 }
 
                                 let current_time = std::time::SystemTime::now()
@@ -554,18 +573,6 @@ async fn monitor_telegram_connection(
                                 state.user_repository.delete_bridge(user_id, "telegram")?;
                                 state.user_repository.create_bridge(new_bridge)?;
 
-                                // TODO: Re-enable E2EE when mautrix bridges config supports encryption
-                                // // Enable E2EE for this user when connecting a bridge
-                                // if let Err(e) =
-                                //     state.user_repository.set_matrix_e2ee_enabled(user_id, true)
-                                // {
-                                //     tracing::warn!(
-                                //         "Failed to enable E2EE for user {}: {}",
-                                //         user_id,
-                                //         e
-                                //     );
-                                // }
-
                                 // Add client to app state and start sync
                                 let mut matrix_clients = state.matrix_clients.lock().await;
                                 let mut sync_tasks = state.matrix_sync_tasks.lock().await;
@@ -574,7 +581,7 @@ async fn monitor_telegram_connection(
                                 client.add_event_handler(move |ev: matrix_sdk::ruma::events::room::message::OriginalSyncRoomMessageEvent, room: matrix_sdk::room::Room, client| {
                                     let state = Arc::clone(&state_for_handler);
                                     async move {
-                                        tracing::debug!("📨 Received message in room {}: {:?}", room.room_id(), ev);
+                                        tracing::debug!("Received message in room {}: {:?}", room.room_id(), ev);
                                         crate::utils::bridge::handle_bridge_message(ev, room, client, state).await;
                                     }
                                 });
@@ -611,39 +618,41 @@ async fn monitor_telegram_connection(
                                 sync_tasks.insert(user_id, handle);
 
                                 if let Some(room) = client.get_room(room_id) {
-                                    room.send(RoomMessageEventContent::text_plain("sync contacts"))
-                                        .await?;
-                                    tracing::debug!(
-                                        "Sent contacts sync command for user {}",
-                                        user_id
-                                    );
+                                    if let Err(e) = room
+                                        .send(RoomMessageEventContent::text_plain("sync contacts"))
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "Failed to send contacts sync for user {}: {}",
+                                            user_id,
+                                            e
+                                        );
+                                    }
                                     sleep(Duration::from_millis(500)).await;
-                                    room.send(RoomMessageEventContent::text_plain("sync chats"))
-                                        .await?;
-                                    tracing::debug!("Sent chats sync command for user {}", user_id);
-                                } else {
-                                    tracing::error!("Telegram room not found for sync commands");
+                                    if let Err(e) = room
+                                        .send(RoomMessageEventContent::text_plain("sync chats"))
+                                        .await
+                                    {
+                                        tracing::warn!(
+                                            "Failed to send chats sync for user {}: {}",
+                                            user_id,
+                                            e
+                                        );
+                                    }
                                 }
 
                                 return Ok(());
                             }
 
-                            let error_patterns = [
-                                "error",
-                                "failed",
-                                "timeout",
-                                "disconnected",
-                                "invalid code",
-                                "connection lost",
-                                "authentication failed",
-                                "login failed",
-                            ];
-                            if error_patterns
+                            // Only treat fatal errors as failures - skip transient ones
+                            let fatal_patterns =
+                                ["authentication failed", "login failed", "invalid code"];
+                            if fatal_patterns
                                 .iter()
                                 .any(|&pattern| content.to_lowercase().contains(pattern))
                             {
                                 tracing::error!(
-                                    "❌ Telegram connection failed for user {}: {}",
+                                    "Telegram connection failed for user {}: {}",
                                     user_id,
                                     content
                                 );
@@ -656,7 +665,7 @@ async fn monitor_telegram_connection(
             }
         }
 
-        sleep(Duration::from_secs(5)).await; // Increase to 5 seconds for stability
+        sleep(Duration::from_secs(5)).await;
     }
 
     state.user_repository.delete_bridge(user_id, "telegram")?;

--- a/backend/src/handlers/telegram_auth.rs
+++ b/backend/src/handlers/telegram_auth.rs
@@ -242,7 +242,7 @@ async fn connect_telegram(
                                 }
                             };
 
-                            tracing::info!("Telegram login response: {}", message_body);
+                            tracing::info!("Received Telegram login response from bot");
 
                             // More efficient login url extraction
                             if let Some(url) = extract_login_url(&message_body) {

--- a/backend/src/jobs/scheduler.rs
+++ b/backend/src/jobs/scheduler.rs
@@ -305,7 +305,7 @@ pub async fn start_scheduler(state: Arc<AppState>) {
                 // Check IMAP service
                 if let Ok(imap_users) = state.user_repository.get_active_imap_connection_users() {
                     if imap_users.contains(&user.id) {
-                        match imap_handlers::fetch_emails_imap(&state, user.id, true, Some(10), true, true).await {
+                        match imap_handlers::fetch_emails_imap(&state, user.id, Some(10), true, true).await {
                             Ok(emails) => {
                                 match state.user_repository.get_processed_emails(user.id) {
                                     Ok(mut processed_emails) => {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -238,6 +238,16 @@ pub struct AppState {
     pub system_notify_cooldowns: DashMap<(i32, String), i32>,
     // user_id -> unix timestamp of last digest delivery
     pub digest_cooldowns: DashMap<i32, i32>,
+    // Broadcast channel: signals activity feed subscribers that new data is available for a user_id
+    pub activity_feed_tx: tokio::sync::broadcast::Sender<i32>,
+}
+
+impl AppState {
+    /// Signal that the activity feed has new data for a user.
+    /// Subscribers (SSE connections) will notify the frontend to re-fetch.
+    pub fn notify_activity_feed(&self, user_id: i32) {
+        let _ = self.activity_feed_tx.send(user_id);
+    }
 }
 
 /// Build the tool registry with all static tool handlers.

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1072,6 +1072,7 @@ async fn main() {
         )
         .route("/api/auth/imap/login", post(imap_auth::imap_login))
         .route("/api/auth/imap/status", get(imap_auth::imap_status))
+        .route("/api/auth/imap/detect", post(imap_auth::detect_provider))
         .route(
             "/api/auth/imap/disconnect",
             delete(imap_auth::delete_imap_connection),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -493,6 +493,7 @@ async fn main() {
         maintenance_mode: Arc::new(AtomicBool::new(false)),
         system_notify_cooldowns: DashMap::new(),
         digest_cooldowns: DashMap::new(),
+        activity_feed_tx: tokio::sync::broadcast::channel(64).0,
     });
     // SMS server route - validates signature using user lookup
     let twilio_sms_routes = Router::new()
@@ -1204,6 +1205,10 @@ async fn main() {
         .route(
             "/api/dashboard/activity-feed",
             get(dashboard_handlers::get_activity_feed),
+        )
+        .route(
+            "/api/dashboard/activity-feed/stream",
+            get(dashboard_handlers::activity_feed_stream),
         )
         .route(
             "/api/dashboard/senders",

--- a/backend/src/pg_models.rs
+++ b/backend/src/pg_models.rs
@@ -401,6 +401,7 @@ pub struct PgProcessedEmail {
     pub user_id: i32,
     pub email_uid: String,
     pub processed_at: i32,
+    pub imap_connection_id: Option<i32>,
 }
 
 #[derive(Insertable)]
@@ -409,6 +410,7 @@ pub struct NewPgProcessedEmail {
     pub user_id: i32,
     pub email_uid: String,
     pub processed_at: i32,
+    pub imap_connection_id: Option<i32>,
 }
 
 // -- refund_info --

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -207,6 +207,7 @@ diesel::table! {
         user_id -> Int4,
         email_uid -> Text,
         processed_at -> Int4,
+        imap_connection_id -> Nullable<Int4>,
     }
 }
 

--- a/backend/src/proactive/rules.rs
+++ b/backend/src/proactive/rules.rs
@@ -1222,6 +1222,9 @@ pub async fn emit_ontology_change(
     change_type: &str,
     entity_snapshot: serde_json::Value,
 ) {
+    // Notify activity feed SSE subscribers
+    state.notify_activity_feed(user_id);
+
     // Skip completed messages early (before evaluating any rules)
     if entity_type == "Message" {
         if let Some(status) = entity_snapshot.get("status").and_then(|v| v.as_str()) {

--- a/backend/src/proactive/utils.rs
+++ b/backend/src/proactive/utils.rs
@@ -310,4 +310,7 @@ pub async fn send_notification_with_context(
             }
         }
     }
+
+    // Notify activity feed SSE subscribers after any notification attempt
+    state.notify_activity_feed(user_id);
 }

--- a/backend/src/repositories/ontology_repository.rs
+++ b/backend/src/repositories/ontology_repository.rs
@@ -113,7 +113,7 @@ fn compute_response_deltas(messages: &[OntMessage]) -> Vec<f64> {
 
     let mut deltas = Vec::new();
 
-    for (_room, room_msgs) in &by_room {
+    for room_msgs in by_room.values() {
         let received: Vec<&&OntMessage> = room_msgs
             .iter()
             .filter(|m| m.sender_name != "You")
@@ -1184,6 +1184,7 @@ impl OntologyRepository {
         }
     }
 
+    #[allow(clippy::too_many_arguments)]
     pub fn compute_sender_signals(
         &self,
         user_id: i32,

--- a/backend/src/repositories/user_repository.rs
+++ b/backend/src/repositories/user_repository.rs
@@ -19,6 +19,16 @@ use crate::{
 /// Type alias for IMAP credentials: (description, password, server, port)
 pub type ImapCredentials = (String, String, Option<String>, Option<i32>);
 
+/// Structured IMAP connection info (replaces raw tuples for multi-email support)
+#[derive(Debug, Clone)]
+pub struct ImapConnectionInfo {
+    pub id: i32,
+    pub email: String,
+    pub password: String,
+    pub imap_server: Option<String>,
+    pub imap_port: Option<i32>,
+}
+
 /// Parameters for logging usage
 pub struct LogUsageParams {
     pub user_id: i32,
@@ -199,30 +209,51 @@ impl UserRepository {
             .unwrap()
             .as_secs() as i32;
 
-        // First, delete any existing connections for this user
-        diesel::delete(imap_connection::table)
+        // Check if this email already exists for this user
+        let existing = imap_connection::table
             .filter(imap_connection::user_id.eq(user_id))
-            .execute(&mut conn)?;
+            .filter(imap_connection::description.eq(email))
+            .first::<crate::pg_models::PgImapConnection>(&mut conn)
+            .optional()?;
 
-        // Create new connection
-        let new_connection = NewPgImapConnection {
-            user_id,
-            method: imap_server
-                .map(|s| s.to_string())
-                .unwrap_or("gmail".to_string()),
-            encrypted_password,
-            status: "active".to_string(),
-            last_update: current_time,
-            created_on: current_time,
-            description: email.to_string(),
-            imap_server: imap_server.map(|s| s.to_string()),
-            imap_port: imap_port.map(|p| p as i32),
-        };
-
-        // Insert the new connection
-        diesel::insert_into(imap_connection::table)
-            .values(&new_connection)
+        if existing.is_some() {
+            // Update existing connection
+            diesel::update(
+                imap_connection::table
+                    .filter(imap_connection::user_id.eq(user_id))
+                    .filter(imap_connection::description.eq(email)),
+            )
+            .set((
+                imap_connection::encrypted_password.eq(&encrypted_password),
+                imap_connection::status.eq("active"),
+                imap_connection::last_update.eq(current_time),
+                imap_connection::imap_server.eq(imap_server),
+                imap_connection::imap_port.eq(imap_port.map(|p| p as i32)),
+                imap_connection::method.eq(imap_server
+                    .map(|s| s.to_string())
+                    .unwrap_or("gmail".to_string())),
+            ))
             .execute(&mut conn)?;
+        } else {
+            // Insert new connection
+            let new_connection = NewPgImapConnection {
+                user_id,
+                method: imap_server
+                    .map(|s| s.to_string())
+                    .unwrap_or("gmail".to_string()),
+                encrypted_password,
+                status: "active".to_string(),
+                last_update: current_time,
+                created_on: current_time,
+                description: email.to_string(),
+                imap_server: imap_server.map(|s| s.to_string()),
+                imap_port: imap_port.map(|p| p as i32),
+            };
+
+            diesel::insert_into(imap_connection::table)
+                .values(&new_connection)
+                .execute(&mut conn)?;
+        }
 
         Ok(())
     }
@@ -257,12 +288,95 @@ impl UserRepository {
         }
     }
 
+    /// Get all active IMAP connections for a user
+    pub fn get_all_imap_credentials(
+        &self,
+        user_id: i32,
+    ) -> Result<Vec<ImapConnectionInfo>, diesel::result::Error> {
+        use crate::pg_schema::imap_connection;
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+
+        let connections = imap_connection::table
+            .filter(imap_connection::user_id.eq(user_id))
+            .filter(imap_connection::status.eq("active"))
+            .load::<crate::pg_models::PgImapConnection>(&mut conn)?;
+
+        let mut result = Vec::new();
+        for c in connections {
+            match decrypt(&c.encrypted_password) {
+                Ok(password) => result.push(ImapConnectionInfo {
+                    id: c.id,
+                    email: c.description,
+                    password,
+                    imap_server: c.imap_server,
+                    imap_port: c.imap_port,
+                }),
+                Err(_) => {
+                    tracing::error!("Failed to decrypt password for imap_connection id={}", c.id);
+                }
+            }
+        }
+        Ok(result)
+    }
+
+    /// Get IMAP credentials for a specific email address
+    pub fn get_imap_credentials_by_email(
+        &self,
+        user_id: i32,
+        email: &str,
+    ) -> Result<Option<ImapConnectionInfo>, diesel::result::Error> {
+        use crate::pg_schema::imap_connection;
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+
+        let imap_conn = imap_connection::table
+            .filter(imap_connection::user_id.eq(user_id))
+            .filter(imap_connection::description.eq(email))
+            .filter(imap_connection::status.eq("active"))
+            .first::<crate::pg_models::PgImapConnection>(&mut conn)
+            .optional()?;
+
+        if let Some(c) = imap_conn {
+            match decrypt(&c.encrypted_password) {
+                Ok(password) => Ok(Some(ImapConnectionInfo {
+                    id: c.id,
+                    email: c.description,
+                    password,
+                    imap_server: c.imap_server,
+                    imap_port: c.imap_port,
+                })),
+                Err(_) => Err(diesel::result::Error::RollbackTransaction),
+            }
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Delete all IMAP connections for a user
     pub fn delete_imap_credentials(&self, user_id: i32) -> Result<(), diesel::result::Error> {
         use crate::pg_schema::imap_connection;
         let connection = &mut self.pool.get().unwrap();
 
         diesel::delete(imap_connection::table.filter(imap_connection::user_id.eq(user_id)))
             .execute(connection)?;
+
+        Ok(())
+    }
+
+    /// Delete a specific IMAP connection by email address
+    pub fn delete_imap_connection_by_email(
+        &self,
+        user_id: i32,
+        email: &str,
+    ) -> Result<(), diesel::result::Error> {
+        use crate::pg_schema::imap_connection;
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+
+        diesel::delete(
+            imap_connection::table
+                .filter(imap_connection::user_id.eq(user_id))
+                .filter(imap_connection::description.eq(email)),
+        )
+        .execute(&mut conn)?;
 
         Ok(())
     }
@@ -670,6 +784,7 @@ impl UserRepository {
         let user_ids = imap_connection::table
             .filter(imap_connection::status.eq("active"))
             .select(imap_connection::user_id)
+            .distinct()
             .load::<i32>(&mut conn)?;
 
         Ok(user_ids)
@@ -1428,12 +1543,13 @@ impl UserRepository {
         &self,
         user_id: i32,
         email_uid: &str,
+        imap_connection_id: Option<i32>,
     ) -> Result<(), DieselError> {
         use crate::pg_schema::processed_emails;
         let mut conn = self.pool.get().expect("Failed to get DB connection");
 
         // First check if the email is already processed
-        let already_processed = self.is_email_processed(user_id, email_uid)?;
+        let already_processed = self.is_email_processed(user_id, email_uid, imap_connection_id)?;
         if already_processed {
             tracing::debug!(
                 "Email {} for user {} is already marked as processed",
@@ -1452,6 +1568,7 @@ impl UserRepository {
             user_id,
             email_uid: email_uid.to_string(),
             processed_at: current_time,
+            imap_connection_id,
         };
 
         match diesel::insert_into(processed_emails::table)
@@ -1479,13 +1596,25 @@ impl UserRepository {
     }
 
     // Check if an email is processed
-    pub fn is_email_processed(&self, user_id: i32, email_uid: &str) -> Result<bool, DieselError> {
+    pub fn is_email_processed(
+        &self,
+        user_id: i32,
+        email_uid: &str,
+        imap_connection_id: Option<i32>,
+    ) -> Result<bool, DieselError> {
         use crate::pg_schema::processed_emails;
         let mut conn = self.pool.get().expect("Failed to get DB connection");
 
-        let processed = processed_emails::table
+        let mut query = processed_emails::table
             .filter(processed_emails::user_id.eq(user_id))
             .filter(processed_emails::email_uid.eq(email_uid))
+            .into_boxed();
+
+        if let Some(conn_id) = imap_connection_id {
+            query = query.filter(processed_emails::imap_connection_id.eq(conn_id));
+        }
+
+        let processed = query
             .first::<crate::pg_models::PgProcessedEmail>(&mut conn)
             .optional()?;
 

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -162,6 +162,7 @@ pub fn create_test_state() -> Arc<crate::AppState> {
         maintenance_mode: Arc::new(std::sync::atomic::AtomicBool::new(false)),
         system_notify_cooldowns: dashmap::DashMap::new(),
         digest_cooldowns: dashmap::DashMap::new(),
+        activity_feed_tx: tokio::sync::broadcast::channel(64).0,
     })
 }
 

--- a/backend/src/tool_call_utils/email.rs
+++ b/backend/src/tool_call_utils/email.rs
@@ -2,6 +2,10 @@ use crate::AppState;
 use std::sync::Arc;
 
 pub fn get_send_email_tool() -> openai_api_rs::v1::chat_completion::Tool {
+    get_send_email_tool_for_user(&[])
+}
+
+pub fn get_send_email_tool_for_user(emails: &[String]) -> openai_api_rs::v1::chat_completion::Tool {
     use openai_api_rs::v1::{chat_completion, types};
     use std::collections::HashMap;
     let mut properties = HashMap::new();
@@ -29,6 +33,21 @@ pub fn get_send_email_tool() -> openai_api_rs::v1::chat_completion::Tool {
             ..Default::default()
         }),
     );
+    if !emails.is_empty() {
+        let desc = format!(
+            "The sender email address to use. Connected accounts: {}",
+            emails.join(", ")
+        );
+        properties.insert(
+            "from".to_string(),
+            Box::new(types::JSONSchemaDefine {
+                schema_type: Some(types::JSONSchemaType::String),
+                description: Some(desc),
+                enum_values: Some(emails.to_vec()),
+                ..Default::default()
+            }),
+        );
+    }
     chat_completion::Tool {
         r#type: chat_completion::ToolType::Function,
         function: types::Function {
@@ -50,6 +69,12 @@ pub fn get_send_email_tool() -> openai_api_rs::v1::chat_completion::Tool {
 }
 
 pub fn get_respond_to_email_tool() -> openai_api_rs::v1::chat_completion::Tool {
+    get_respond_to_email_tool_for_user(&[])
+}
+
+pub fn get_respond_to_email_tool_for_user(
+    emails: &[String],
+) -> openai_api_rs::v1::chat_completion::Tool {
     use openai_api_rs::v1::{chat_completion, types};
     use std::collections::HashMap;
     let mut properties = HashMap::new();
@@ -69,6 +94,21 @@ pub fn get_respond_to_email_tool() -> openai_api_rs::v1::chat_completion::Tool {
             ..Default::default()
         }),
     );
+    if !emails.is_empty() {
+        let desc = format!(
+            "The sender email address to use for the reply. Connected accounts: {}",
+            emails.join(", ")
+        );
+        properties.insert(
+            "from".to_string(),
+            Box::new(types::JSONSchemaDefine {
+                schema_type: Some(types::JSONSchemaType::String),
+                description: Some(desc),
+                enum_values: Some(emails.to_vec()),
+                ..Default::default()
+            }),
+        );
+    }
     chat_completion::Tool {
         r#type: chat_completion::ToolType::Function,
         function: types::Function {
@@ -83,13 +123,49 @@ pub fn get_respond_to_email_tool() -> openai_api_rs::v1::chat_completion::Tool {
     }
 }
 
+use crate::repositories::user_repository::ImapConnectionInfo;
 use serde::Deserialize;
+
+/// Resolve which email account to use based on the `from` parameter.
+/// - If `from` is specified, look up that specific account.
+/// - If only one account exists, use it.
+/// - If multiple accounts exist and `from` is not specified, return an error message.
+fn resolve_email_account(
+    state: &Arc<AppState>,
+    user_id: i32,
+    from: &Option<String>,
+) -> Result<ImapConnectionInfo, String> {
+    if let Some(from_email) = from {
+        state
+            .user_repository
+            .get_imap_credentials_by_email(user_id, from_email)
+            .map_err(|e| format!("Failed to look up email account: {}", e))?
+            .ok_or_else(|| format!("No connected email account found for '{}'", from_email))
+    } else {
+        let accounts = state
+            .user_repository
+            .get_all_imap_credentials(user_id)
+            .map_err(|e| format!("Failed to fetch email accounts: {}", e))?;
+        match accounts.len() {
+            0 => Err("No email account connected.".to_string()),
+            1 => Ok(accounts.into_iter().next().unwrap()),
+            _ => {
+                let emails: Vec<String> = accounts.iter().map(|a| a.email.clone()).collect();
+                Err(format!(
+                    "Multiple email accounts connected ({}). Please specify which one to use.",
+                    emails.join(", ")
+                ))
+            }
+        }
+    }
+}
 
 #[derive(Deserialize, Debug)]
 pub struct SendEmailArgs {
     pub to: String,
     pub subject: String,
     pub body: String,
+    pub from: Option<String>,
 }
 pub async fn handle_send_email(
     state: &Arc<AppState>,
@@ -106,6 +182,22 @@ pub async fn handle_send_email(
     Box<dyn std::error::Error>,
 > {
     let args: SendEmailArgs = serde_json::from_str(args)?;
+
+    // Resolve which email account to send from
+    let sender_account = match resolve_email_account(state, user_id, &args.from) {
+        Ok(account) => account,
+        Err(msg) => {
+            return Ok((
+                axum::http::StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                axum::Json(crate::api::twilio_sms::TwilioResponse {
+                    message: msg,
+                    created_item_id: None,
+                }),
+            ));
+        }
+    };
+    let from_email = sender_account.email.clone();
 
     // Check if 'to' is a contact name and resolve to email address
     let recipient_email = if args.to.contains('@') {
@@ -184,6 +276,7 @@ pub async fn handle_send_email(
     let cloned_to = recipient_email.clone();
     let cloned_subject = args.subject.clone();
     let cloned_body = args.body.clone();
+    let cloned_from = Some(from_email);
     let cloned_skip_sms = skip_sms;
     tokio::spawn(async move {
         let reason = tokio::select! {
@@ -195,6 +288,7 @@ pub async fn handle_send_email(
                 to: cloned_to,
                 subject: cloned_subject,
                 body: cloned_body,
+                from: cloned_from,
             };
             match crate::handlers::imap_handlers::send_email(
                 axum::extract::State(cloned_state.clone()),
@@ -256,6 +350,7 @@ use axum::extract::{Json, State};
 pub struct RespondToEmailArgs {
     pub email_id: String,
     pub response_text: String,
+    pub from: Option<String>,
 }
 pub async fn handle_respond_to_email(
     state: &Arc<AppState>,
@@ -272,6 +367,23 @@ pub async fn handle_respond_to_email(
     Box<dyn std::error::Error>,
 > {
     let args: RespondToEmailArgs = serde_json::from_str(args)?;
+
+    // Resolve which email account to send from
+    let sender_account = match resolve_email_account(state, user_id, &args.from) {
+        Ok(account) => account,
+        Err(msg) => {
+            return Ok((
+                axum::http::StatusCode::OK,
+                [(axum::http::header::CONTENT_TYPE, "application/json")],
+                axum::Json(crate::api::twilio_sms::TwilioResponse {
+                    message: msg,
+                    created_item_id: None,
+                }),
+            ));
+        }
+    };
+    let from_email = sender_account.email.clone();
+
     // Fetch the email details to get the subject
     let email_details = match crate::handlers::imap_handlers::fetch_single_imap_email(
         State(state.clone()),
@@ -355,6 +467,7 @@ pub async fn handle_respond_to_email(
     let cloned_user = user.clone();
     let cloned_email_id = args.email_id.clone();
     let cloned_response_text = args.response_text.clone();
+    let cloned_from = Some(from_email);
     let cloned_skip_sms = skip_sms;
     tokio::spawn(async move {
         let reason = tokio::select! {
@@ -365,6 +478,7 @@ pub async fn handle_respond_to_email(
             let request = crate::handlers::imap_handlers::EmailResponseRequest {
                 email_id: cloned_email_id,
                 response_text: cloned_response_text,
+                from: cloned_from,
             };
             match crate::handlers::imap_handlers::respond_to_email(
                 State(cloned_state.clone()),

--- a/backend/src/tools/email.rs
+++ b/backend/src/tools/email.rs
@@ -5,6 +5,7 @@ use crate::api::twilio_sms::TwilioResponse;
 use crate::tools::registry::{
     write_outgoing_error_history, write_outgoing_history, ToolContext, ToolHandler, ToolResult,
 };
+use crate::AppState;
 
 // ─── send_email (outgoing) ───────────────────────────────────────────────────
 
@@ -18,6 +19,17 @@ impl ToolHandler for SendEmailHandler {
 
     fn definition(&self) -> chat_completion::Tool {
         crate::tool_call_utils::email::get_send_email_tool()
+    }
+
+    fn definition_for_user(&self, state: &AppState, user_id: i32) -> chat_completion::Tool {
+        let emails: Vec<String> = state
+            .user_repository
+            .get_all_imap_credentials(user_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|c| c.email)
+            .collect();
+        crate::tool_call_utils::email::get_send_email_tool_for_user(&emails)
     }
 
     fn is_outgoing(&self) -> bool {
@@ -87,6 +99,17 @@ impl ToolHandler for RespondEmailHandler {
 
     fn definition(&self) -> chat_completion::Tool {
         crate::tool_call_utils::email::get_respond_to_email_tool()
+    }
+
+    fn definition_for_user(&self, state: &AppState, user_id: i32) -> chat_completion::Tool {
+        let emails: Vec<String> = state
+            .user_repository
+            .get_all_imap_credentials(user_id)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|c| c.email)
+            .collect();
+        crate::tool_call_utils::email::get_respond_to_email_tool_for_user(&emails)
     }
 
     fn auto_injected_params(&self) -> Vec<&'static str> {

--- a/backend/src/tools/registry.rs
+++ b/backend/src/tools/registry.rs
@@ -53,6 +53,13 @@ pub trait ToolHandler: Send + Sync {
     /// OpenAI-format tool definition
     fn definition(&self) -> chat_completion::Tool;
 
+    /// User-aware tool definition. Override for tools that need to inject
+    /// per-user data (e.g. email tools listing connected accounts).
+    /// Default falls back to the static definition().
+    fn definition_for_user(&self, _state: &AppState, _user_id: i32) -> chat_completion::Tool {
+        self.definition()
+    }
+
     /// Whether this tool sends data externally (requires user confirmation)
     fn is_outgoing(&self) -> bool {
         false
@@ -99,6 +106,17 @@ impl ToolRegistry {
 
     pub fn definitions(&self) -> Vec<chat_completion::Tool> {
         self.handlers.values().map(|h| h.definition()).collect()
+    }
+
+    pub fn definitions_for_user(
+        &self,
+        state: &AppState,
+        user_id: i32,
+    ) -> Vec<chat_completion::Tool> {
+        self.handlers
+            .values()
+            .map(|h| h.definition_for_user(state, user_id))
+            .collect()
     }
 
     pub fn get(&self, name: &str) -> Option<&Arc<dyn ToolHandler>> {

--- a/backend/src/utils/bridge.rs
+++ b/backend/src/utils/bridge.rs
@@ -1778,9 +1778,9 @@ pub async fn search_bridge_rooms(
 
     let mut results: Vec<BridgeRoom> = matching_rooms.into_iter().map(|(_, room)| room).collect();
 
-    // Search Synapse Admin API for bridge ghost users (contacts without rooms).
-    // The user directory API excludes appservice users by design, so we use the
-    // admin API which searches the users table directly.
+    // Search Matrix user directory for bridge ghost users (contacts without rooms).
+    // Uses the standard Matrix user directory search API which, unlike Synapse,
+    // may include appservice-managed users on Tuwunel/Conduit-based homeservers.
     if search_term.trim().len() >= 2 {
         let homeserver_url = std::env::var("MATRIX_HOMESERVER").unwrap_or_default();
         let access_token = client
@@ -1790,15 +1790,18 @@ pub async fn search_bridge_rooms(
             .unwrap_or_default();
 
         if !homeserver_url.is_empty() && !access_token.is_empty() {
-            let admin_url = format!(
-                "{}/_synapse/admin/v2/users?from=0&limit=50&name={}",
-                homeserver_url.trim_end_matches('/'),
-                urlencoding::encode(search_term.trim())
+            let search_url = format!(
+                "{}/_matrix/client/v3/user_directory/search",
+                homeserver_url.trim_end_matches('/')
             );
             let http_client = reqwest::Client::new();
             match http_client
-                .get(&admin_url)
+                .post(&search_url)
                 .header("Authorization", format!("Bearer {}", access_token))
+                .json(&serde_json::json!({
+                    "search_term": search_term.trim(),
+                    "limit": 50
+                }))
                 .send()
                 .await
             {
@@ -1813,16 +1816,16 @@ pub async fn search_bridge_rooms(
                             .map(|r| remove_bridge_suffix(&r.display_name).to_lowercase())
                             .collect();
 
-                        if let Some(users) = body["users"].as_array() {
+                        if let Some(users) = body["results"].as_array() {
                             tracing::info!(
-                                "Admin API returned {} users for '{}'",
+                                "User directory returned {} users for '{}'",
                                 users.len(),
                                 search_term
                             );
                             for user in users {
-                                let name = user["name"].as_str().unwrap_or_default();
+                                let user_id = user["user_id"].as_str().unwrap_or_default();
                                 // Extract localpart from @localpart:server
-                                let localpart = name
+                                let localpart = user_id
                                     .trim_start_matches('@')
                                     .split(':')
                                     .next()
@@ -1835,7 +1838,7 @@ pub async fn search_bridge_rooms(
                                     continue;
                                 }
 
-                                let raw_display = user["displayname"].as_str().unwrap_or_default();
+                                let raw_display = user["display_name"].as_str().unwrap_or_default();
                                 let display_name = if !raw_display.is_empty() {
                                     remove_bridge_suffix(raw_display)
                                 } else {
@@ -1871,17 +1874,17 @@ pub async fn search_bridge_rooms(
                             }
                         }
                         tracing::info!(
-                            "Total results after admin search: {} for {}",
+                            "Total results after directory search: {} for {}",
                             results.len(),
                             capitalize(service)
                         );
                     }
                 }
                 Ok(resp) => {
-                    tracing::warn!("Admin API returned status {}", resp.status());
+                    tracing::warn!("User directory search returned status {}", resp.status());
                 }
                 Err(e) => {
-                    tracing::warn!("Admin API search failed: {:?}", e);
+                    tracing::warn!("User directory search failed: {:?}", e);
                 }
             }
         }

--- a/backend/src/utils/notification_utils.rs
+++ b/backend/src/utils/notification_utils.rs
@@ -336,6 +336,7 @@ pub async fn send_tinfoil_renewal_notification(
         to: "rasmus@ahtava.com".to_string(),
         subject: format!("Tinfoil Key Renewal - User {}", user_id),
         body: body.replace("\n", "\r\n"), // CRLF for email
+        from: None,
     };
 
     // Create a fake auth user for sending (admin context)
@@ -485,6 +486,7 @@ pub async fn send_admin_alert(
         to: admin_email.clone(),
         subject: subject.to_string(),
         body: enhanced_message,
+        from: None,
     };
 
     // Create admin auth context

--- a/enclave/Dockerfile
+++ b/enclave/Dockerfile
@@ -111,6 +111,18 @@ RUN cargo build --release --target-dir /src/oyster/target --manifest-path initia
     cargo build --release --target-dir /src/oyster/target --manifest-path kms/derive-server/Cargo.toml && \
     ls -la /src/oyster/target/release/keygen-x25519 /src/oyster/target/release/oyster-attestation-server-custom /src/oyster/target/release/kms-derive-server
 
+# ── Stage 2c: Build Tesla HTTP proxy (Go) ─────────────────────────────────────
+
+FROM golang:1.23-bookworm AS tesla-proxy-builder
+
+ARG VEHICLE_COMMAND_COMMIT=main
+
+RUN apt-get update && apt-get install -y git && rm -rf /var/lib/apt/lists/*
+RUN git clone https://github.com/teslamotors/vehicle-command.git /src/vehicle-command && \
+    cd /src/vehicle-command && git checkout "${VEHICLE_COMMAND_COMMIT}"
+WORKDIR /src/vehicle-command/cmd/tesla-http-proxy
+RUN CGO_ENABLED=0 go build -o /tesla-http-proxy
+
 # ── Stage 3: Collect bridge binaries from official images ───────────────────
 
 FROM jevolk/tuwunel:latest AS tuwunel-src
@@ -180,6 +192,9 @@ RUN mkdir -p /opt/mautrix-telegram && \
     /opt/mautrix-telegram-venv/bin/pip install --upgrade pip && \
     /opt/mautrix-telegram-venv/bin/pip install "mautrix-telegram[all]==${MAUTRIX_TELEGRAM_VERSION}"
 
+# ── Copy Tesla HTTP proxy binary ────────────────────────────────────────────
+COPY --from=tesla-proxy-builder /tesla-http-proxy /usr/local/bin/tesla-http-proxy
+
 # ── Copy Lightfriend backend ──────────────────────────────────────────────
 WORKDIR /app
 COPY --from=builder /backend ./backend
@@ -212,6 +227,7 @@ RUN mkdir -p \
     /data/bridges/signal \
     /data/bridges/telegram \
     /data/seed \
+    /etc/tesla-proxy-tls \
     /var/lib/tuwunel \
     /var/lib/tuwunel-backup \
     /etc/tuwunel \

--- a/enclave/configs/telegram.yaml.template
+++ b/enclave/configs/telegram.yaml.template
@@ -44,9 +44,9 @@ telegram:
         use_ipv6: false
 
     device_info:
-        device_model: lightfriend
-        system_version: auto
-        app_version: auto
+        device_model: Samsung Galaxy S24
+        system_version: SDK 34
+        app_version: 11.4.2
         lang_code: en
         system_lang_code: en
 
@@ -54,9 +54,9 @@ telegram:
         enabled: false
 
     proxy:
-        type: ${TELEGRAM_PROXY_TYPE:-socks5}
-        address: ${TELEGRAM_PROXY_ADDRESS:-gw.dataimpulse.com}
-        port: ${TELEGRAM_PROXY_PORT:-10000}
+        type: ${TELEGRAM_PROXY_TYPE:-disabled}
+        address: ${TELEGRAM_PROXY_ADDRESS:-}
+        port: ${TELEGRAM_PROXY_PORT:-}
         rdns: true
         username: ${TELEGRAM_PROXY_USERNAME:-}
         password: ${TELEGRAM_PROXY_PASSWORD:-}

--- a/enclave/configs/telegram.yaml.template
+++ b/enclave/configs/telegram.yaml.template
@@ -44,9 +44,9 @@ telegram:
         use_ipv6: false
 
     device_info:
-        device_model: Samsung Galaxy S24
-        system_version: SDK 34
-        app_version: 11.4.2
+        device_model: Lightfriend
+        system_version: auto
+        app_version: auto
         lang_code: en
         system_lang_code: en
 
@@ -54,7 +54,7 @@ telegram:
         enabled: false
 
     proxy:
-        type: ${TELEGRAM_PROXY_TYPE:-disabled}
+        type: ${TELEGRAM_PROXY_TYPE:-socks5}
         address: ${TELEGRAM_PROXY_ADDRESS:-}
         port: ${TELEGRAM_PROXY_PORT:-}
         rdns: true

--- a/enclave/entrypoint.sh
+++ b/enclave/entrypoint.sh
@@ -114,6 +114,36 @@ export TELEGRAM_BRIDGE_BOT="${TELEGRAM_BRIDGE_BOT:-@telegrambot:localhost}"
 export PORT="${PORT:-3100}"
 export SKIP_BACKEND="${SKIP_BACKEND:-false}"
 export RESTORE_MODE="${RESTORE_MODE:-none}"
+export TESLA_HTTP_PROXY_URL="${TESLA_HTTP_PROXY_URL:-https://localhost:4443}"
+
+# ── 0b2. Fetch Tesla private key from host seed server ──────────────────────
+# The key is served by the host's HTTP seed server (port 9080) after being
+# downloaded from S3. Without it, the Tesla proxy (and vehicle commands) won't work.
+if [ ! -f /app/tesla_private_key.pem ]; then
+    echo "Fetching Tesla private key from host seed server..."
+    if curl -sf --max-time 10 http://127.0.0.1:9080/tesla_private_key.pem -o /app/tesla_private_key.pem 2>/dev/null; then
+        chmod 600 /app/tesla_private_key.pem
+        echo "  Tesla private key fetched successfully"
+    else
+        echo "  Tesla private key not available (Tesla integration will be disabled)"
+        rm -f /app/tesla_private_key.pem
+    fi
+fi
+
+# ── 0b3. Generate Tesla proxy TLS certs (self-signed, localhost only) ────────
+if [ ! -f /etc/tesla-proxy-tls/cert.pem ]; then
+    echo "Generating Tesla proxy TLS certificates..."
+    openssl req -x509 -nodes -newkey ec \
+        -pkeyopt ec_paramgen_curve:secp521r1 \
+        -pkeyopt ec_param_enc:named_curve \
+        -subj '/CN=localhost' \
+        -keyout /etc/tesla-proxy-tls/key.pem \
+        -out /etc/tesla-proxy-tls/cert.pem \
+        -sha256 -days 3650 \
+        -addext 'extendedKeyUsage = serverAuth' \
+        -addext 'keyUsage = digitalSignature, keyCertSign, keyAgreement' \
+        2>/dev/null && echo "  Tesla proxy TLS certs generated" || echo "  WARNING: failed to generate Tesla proxy TLS certs"
+fi
 
 # ── 0c. Start VSOCK outbound proxy bridge ────────────────────────────────────
 echo ""

--- a/enclave/entrypoint.sh
+++ b/enclave/entrypoint.sh
@@ -853,7 +853,7 @@ if shared_secret:
         text = re.sub(login_secret_pattern, login_secret_block, text, count=1)
 
 # Patch proxy fields from current .env (config may have stale values from backup)
-proxy_type = os.environ.get("TELEGRAM_PROXY_TYPE", "disabled")
+proxy_type = os.environ.get("TELEGRAM_PROXY_TYPE", "socks5")
 proxy_fields = {
     "type": proxy_type,
     "address": os.environ.get("TELEGRAM_PROXY_ADDRESS", ""),
@@ -873,11 +873,6 @@ if proxy_fields["address"] and proxy_fields["port"] and proxy_type != "disabled"
     print(f"  Patched proxy: {proxy_type} {proxy_fields['address']}:{proxy_fields['port']}", flush=True)
 else:
     print(f"  Proxy: {proxy_type} (direct connection via tap0)", flush=True)
-
-# Patch device_info to look like a real device (reduces Telegram detection)
-text = re.sub(r"(?m)^(        device_model:).*$", r"\1 Samsung Galaxy S24", text, count=1)
-text = re.sub(r"(?m)^(        system_version:).*$", r"\1 SDK 34", text, count=1)
-text = re.sub(r"(?m)^(        app_version:).*$", r"\1 11.4.2", text, count=1)
 
 path.write_text(text)
 PY

--- a/enclave/entrypoint.sh
+++ b/enclave/entrypoint.sh
@@ -853,19 +853,31 @@ if shared_secret:
         text = re.sub(login_secret_pattern, login_secret_block, text, count=1)
 
 # Patch proxy fields from current .env (config may have stale values from backup)
+proxy_type = os.environ.get("TELEGRAM_PROXY_TYPE", "disabled")
 proxy_fields = {
-    "type": os.environ.get("TELEGRAM_PROXY_TYPE", "socks5"),
+    "type": proxy_type,
     "address": os.environ.get("TELEGRAM_PROXY_ADDRESS", ""),
     "port": os.environ.get("TELEGRAM_PROXY_PORT", ""),
     "username": os.environ.get("TELEGRAM_PROXY_USERNAME", ""),
     "password": os.environ.get("TELEGRAM_PROXY_PASSWORD", ""),
 }
-if proxy_fields["address"] and proxy_fields["port"]:
+# Always patch proxy type (to allow disabling proxy on existing configs)
+text = re.sub(r"(?m)^(        type:).*$", rf"\1 {proxy_type}", text, count=1)
+if proxy_fields["address"] and proxy_fields["port"] and proxy_type != "disabled":
     for field, value in proxy_fields.items():
+        if field == "type":
+            continue
         pattern = rf"(?m)^(        {field}:).*$"
         replacement = rf"\1 {value}"
         text = re.sub(pattern, replacement, text, count=1)
-    print(f"  Patched proxy: {proxy_fields['address']}:{proxy_fields['port']}", flush=True)
+    print(f"  Patched proxy: {proxy_type} {proxy_fields['address']}:{proxy_fields['port']}", flush=True)
+else:
+    print(f"  Proxy: {proxy_type} (direct connection via tap0)", flush=True)
+
+# Patch device_info to look like a real device (reduces Telegram detection)
+text = re.sub(r"(?m)^(        device_model:).*$", r"\1 Samsung Galaxy S24", text, count=1)
+text = re.sub(r"(?m)^(        system_version:).*$", r"\1 SDK 34", text, count=1)
+text = re.sub(r"(?m)^(        app_version:).*$", r"\1 11.4.2", text, count=1)
 
 path.write_text(text)
 PY

--- a/enclave/supervisord.conf
+++ b/enclave/supervisord.conf
@@ -80,6 +80,19 @@ priority=40
 stdout_logfile=/var/log/supervisor/lightfriend.log
 stderr_logfile=/var/log/supervisor/lightfriend-err.log
 
+# ── Tesla HTTP Proxy (vehicle command signing) ────────────────────────────
+# Waits for the backend to generate the Tesla private key, then starts the
+# proxy that signs vehicle commands. Listens on localhost:4443 with self-signed TLS.
+[program:tesla-http-proxy]
+command=/bin/sh -c 'echo "Waiting for Tesla private key..."; for i in $(seq 1 120); do if [ -f /app/tesla_private_key.pem ]; then echo "Tesla key found after ${i}s, starting proxy"; exec /usr/local/bin/tesla-http-proxy -tls-key /etc/tesla-proxy-tls/key.pem -cert /etc/tesla-proxy-tls/cert.pem -key-file /app/tesla_private_key.pem -port 4443 -host 0.0.0.0 -timeout 90s -verbose; fi; sleep 1; done; echo "Tesla private key not found after 120s, proxy disabled"; exit 0'
+autostart=true
+autorestart=true
+startsecs=0
+startretries=999
+priority=45
+stdout_logfile=/var/log/supervisor/tesla-proxy.log
+stderr_logfile=/var/log/supervisor/tesla-proxy-err.log
+
 # ── VSOCK bridges for host HTTP services ─────────────────────────────────
 # These MUST be supervisord-managed because background processes from the
 # entrypoint die when exec supervisord replaces the shell.

--- a/frontend/src/connections/email.rs
+++ b/frontend/src/connections/email.rs
@@ -13,68 +13,55 @@ pub struct EmailProps {
 pub fn email_connect(props: &EmailProps) -> Html {
     let error = use_state(|| None::<String>);
     let success_message = use_state(|| None::<String>);
-    let imap_connected = use_state(|| false);
+    let connected_accounts = use_state(|| Vec::<String>::new());
     let imap_email = use_state(|| String::new());
     let imap_password = use_state(|| String::new());
-    let imap_provider = use_state(|| "gmail".to_string()); // Default to Gmail
-    let imap_server = use_state(|| String::new()); // For custom provider
-    let imap_port = use_state(|| String::new()); // For custom provider
-    let connected_email = use_state(|| None::<String>);
-    // Predefined providers - sorted alphabetically for easy lookup, with Custom at the end
+    let imap_server = use_state(|| String::new());
+    let imap_port = use_state(|| String::new());
+    let detecting = use_state(|| false);
+    let manual_override = use_state(|| false); // true = show provider dropdown instead of auto-detect
+    let manual_provider = use_state(|| "gmail".to_string());
+    // Detection result: (provider_key, label, imap_server, imap_port, instructions, instructions_url)
+    let detected = use_state(|| None::<(String, String, String, u16, Option<String>, Option<String>)>);
+    let detected_reset = detected.clone();
+    // Provider list for manual override
     let providers = vec![
+        ("gmail", "Gmail", "imap.gmail.com", "993"),
+        ("icloud", "iCloud", "imap.mail.me.com", "993"),
+        ("outlook", "Outlook / Hotmail", "outlook.office365.com", "993"),
+        ("yahoo", "Yahoo Mail", "imap.mail.yahoo.com", "993"),
         ("aol", "AOL", "imap.aol.com", "993"),
         ("fastmail", "Fastmail", "imap.fastmail.com", "993"),
-        ("gmail", "Gmail", "imap.gmail.com", "993"),
-        ("gmx", "GMX", "imap.gmx.com", "993"),
-        ("icloud", "iCloud", "imap.mail.me.com", "993"),
-        (
-            "outlook",
-            "Outlook / Hotmail",
-            "outlook.office365.com",
-            "993",
-        ),
-        (
-            "privateemail",
-            "PrivateEmail (Namecheap)",
-            "mail.privateemail.com",
-            "993",
-        ),
-        ("yahoo", "Yahoo Mail", "imap.mail.yahoo.com", "993"),
-        ("yandex", "Yandex", "imap.yandex.com", "993"),
         ("zoho", "Zoho Mail", "imap.zoho.com", "993"),
-        // Hosting providers for users with custom domain emails
-        ("bluehost", "Bluehost", "imap.oxcs.bluehost.com", "993"),
-        ("dreamhost", "DreamHost", "imap.dreamhost.com", "993"),
+        ("yandex", "Yandex", "imap.yandex.com", "993"),
+        ("gmx", "GMX", "imap.gmx.com", "993"),
+        ("privateemail", "PrivateEmail (Namecheap)", "mail.privateemail.com", "993"),
         ("godaddy", "GoDaddy", "imap.secureserver.net", "993"),
         ("hostinger", "Hostinger", "imap.hostinger.com", "993"),
-        ("ionos", "IONOS (1&1)", "imap.ionos.com", "993"),
-        ("custom", "Other / Custom", "", ""), // Custom option with empty defaults
+        ("custom", "Other / Custom", "", ""),
     ];
     // Check connection status on component mount
     {
-        let imap_connected = imap_connected.clone();
-        let connected_email = connected_email.clone();
+        let connected_accounts = connected_accounts.clone();
         use_effect_with_deps(
             move |_| {
-                // Auth handled by cookies
                 spawn_local(async move {
                     let request = Api::get("/api/auth/imap/status").send().await;
                     if let Ok(response) = request {
                         if response.ok() {
                             if let Ok(data) = response.json::<serde_json::Value>().await {
-                                if let Some(connected) =
-                                    data.get("connected").and_then(|v| v.as_bool())
+                                if let Some(connections) =
+                                    data.get("connections").and_then(|v| v.as_array())
                                 {
-                                    imap_connected.set(connected);
-                                    if connected {
-                                        connected_email.set(
-                                            data.get("email")
+                                    let emails: Vec<String> = connections
+                                        .iter()
+                                        .filter_map(|c| {
+                                            c.get("email")
                                                 .and_then(|e| e.as_str())
-                                                .map(String::from),
-                                        );
-                                    } else {
-                                        connected_email.set(None);
-                                    }
+                                                .map(String::from)
+                                        })
+                                        .collect();
+                                    connected_accounts.set(emails);
                                 }
                             }
                         }
@@ -88,9 +75,14 @@ pub fn email_connect(props: &EmailProps) -> Html {
     // Handlers for input changes
     let onchange_imap_email = {
         let imap_email = imap_email.clone();
+        let detected = detected.clone();
+        let manual_override = manual_override.clone();
         Callback::from(move |e: Event| {
             let input: HtmlInputElement = e.target_unchecked_into();
             imap_email.set(input.value());
+            // Reset detection and manual override when email changes
+            detected.set(None);
+            manual_override.set(false);
         })
     };
     let onchange_imap_password = {
@@ -98,26 +90,6 @@ pub fn email_connect(props: &EmailProps) -> Html {
         Callback::from(move |e: Event| {
             let input: HtmlInputElement = e.target_unchecked_into();
             imap_password.set(input.value());
-        })
-    };
-    let onchange_imap_provider = {
-        let imap_provider = imap_provider.clone();
-        let imap_server = imap_server.clone();
-        let imap_port = imap_port.clone();
-        let providers = providers.clone();
-        Callback::from(move |e: Event| {
-            let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
-            let value = select.value();
-            imap_provider.set(value.clone());
-            // Auto-fill server and port for predefined providers
-            if let Some((_, _, server, port)) = providers.iter().find(|(id, _, _, _)| *id == value)
-            {
-                imap_server.set(server.to_string());
-                imap_port.set(port.to_string());
-            } else {
-                imap_server.set(String::new());
-                imap_port.set(String::new());
-            }
         })
     };
     let onchange_imap_server = {
@@ -134,38 +106,88 @@ pub fn email_connect(props: &EmailProps) -> Html {
             imap_port.set(input.value());
         })
     };
+    // Step 1: Detect provider from email
+    let onclick_detect = {
+        let imap_email = imap_email.clone();
+        let detected = detected.clone();
+        let detecting = detecting.clone();
+        let imap_server = imap_server.clone();
+        let imap_port = imap_port.clone();
+        let error = error.clone();
+        Callback::from(move |_: MouseEvent| {
+            let email = (*imap_email).clone();
+            let detected = detected.clone();
+            let detecting = detecting.clone();
+            let imap_server = imap_server.clone();
+            let imap_port = imap_port.clone();
+            let error = error.clone();
+            if email.is_empty() || !email.contains('@') {
+                error.set(Some("Please enter a valid email address.".to_string()));
+                return;
+            }
+            error.set(None);
+            detecting.set(true);
+            spawn_local(async move {
+                let payload = json!({"email": email});
+                let request = Api::post("/api/auth/imap/detect")
+                    .header("Content-Type", "application/json")
+                    .json(&payload)
+                    .unwrap();
+                match request.send().await {
+                    Ok(response) => {
+                        detecting.set(false);
+                        if response.ok() {
+                            if let Ok(data) = response.json::<serde_json::Value>().await {
+                                let provider = data.get("provider").and_then(|v| v.as_str()).unwrap_or("unknown").to_string();
+                                let label = data.get("label").and_then(|v| v.as_str()).unwrap_or("Unknown").to_string();
+                                let server = data.get("imap_server").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                                let port = data.get("imap_port").and_then(|v| v.as_u64()).unwrap_or(993) as u16;
+                                let instructions = data.get("instructions").and_then(|v| v.as_str()).map(String::from);
+                                let instructions_url = data.get("instructions_url").and_then(|v| v.as_str()).map(String::from);
+                                imap_server.set(server.clone());
+                                imap_port.set(port.to_string());
+                                detected.set(Some((provider, label, server, port, instructions, instructions_url)));
+                            }
+                        } else {
+                            error.set(Some("Failed to detect email provider.".to_string()));
+                        }
+                    }
+                    Err(e) => {
+                        detecting.set(false);
+                        error.set(Some(format!("Network error: {}", e)));
+                    }
+                }
+            });
+        })
+    };
     let onclick_imap_connect = {
         let imap_email_value = imap_email.clone();
         let imap_password_value = imap_password.clone();
-        let imap_provider_value = imap_provider.clone();
         let imap_server_value = imap_server.clone();
         let imap_port_value = imap_port.clone();
-        let imap_connected = imap_connected.clone();
+        let connected_accounts = connected_accounts.clone();
         let error = error.clone();
         let success_message = success_message.clone();
         let imap_email_setter = imap_email.clone();
         let imap_password_setter = imap_password.clone();
-        let connected_email = connected_email.clone();
+        let detected_setter = detected.clone();
         Callback::from(move |_: MouseEvent| {
             let email = (*imap_email_value).clone();
             let password = (*imap_password_value).clone();
-            let provider = (*imap_provider_value).clone();
             let server = (*imap_server_value).clone();
             let port = (*imap_port_value).clone();
-            let imap_connected = imap_connected.clone();
+            let connected_accounts = connected_accounts.clone();
             let error = error.clone();
             let success_message = success_message.clone();
             let imap_email_setter = imap_email_setter.clone();
             let imap_password_setter = imap_password_setter.clone();
-            let connected_email = connected_email.clone();
-            // Auth handled by cookies
+            let detected_setter = detected_setter.clone();
             spawn_local(async move {
                 let mut payload = json!({
                     "email": email,
                     "password": password,
                 });
-                // Include server and port only for custom provider or if overridden
-                if provider == "custom" || (!server.is_empty() && !port.is_empty()) {
+                if !server.is_empty() && !port.is_empty() {
                     payload["imap_server"] = json!(server);
                     payload["imap_port"] = json!(port.parse::<u16>().unwrap_or(993));
                 }
@@ -176,13 +198,17 @@ pub fn email_connect(props: &EmailProps) -> Html {
                 match request.send().await {
                     Ok(response) => {
                         if response.ok() {
-                            imap_connected.set(true);
+                            // Add to connected accounts list
+                            let mut accounts = (*connected_accounts).clone();
+                            if !accounts.contains(&email) {
+                                accounts.push(email);
+                            }
+                            connected_accounts.set(accounts);
                             imap_email_setter.set(String::new());
                             imap_password_setter.set(String::new());
+                            detected_setter.set(None);
                             error.set(None);
-                            connected_email.set(Some(email));
                             success_message.set(Some("Email connected successfully!".to_string()));
-                            // Auto-hide success message after 3 seconds
                             let success_message_clone = success_message.clone();
                             spawn_local(async move {
                                 TimeoutFuture::new(3_000).await;
@@ -197,45 +223,6 @@ pub fn email_connect(props: &EmailProps) -> Html {
                                 } else {
                                     error.set(Some(format!(
                                         "Failed to connect: {}",
-                                        response.status()
-                                    )));
-                                }
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        error.set(Some(format!("Network error: {}", e)));
-                    }
-                }
-            });
-        })
-    };
-    let onclick_imap_disconnect = {
-        let imap_connected = imap_connected.clone();
-        let error = error.clone();
-        let connected_email = connected_email.clone();
-        Callback::from(move |_: MouseEvent| {
-            let imap_connected = imap_connected.clone();
-            let error = error.clone();
-            let connected_email = connected_email.clone();
-            // Auth handled by cookies
-            spawn_local(async move {
-                let request = Api::delete("/api/auth/imap/disconnect").send().await;
-                match request {
-                    Ok(response) => {
-                        if response.ok() {
-                            imap_connected.set(false);
-                            connected_email.set(None);
-                            error.set(None);
-                        } else {
-                            if let Ok(error_data) = response.json::<serde_json::Value>().await {
-                                if let Some(error_msg) =
-                                    error_data.get("error").and_then(|e| e.as_str())
-                                {
-                                    error.set(Some(error_msg.to_string()));
-                                } else {
-                                    error.set(Some(format!(
-                                        "Failed to disconnect: {}",
                                         response.status()
                                     )));
                                 }
@@ -278,17 +265,10 @@ pub fn email_connect(props: &EmailProps) -> Html {
                 })}>
                     {"ⓘ"}
                 </button>
-                if *imap_connected {
+                if !connected_accounts.is_empty() {
                     <div class="service-status-container">
-                        <span class="service-status">{"Connected ✓"}</span>
-                        <span class="connected-email">
-                            {
-                                if let Some(email) = &*connected_email {
-                                    format!(" ({})", email)
-                                } else {
-                                    "".to_string()
-                                }
-                            }
+                        <span class="service-status">
+                            {format!("{} connected", connected_accounts.len())}
                         </span>
                     </div>
                 }
@@ -332,274 +312,27 @@ pub fn email_connect(props: &EmailProps) -> Html {
             <p class="service-description">
                 {"Connect your email account using IMAP to access your emails through SMS or voice calls."}
             </p>
-            {
-                if *imap_provider == "gmail" {
-                    html! {
-                        <p class="provider-hint">
-                            {"Gmail requires an App Password (2FA must be enabled). "}
-                            <a class="nice-link" href="https://myaccount.google.com/apppasswords" target="_blank">{"Create App Password"}</a>
-                        </p>
-                    }
-                } else if *imap_provider == "icloud" {
-                    html! {
-                        <p class="provider-hint">
-                            {"iCloud requires an App-Specific Password. Go to "}
-                            <a class="nice-link" href="https://appleid.apple.com/account/manage" target="_blank">{"Apple ID Settings"}</a>
-                            {" > Sign-In and Security > App-Specific Passwords to create one."}
-                        </p>
-                    }
-                } else if *imap_provider == "yahoo" {
-                    html! {
-                        <p class="provider-hint">
-                            {"Yahoo requires an App Password (2FA must be enabled). "}
-                            <a class="nice-link" href="https://login.yahoo.com/myaccount/security/app-password" target="_blank">{"Create App Password"}</a>
-                        </p>
-                    }
-                } else if *imap_provider == "aol" {
-                    html! {
-                        <p class="provider-hint">
-                            {"AOL requires an App Password (2FA must be enabled). "}
-                            <a class="nice-link" href="https://login.aol.com/myaccount/security/app-password" target="_blank">{"Create App Password"}</a>
-                        </p>
-                    }
-                } else if *imap_provider == "outlook" {
-                    html! {
-                        <p class="provider-hint">
-                            {"Use your regular Outlook/Hotmail password. If you have 2FA enabled, "}
-                            <a class="nice-link" href="https://account.microsoft.com/security" target="_blank">{"create an app password"}</a>
-                            {"."}
-                        </p>
-                    }
-                } else if *imap_provider == "zoho" {
-                    html! {
-                        <p class="provider-hint">
-                            {"Make sure IMAP is enabled in your Zoho settings. Use your regular password or "}
-                            <a class="nice-link" href="https://accounts.zoho.com/home#security/security_pwd" target="_blank">{"create an app password"}</a>
-                            {" if 2FA is enabled."}
-                        </p>
-                    }
-                } else if *imap_provider == "fastmail" {
-                    html! {
-                        <p class="provider-hint">
-                            {"Fastmail recommends using an App Password. "}
-                            <a class="nice-link" href="https://www.fastmail.com/settings/security/devicekeys" target="_blank">{"Create App Password"}</a>
-                        </p>
-                    }
-                } else if *imap_provider == "custom" {
-                    html! {
-                        <p class="provider-hint">
-                            {"Enter your email provider's IMAP server and port. Most providers use port 993 with SSL/TLS."}
-                        </p>
-                    }
-                } else {
-                    html! {
-                        <p class="provider-hint">
-                            {"Use your email password. If you have 2FA enabled, you may need to create an app-specific password in your account settings."}
-                        </p>
-                    }
-                }
-            }
             if props.sub_tier.is_some() {
-                if *imap_connected {
-                    <div class="imap-controls">
-                        <button
-                            onclick={onclick_imap_disconnect}
-                            class="disconnect-button"
-                        >
-                            {"Disconnect"}
-                        </button>
-                        // Test buttons for admin
-                        if props.user_id == 1 {
-                            <>
-                                <button
-                                    onclick={
-                                        let error = error.clone();
-                                        Callback::from(move |_: MouseEvent| {
-                                            let error = error.clone();
-                                            // Auth handled by cookies
+                // List connected accounts with per-account disconnect
+                if !connected_accounts.is_empty() {
+                    <div class="connected-accounts-list">
+                        { for connected_accounts.iter().map(|account_email| {
+                            let email_for_display = account_email.clone();
+                            let email_for_disconnect = account_email.clone();
+                            let connected_accounts_clone = connected_accounts.clone();
+                            let error_clone = error.clone();
+                            html! {
+                                <div class="connected-account-row">
+                                    <span class="connected-account-email">{&email_for_display}</span>
+                                    <button
+                                        class="disconnect-button-small"
+                                        onclick={Callback::from(move |_: MouseEvent| {
+                                            let email = email_for_disconnect.clone();
+                                            let connected_accounts = connected_accounts_clone.clone();
+                                            let error = error_clone.clone();
                                             spawn_local(async move {
-                                                let request = Api::get("/api/imap/previews")
-                                                    .send()
-                                                    .await;
-                                                match request {
-                                                    Ok(response) => {
-                                                        if response.status() == 200 {
-                                                            if let Ok(data) = response.json::<serde_json::Value>().await {
-                                                                web_sys::console::log_1(&format!("IMAP previews: {:?}", data).into());
-                                                            }
-                                                        } else {
-                                                            error.set(Some("Failed to fetch IMAP previews".to_string()));
-                                                        }
-                                                    }
-                                                    Err(e) => {
-                                                        error.set(Some(format!("Network error: {}", e)));
-                                                    }
-                                                }
-                                            });
-                                        })
-                                    }
-                                    class="test-button"
-                                >
-                                    {"Test IMAP Previews"}
-                                </button>
-                                <button
-                                    onclick={
-                                        let error = error.clone();
-                                        Callback::from(move |_: MouseEvent| {
-                                            let error = error.clone();
-                                            // Auth handled by cookies
-                                            spawn_local(async move {
-                                                let request = Api::get("/api/imap/full_emails")
-                                                    .send()
-                                                    .await;
-                                                match request {
-                                                    Ok(response) => {
-                                                        if response.status() == 200 {
-                                                            if let Ok(data) = response.json::<serde_json::Value>().await {
-                                                                web_sys::console::log_1(&format!("IMAP full emails: {:?}", data).into());
-                                                            }
-                                                        } else {
-                                                            error.set(Some("Failed to fetch full IMAP emails".to_string()));
-                                                        }
-                                                    }
-                                                    Err(e) => {
-                                                        error.set(Some(format!("Network error: {}", e)));
-                                                    }
-                                                }
-                                            });
-                                        })
-                                    }
-                                    class="test-button"
-                                >
-                                    {"Test Full Emails"}
-                                </button>
-                                <button
-                                    onclick={
-                                        let error = error.clone();
-                                        Callback::from(move |_: MouseEvent| {
-                                            let error = error.clone();
-                                            // Auth handled by cookies
-                                            spawn_local(async move {
-                                                let previews_request = Api::get("/api/imap/previews")
-                                                    .send()
-                                                    .await;
-                                                match previews_request {
-                                                    Ok(response) => {
-                                                        if response.status() == 200 {
-                                                            if let Ok(data) = response.json::<serde_json::Value>().await {
-                                                                if let Some(previews) = data.get("previews").and_then(|p| p.as_array()) {
-                                                                    if let Some(first_message) = previews.first() {
-                                                                        if let Some(id) = first_message.get("id").and_then(|i| i.as_str()) {
-                                                                            let message_request = Api::get(&format!("/api/imap/message/{}", id))
-                                                                                .send()
-                                                                                .await;
-                                                                            match message_request {
-                                                                                Ok(msg_response) => {
-                                                                                    if msg_response.status() == 200 {
-                                                                                        if let Ok(msg_data) = msg_response.json::<serde_json::Value>().await {
-                                                                                            web_sys::console::log_1(&format!("IMAP single message: {:?}", msg_data).into());
-                                                                                        }
-                                                                                    } else {
-                                                                                        error.set(Some("Failed to fetch single IMAP message".to_string()));
-                                                                                    }
-                                                                                }
-                                                                                Err(e) => {
-                                                                                    error.set(Some(format!("Network error: {}", e)));
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        }
-                                                    }
-                                                    Err(e) => {
-                                                        error.set(Some(format!("Network error: {}", e)));
-                                                    }
-                                                }
-                                            });
-                                        })
-                                    }
-                                    class="test-button"
-                                >
-                                    {"Test Single Message"}
-                                </button>
-                                <button
-                                    onclick={
-                                        let error = error.clone();
-                                        Callback::from(move |_: MouseEvent| {
-                                            let error = error.clone();
-                                            // Auth handled by cookies
-                                            spawn_local(async move {
-                                                // First fetch previews to get the latest email ID
-                                                let previews_request = Api::get("/api/imap/previews?limit=1")
-                                                    .send()
-                                                    .await;
-                                                match previews_request {
-                                                    Ok(response) => {
-                                                        if response.status() == 200 {
-                                                            if let Ok(data) = response.json::<serde_json::Value>().await {
-                                                                if let Some(previews) = data.get("previews").and_then(|p| p.as_array()) {
-                                                                    if let Some(latest_email) = previews.first() {
-                                                                        if let Some(id) = latest_email.get("id").and_then(|i| i.as_str()) {
-                                                                            // Now send a test reply
-                                                                            let reply_payload = json!({
-                                                                                "email_id": id,
-                                                                                "response_text": "This is a test reply from LightFriend!"
-                                                                            });
-                                                                            let reply_request = Api::post("/api/imap/reply")
-                                                                                .header("Content-Type", "application/json")
-                                                                                .json(&reply_payload)
-                                                                                .unwrap()
-                                                                                .send()
-                                                                                .await;
-                                                                            match reply_request {
-                                                                                Ok(reply_response) => {
-                                                                                    if reply_response.status() == 200 {
-                                                                                        web_sys::console::log_1(&"Successfully sent test reply".into());
-                                                                                    } else {
-                                                                                        if let Ok(error_data) = reply_response.json::<serde_json::Value>().await {
-                                                                                            error.set(Some(format!("Failed to send reply: {}",
-                                                                                                error_data.get("error").and_then(|e| e.as_str()).unwrap_or("Unknown error"))));
-                                                                                        }
-                                                                                    }
-                                                                                }
-                                                                                Err(e) => {
-                                                                                    error.set(Some(format!("Network error while sending reply: {}", e)));
-                                                                                }
-                                                                            }
-                                                                        }
-                                                                    }
-                                                                }
-                                                            }
-                                                        } else {
-                                                            error.set(Some("Failed to fetch latest email".to_string()));
-                                                        }
-                                                    }
-                                                    Err(e) => {
-                                                        error.set(Some(format!("Network error: {}", e)));
-                                                    }
-                                                }
-                                            });
-                                        })
-                                    }
-                                    class="test-button"
-                                >
-                                    {"Test Reply to Latest"}
-                                </button>
-                                <button
-                                    onclick={
-                                        let error = error.clone();
-                                        Callback::from(move |_: MouseEvent| {
-                                            let error = error.clone();
-                                            // Auth handled by cookies
-                                            spawn_local(async move {
-                                                let payload = json!({
-                                                    "to": "rasmus@ahtava.com",
-                                                    "subject": "test email subject",
-                                                    "body": "testing body here"
-                                                });
-                                                let request = Api::post("/api/imap/send")
+                                                let payload = json!({"email": email});
+                                                let request = Api::delete("/api/auth/imap/disconnect")
                                                     .header("Content-Type", "application/json")
                                                     .json(&payload)
                                                     .unwrap()
@@ -607,12 +340,19 @@ pub fn email_connect(props: &EmailProps) -> Html {
                                                     .await;
                                                 match request {
                                                     Ok(response) => {
-                                                        if response.status() == 200 {
-                                                            web_sys::console::log_1(&"Successfully sent test email".into());
+                                                        if response.ok() {
+                                                            let mut accounts = (*connected_accounts).clone();
+                                                            accounts.retain(|e| e != &email);
+                                                            connected_accounts.set(accounts);
+                                                            error.set(None);
                                                         } else {
                                                             if let Ok(error_data) = response.json::<serde_json::Value>().await {
-                                                                error.set(Some(format!("Failed to send email: {}",
-                                                                    error_data.get("error").and_then(|e| e.as_str()).unwrap_or("Unknown error"))));
+                                                                error.set(Some(
+                                                                    error_data.get("error")
+                                                                        .and_then(|e| e.as_str())
+                                                                        .unwrap_or("Failed to disconnect")
+                                                                        .to_string()
+                                                                ));
                                                             }
                                                         }
                                                     }
@@ -621,69 +361,180 @@ pub fn email_connect(props: &EmailProps) -> Html {
                                                     }
                                                 }
                                             });
-                                        })
-                                    }
-                                    class="test-button"
-                                >
-                                    {"Test Send Email"}
-                                </button>
-                            </>
-                        }
+                                        })}
+                                    >
+                                        {"Disconnect"}
+                                    </button>
+                                </div>
+                            }
+                        })}
                     </div>
-                } else {
-                    <div class="imap-form" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center;">
-                        <select
-                            onchange={onchange_imap_provider}
-                            style="flex: 1 1 100px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444; appearance: none;"
-                        >
-                            { for providers.iter().map(|(id, name, _, _)| {
-                                html! {
-                                    <option value={id.to_string()} selected={*imap_provider == *id}>
-                                        {name}
-                                    </option>
-                                }
-                            })}
-                        </select>
+                }
+                // Two-step connect flow
+                if detected.is_none() {
+                    // Step 1: Enter email and detect provider
+                    <div class="imap-form" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-top: 10px;">
                         <input
                             type="email"
                             placeholder="Email address"
                             value={(*imap_email).clone()}
                             onchange={onchange_imap_email}
-                            style="flex: 2 1 200px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
+                            style="flex: 2 1 250px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
                         />
-                        <input
-                            type="password"
-                            placeholder="Password or App Password"
-                            value={(*imap_password).clone()}
-                            onchange={onchange_imap_password}
-                            style="flex: 2 1 200px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
-                        />
-                        if *imap_provider == "custom" {
-                            <>
-                                <input
-                                    type="text"
-                                    placeholder="IMAP Server (e.g., mail.privateemail.com)"
-                                    value={(*imap_server).clone()}
-                                    onchange={onchange_imap_server}
-                                    style="flex: 2 1 200px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
-                                />
-                                <input
-                                    type="number"
-                                    placeholder="IMAP Port (e.g., 993)"
-                                    value={(*imap_port).clone()}
-                                    onchange={onchange_imap_port}
-                                    style="flex: 1 1 100px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
-                                />
-                            </>
-                        }
+                        <button
+                            onclick={onclick_detect}
+                            class="connect-button"
+                            disabled={*detecting}
+                            style="padding: 8px 16px; background-color: #3b82f6; color: white; border: none; border-radius: 4px; cursor: pointer;"
+                        >
+                            {if *detecting { "Detecting..." } else { "Next" }}
+                        </button>
                     </div>
-                    <button
-                        onclick={onclick_imap_connect}
-                        class="connect-button"
-                        style="margin-top: 10px; padding: 8px 16px; background-color: #3b82f6; color: white; border: none; border-radius: 4px; cursor: pointer;"
-                    >
-                        {"Connect"}
-                    </button>
+                } else {
+                    // Step 2: Show detected provider + password input
+                    {
+                        if let Some((ref provider, ref label, ref _server, _port, ref instructions, ref instructions_url)) = *detected {
+                            html! {
+                                <>
+                                    if !*manual_override {
+                                        // Show auto-detected provider
+                                        <div class="provider-detected" style="margin-top: 10px; padding: 10px 14px; background: rgba(76, 175, 80, 0.1); border: 1px solid rgba(76, 175, 80, 0.25); border-radius: 8px;">
+                                            <span style="color: #4CAF50; font-weight: 500;">
+                                                {format!("Detected: {}", label)}
+                                            </span>
+                                            <span style="color: #888; margin-left: 8px; font-size: 0.9rem;">
+                                                {format!("({})", (*imap_email).clone())}
+                                            </span>
+                                            <button
+                                                onclick={{
+                                                    let manual_override = manual_override.clone();
+                                                    Callback::from(move |_: MouseEvent| manual_override.set(true))
+                                                }}
+                                                style="float: right; background: none; border: none; color: #888; cursor: pointer; font-size: 0.85rem;"
+                                            >
+                                                {"Change"}
+                                            </button>
+                                        </div>
+                                        if let Some(instr) = instructions {
+                                            <p class="provider-hint">
+                                                {instr.clone()}
+                                                {" "}
+                                                if let Some(url) = instructions_url {
+                                                    <a class="nice-link" href={url.clone()} target="_blank">{"Get App Password"}</a>
+                                                }
+                                            </p>
+                                        }
+                                        if provider == "unknown" {
+                                            <p class="provider-hint">
+                                                {"Provider not detected. Enter your IMAP server details, or click Change to select your provider."}
+                                            </p>
+                                            <div class="imap-form" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-top: 6px;">
+                                                <input
+                                                    type="text"
+                                                    placeholder="IMAP Server (e.g., imap.example.com)"
+                                                    value={(*imap_server).clone()}
+                                                    onchange={onchange_imap_server.clone()}
+                                                    style="flex: 2 1 200px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
+                                                />
+                                                <input
+                                                    type="number"
+                                                    placeholder="Port (993)"
+                                                    value={(*imap_port).clone()}
+                                                    onchange={onchange_imap_port.clone()}
+                                                    style="flex: 1 1 80px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
+                                                />
+                                            </div>
+                                        }
+                                    } else {
+                                        // Manual provider override
+                                        <div style="margin-top: 10px;">
+                                            <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px;">
+                                                <span style="color: #888; font-size: 0.9rem;">
+                                                    {format!("({})", (*imap_email).clone())}
+                                                </span>
+                                                <button
+                                                    onclick={{
+                                                        let manual_override = manual_override.clone();
+                                                        Callback::from(move |_: MouseEvent| manual_override.set(false))
+                                                    }}
+                                                    style="background: none; border: none; color: #3b82f6; cursor: pointer; font-size: 0.85rem;"
+                                                >
+                                                    {"Use auto-detected"}
+                                                </button>
+                                            </div>
+                                            <div class="imap-form" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center;">
+                                                <select
+                                                    onchange={{
+                                                        let manual_provider = manual_provider.clone();
+                                                        let imap_server = imap_server.clone();
+                                                        let imap_port = imap_port.clone();
+                                                        let providers = providers.clone();
+                                                        Callback::from(move |e: Event| {
+                                                            let select: web_sys::HtmlSelectElement = e.target_unchecked_into();
+                                                            let value = select.value();
+                                                            manual_provider.set(value.clone());
+                                                            if let Some((_, _, server, port)) = providers.iter().find(|(id, _, _, _)| *id == value) {
+                                                                imap_server.set(server.to_string());
+                                                                imap_port.set(port.to_string());
+                                                            } else {
+                                                                imap_server.set(String::new());
+                                                                imap_port.set(String::new());
+                                                            }
+                                                        })
+                                                    }}
+                                                    style="flex: 1 1 150px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444; appearance: none;"
+                                                >
+                                                    { for providers.iter().map(|(id, name, _, _)| {
+                                                        html! {
+                                                            <option value={id.to_string()} selected={*manual_provider == *id}>
+                                                                {name}
+                                                            </option>
+                                                        }
+                                                    })}
+                                                </select>
+                                            </div>
+                                            if *manual_provider == "custom" {
+                                                <div class="imap-form" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-top: 6px;">
+                                                    <input
+                                                        type="text"
+                                                        placeholder="IMAP Server (e.g., imap.example.com)"
+                                                        value={(*imap_server).clone()}
+                                                        onchange={onchange_imap_server.clone()}
+                                                        style="flex: 2 1 200px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
+                                                    />
+                                                    <input
+                                                        type="number"
+                                                        placeholder="Port (993)"
+                                                        value={(*imap_port).clone()}
+                                                        onchange={onchange_imap_port.clone()}
+                                                        style="flex: 1 1 80px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
+                                                    />
+                                                </div>
+                                            }
+                                        </div>
+                                    }
+                                    <div class="imap-form" style="display: flex; flex-wrap: wrap; gap: 10px; align-items: center; margin-top: 8px;">
+                                        <input
+                                            type="password"
+                                            placeholder="Password or App Password"
+                                            value={(*imap_password).clone()}
+                                            onchange={onchange_imap_password}
+                                            style="flex: 2 1 250px; padding: 8px; border-radius: 4px; background-color: #2a2a2a; color: #ccc; border: 1px solid #444;"
+                                        />
+                                        <button
+                                            onclick={onclick_imap_connect}
+                                            class="connect-button"
+                                            style="padding: 8px 16px; background-color: #3b82f6; color: white; border: none; border-radius: 4px; cursor: pointer;"
+                                        >
+                                            {"Connect"}
+                                        </button>
+                                    </div>
+                                </>
+                            }
+                        } else {
+                            html! {}
+                        }
+                    }
                 }
             if let Some(err) = (*error).as_ref() {
                 <div class="error-message">
@@ -699,26 +550,43 @@ pub fn email_connect(props: &EmailProps) -> Html {
                     </a>
                 </div>
             </div>
-            {
-                if *imap_connected {
-                    html! {
-                    <div class="imap-controls">
-                        <button
-                            onclick={onclick_imap_disconnect}
-                            class="disconnect-button"
-                        >
-                            {"Disconnect previous connection"}
-                        </button>
-                    </div>
-                    }
-                } else {
-                    html! {}
-                }
-            }
         }
             <style>
 
                 {r#"
+                    .connected-accounts-list {
+                        display: flex;
+                        flex-direction: column;
+                        gap: 8px;
+                        margin: 10px 0;
+                    }
+                    .connected-account-row {
+                        display: flex;
+                        align-items: center;
+                        justify-content: space-between;
+                        padding: 8px 12px;
+                        background: rgba(0, 136, 204, 0.08);
+                        border: 1px solid rgba(0, 136, 204, 0.15);
+                        border-radius: 8px;
+                    }
+                    .connected-account-email {
+                        color: #ccc;
+                        font-size: 0.95rem;
+                    }
+                    .disconnect-button-small {
+                        background: transparent;
+                        border: 1px solid rgba(255, 99, 71, 0.3);
+                        color: #FF6347;
+                        padding: 4px 12px;
+                        border-radius: 6px;
+                        cursor: pointer;
+                        font-size: 0.85rem;
+                        transition: all 0.3s ease;
+                    }
+                    .disconnect-button-small:hover {
+                        background: rgba(255, 99, 71, 0.1);
+                        border-color: rgba(255, 99, 71, 0.5);
+                    }
                     .service-item {
                         background: rgba(0, 0, 0, 0.2);
                         border: 1px solid rgba(0, 136, 204, 0.2);

--- a/frontend/src/dashboard/activity_feed.rs
+++ b/frontend/src/dashboard/activity_feed.rs
@@ -1,5 +1,7 @@
+use crate::config;
 use crate::utils::api::Api;
 use serde::Deserialize;
+use wasm_bindgen::prelude::*;
 use wasm_bindgen::JsCast;
 use wasm_bindgen_futures::spawn_local;
 use yew::prelude::*;
@@ -230,29 +232,64 @@ pub fn activity_feed(props: &ActivityFeedProps) -> Html {
         );
     }
 
-    // Auto-refresh every 30 seconds
+    // SSE: subscribe to server-sent activity feed events for real-time updates
     {
         let refresh_trigger = refresh_trigger.clone();
+        let es_handle = use_state(|| None::<web_sys::EventSource>);
+        let es_handle_clone = es_handle.clone();
         use_effect_with_deps(
             move |_| {
-                let refresh_trigger = refresh_trigger.clone();
-                let interval = gloo_timers::callback::Interval::new(30_000, move || {
-                    refresh_trigger.set(js_sys::Date::now() as u32);
-                });
-                move || drop(interval)
+                let rt = refresh_trigger.clone();
+
+                let url = format!(
+                    "{}/api/dashboard/activity-feed/stream",
+                    config::get_backend_url()
+                );
+                let mut init = web_sys::EventSourceInit::new();
+                init.with_credentials(true);
+                if let Ok(es) =
+                    web_sys::EventSource::new_with_event_source_init_dict(&url, &init)
+                {
+                    let cb = Closure::wrap(Box::new(move |_: web_sys::MessageEvent| {
+                        rt.set(js_sys::Date::now() as u32);
+                    })
+                        as Box<dyn Fn(web_sys::MessageEvent)>);
+
+                    let _ =
+                        es.add_event_listener_with_callback("refresh", cb.as_ref().unchecked_ref());
+                    cb.forget();
+
+                    es_handle_clone.set(Some(es));
+                }
+
+                move || {
+                    // Cleanup handled by drop
+                }
             },
             (),
         );
+
+        // Close EventSource on unmount
+        {
+            let es_handle = es_handle.clone();
+            use_effect_with_deps(
+                move |_| {
+                    move || {
+                        if let Some(es) = &*es_handle {
+                            es.close();
+                        }
+                    }
+                },
+                (),
+            );
+        }
     }
 
-    // Listen for chat-sent and rules-changed events
+    // Listen for chat-sent and rules-changed events (user-initiated, no SSE)
     {
         let refresh_trigger = refresh_trigger.clone();
         use_effect_with_deps(
             move |_| {
-                use wasm_bindgen::closure::Closure;
-                use wasm_bindgen::JsCast;
-
                 let rt1 = refresh_trigger.clone();
                 let rt2 = refresh_trigger.clone();
 

--- a/frontend/src/dashboard/dashboard_view.rs
+++ b/frontend/src/dashboard/dashboard_view.rs
@@ -1701,7 +1701,7 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
                                         <p>{"You get notified only for critical or high urgency. The AI also considers sender relationship, messaging patterns, time of day, and cross-platform escalation (e.g., someone messaging you on both WhatsApp and Signal)."}</p>
                                         <p style="margin-top: 0.5rem; font-size: 0.85rem;">
                                             <a
-                                                href="https://github.com/ahtavarasmus/lightfriend/blob/master/backend/src/proactive/system_behaviors.rs"
+                                                href="https://github.com/ahtavarasmus/lightfriend/blob/master/backend/src/proactive/system_behaviors.rs#L249"
                                                 target="_blank"
                                                 rel="noopener noreferrer"
                                                 style="color: #60a5fa; text-decoration: none;"

--- a/frontend/src/dashboard/dashboard_view.rs
+++ b/frontend/src/dashboard/dashboard_view.rs
@@ -175,30 +175,6 @@ const DASHBOARD_STYLES: &str = r#"
     padding-left: 1.2rem;
 }
 .critical-notif-details li { margin-bottom: 0.15rem; }
-.critical-notif-prompt-toggle {
-    background: none;
-    border: 1px solid rgba(255, 255, 255, 0.1);
-    color: #888;
-    font-size: 0.65rem;
-    cursor: pointer;
-    padding: 0.2rem 0.5rem;
-    border-radius: 4px;
-    margin-top: 0.4rem;
-}
-.critical-notif-prompt-toggle:hover { color: #aaa; border-color: rgba(255, 255, 255, 0.2); }
-.critical-notif-prompt {
-    margin-top: 0.3rem;
-    padding: 0.5rem;
-    background: rgba(0, 0, 0, 0.3);
-    border-radius: 6px;
-    font-size: 0.65rem;
-    color: #888;
-    line-height: 1.4;
-    white-space: pre-wrap;
-    max-height: 300px;
-    overflow-y: auto;
-    font-family: monospace;
-}
 .digest-schedule-row {
     display: flex;
     align-items: center;
@@ -870,7 +846,6 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
     });
     let custom_rules_open = use_state(|| false);
     let critical_notif_details_open = use_state(|| false);
-    let critical_notif_prompt_open = use_state(|| false);
     let digest_details_open = use_state(|| false);
     let digest_custom_input = use_state(|| String::new());
     let digest_show_custom = use_state({
@@ -1379,12 +1354,6 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
         })
     };
 
-    let on_toggle_critical_prompt = {
-        let critical_notif_prompt_open = critical_notif_prompt_open.clone();
-        Callback::from(move |_: web_sys::MouseEvent| {
-            critical_notif_prompt_open.set(!*critical_notif_prompt_open);
-        })
-    };
 
     let on_toggle_digest_details = {
         let digest_details_open = digest_details_open.clone();
@@ -1730,51 +1699,17 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
                                             <li><strong>{"None: "}</strong>{"spam, automated messages"}</li>
                                         </ul>
                                         <p>{"You get notified only for critical or high urgency. The AI also considers sender relationship, messaging patterns, time of day, and cross-platform escalation (e.g., someone messaging you on both WhatsApp and Signal)."}</p>
-                                        <button class="critical-notif-prompt-toggle" onclick={on_toggle_critical_prompt}>
-                                            {if *critical_notif_prompt_open { "Hide classification prompt" } else { "View classification prompt" }}
-                                        </button>
-                                        if *critical_notif_prompt_open {
-                                            <div class="critical-notif-prompt">
-                                                {"You are evaluating whether an incoming message requires the user's immediate attention.\n\
-                                                The user has muted all phone notifications and relies on you to catch time-critical messages. \
-                                                If you miss something important, they won't see it for hours.\n\
-                                                \n\
-                                                Current time: [current time]\n\
-                                                \n\
-                                                SIGNAL REPORT\n\
-                                                Sender: [sender name]\n\
-                                                Relationship: [sender context - how often they message, typical hours, response patterns]\n\
-                                                Cross-platform: [if sender messaged on multiple platforms recently]\n\
-                                                User state: [if user is likely sleeping based on activity patterns]\n\
-                                                Content signals: [detected keywords, question marks, urgency indicators]\n\
-                                                Thread context: [if this is a reply to user's earlier message or question]\n\
-                                                \n\
-                                                The last message in the conversation is being evaluated. Each message is marked [seen] or \
-                                                [unseen]. Use the conversation history, timestamps, and seen status to understand context \
-                                                and urgency. Compare mentioned times against the current time.\n\
-                                                \n\
-                                                Classify the urgency level:\n\
-                                                - critical: immediate danger, medical emergency, security breach\n\
-                                                - high: 2-hour delay would cause real consequences (missed meeting, financial loss, time-sensitive decision)\n\
-                                                - medium: important but can wait a few hours (friend asking to meet later today, non-urgent work question)\n\
-                                                - low: routine updates, casual conversation\n\
-                                                - none: spam, automated messages, irrelevant\n\
-                                                \n\
-                                                Set should_notify=true only for critical or high urgency.\n\
-                                                Use the signal report to calibrate - sender relationship, timing patterns, and content signals all matter.\n\
-                                                \n\
-                                                If should_notify=false, set notification_message to empty string.\n\
-                                                If should_notify=true, write a concise notification (max 480 chars, second person).\n\
-                                                \n\
-                                                COMMITMENT TRACKING (when enabled):\n\
-                                                Also detect if this message contains a concrete commitment or obligation that the user \
-                                                could forget and would benefit from being reminded about. Examples: paying a bill, booking \
-                                                something, confirming attendance, sending a document, following up by a date.\n\
-                                                - Set contains_commitment=true only for specific, actionable obligations with a timeframe.\n\
-                                                - Do NOT track vague intentions or past-tense actions already done.\n\
-                                                - Detect commitments both TO the user and BY the user."}
-                                            </div>
-                                        }
+                                        <p style="margin-top: 0.5rem; font-size: 0.85rem;">
+                                            <a
+                                                href="https://github.com/ahtavarasmus/lightfriend/blob/master/backend/src/proactive/system_behaviors.rs"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                                style="color: #60a5fa; text-decoration: none;"
+                                            >
+                                                {"View the classification prompt on GitHub"}
+                                                <i class="fa-solid fa-arrow-up-right-from-square" style="font-size: 0.7rem; margin-left: 0.3rem;"></i>
+                                            </a>
+                                        </p>
                                     </div>
                                 }
                             </div>

--- a/frontend/src/pages/trust_chain.rs
+++ b/frontend/src/pages/trust_chain.rs
@@ -197,6 +197,7 @@ pub fn trust_chain_page() -> Html {
             } else if let Some(ref d) = d {
                 {render_diagram(d)}
                 {render_verify_section(d)}
+                {render_source_audit_section(d)}
             } else {
                 <div class="tc-loading">
                     {"Could not load trust chain data. This page works best when connected to a live Lightfriend instance."}
@@ -782,6 +783,102 @@ fn render_verify_section(d: &TrustChainData) -> Html {
 }
 
 // =============================================
+// SOURCE AUDIT
+// =============================================
+
+fn render_source_audit_section(d: &TrustChainData) -> Html {
+    let commit = d.commit_sha.as_deref().unwrap_or("unknown");
+    let tree = format!("https://github.com/ahtavarasmus/lightfriend/tree/{}", commit);
+
+    // (label, icon, path, description)
+    let sections: &[(&str, &str, &[(&str, &str)])] = &[
+        (
+            "Encryption & key management",
+            "fa-solid fa-lock",
+            &[
+                ("backend/src/utils/encryption.rs", "AES-256-GCM encryption for all stored credentials"),
+            ],
+        ),
+        (
+            "Email (IMAP) connection",
+            "fa-solid fa-envelope",
+            &[
+                ("backend/src/handlers/imap_auth.rs", "IMAP login flow and credential storage"),
+                ("backend/src/handlers/imap_handlers.rs", "Email fetching and polling"),
+            ],
+        ),
+        (
+            "Messaging bridges",
+            "fa-solid fa-bridge",
+            &[
+                ("backend/src/handlers/whatsapp_auth.rs", "WhatsApp bridge authentication"),
+                ("backend/src/handlers/signal_auth.rs", "Signal bridge authentication"),
+                ("backend/src/handlers/telegram_auth.rs", "Telegram bridge authentication"),
+                ("backend/src/utils/bridge.rs", "Bridge message handling and room management"),
+            ],
+        ),
+        (
+            "AI classification & prompts",
+            "fa-solid fa-brain",
+            &[
+                ("backend/src/proactive/system_behaviors.rs", "Message classification prompts and logic"),
+                ("backend/src/proactive/signal_extraction.rs", "Sender signal analysis and urgency scoring"),
+            ],
+        ),
+        (
+            "Authentication & sessions",
+            "fa-solid fa-user-shield",
+            &[
+                ("backend/src/handlers/auth_handlers.rs", "Login, registration, JWT tokens"),
+                ("backend/src/handlers/auth_middleware.rs", "Request authentication middleware"),
+            ],
+        ),
+        (
+            "Enclave attestation",
+            "fa-solid fa-certificate",
+            &[
+                ("backend/src/handlers/attestation_handlers.rs", "Live attestation endpoint"),
+                ("tools/attestation-verifier/src/main.rs", "Independent verification tool"),
+            ],
+        ),
+    ];
+
+    html! {
+        <div class="tc-source-audit">
+            <h2><i class="fa-solid fa-code"></i>{" Browse Verified Source Code"}</h2>
+            <p class="source-audit-desc">
+                {"These links point to the exact commit ("}
+                <code>{short_hash(commit, 8)}</code>
+                {") running in the attested enclave. Read the code to verify how your data is handled."}
+            </p>
+            <div class="source-audit-grid">
+                { for sections.iter().map(|(label, icon, files)| {
+                    html! {
+                        <div class="source-audit-card">
+                            <div class="source-audit-card-header">
+                                <i class={*icon}></i>
+                                <span>{*label}</span>
+                            </div>
+                            <div class="source-audit-files">
+                                { for files.iter().map(|(path, desc)| {
+                                    let url = format!("{}/{}", tree, path);
+                                    html! {
+                                        <a href={url} target="_blank" rel="noopener noreferrer" class="source-audit-file">
+                                            <span class="source-audit-filename">{path.rsplit('/').next().unwrap_or(path)}</span>
+                                            <span class="source-audit-filedesc">{*desc}</span>
+                                        </a>
+                                    }
+                                })}
+                            </div>
+                        </div>
+                    }
+                })}
+            </div>
+        </div>
+    }
+}
+
+// =============================================
 // STYLES
 // =============================================
 
@@ -1152,6 +1249,53 @@ const STYLES: &str = r#"
 .tc-page .legal-links a { color: rgba(255,255,255,0.35); text-decoration: none; }
 .tc-page .legal-links a:hover { color: #1E90FF; }
 
+/* ---- Source Audit ---- */
+.tc-source-audit {
+    margin-top: 3rem;
+    padding: 2rem;
+    background: rgba(30, 144, 255, 0.04);
+    border: 1px solid rgba(30, 144, 255, 0.12);
+    border-radius: 12px;
+}
+.tc-source-audit h2 {
+    font-size: 1.15rem; color: #e0e0e0; margin: 0 0 0.5rem;
+}
+.tc-source-audit h2 i { color: #1E90FF; margin-right: 0.4rem; }
+.source-audit-desc {
+    font-size: 0.85rem; color: #888; margin-bottom: 1.5rem; line-height: 1.5;
+}
+.source-audit-desc code {
+    background: rgba(255,255,255,0.08); padding: 0.15rem 0.4rem; border-radius: 3px;
+    font-size: 0.8rem; color: #aaa;
+}
+.source-audit-grid {
+    display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+    gap: 1rem;
+}
+.source-audit-card {
+    background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06);
+    border-radius: 8px; padding: 1rem; display: flex; flex-direction: column; gap: 0.6rem;
+}
+.source-audit-card-header {
+    display: flex; align-items: center; gap: 0.5rem;
+    font-size: 0.85rem; color: #ccc; font-weight: 500;
+}
+.source-audit-card-header i { color: #1E90FF; font-size: 0.8rem; width: 1rem; text-align: center; }
+.source-audit-files { display: flex; flex-direction: column; gap: 0.35rem; }
+.source-audit-file {
+    display: flex; flex-direction: column; gap: 0.1rem;
+    padding: 0.4rem 0.6rem; border-radius: 5px;
+    background: rgba(255,255,255,0.02); text-decoration: none;
+    transition: background 0.15s;
+}
+.source-audit-file:hover { background: rgba(30, 144, 255, 0.08); }
+.source-audit-filename {
+    font-size: 0.78rem; color: #60a5fa; font-family: monospace;
+}
+.source-audit-filedesc {
+    font-size: 0.72rem; color: #666;
+}
+
 @media (max-width: 768px) {
     .tc-page { padding: 3rem 1rem 2rem; }
     .tc-header h1 { font-size: 1.4rem; }
@@ -1159,5 +1303,6 @@ const STYLES: &str = r#"
     .att-row { flex-direction: column; gap: 0.05rem; align-items: flex-start; }
     .att-label { min-width: auto; text-align: left; }
     .inter-flow-cols { flex-direction: column; gap: 0.3rem; }
+    .source-audit-grid { grid-template-columns: 1fr; }
 }
 "#;

--- a/frontend/src/pages/trust_chain.rs
+++ b/frontend/src/pages/trust_chain.rs
@@ -345,6 +345,52 @@ fn render_live_enclave(d: &TrustChainData) -> Html {
                         </div>
                     </Details>
 
+                    <Details summary="Audit source code">
+                        <div class="source-audit-intro">
+                            {"Read the exact code running in this enclave. Every file links to commit "}
+                            <code>{&commit_short}</code>
+                            {"."}
+                        </div>
+                        <div class="source-audit-list">
+                            <div class="source-audit-group">
+                                <span class="source-audit-group-label">{"Email (IMAP)"}</span>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/handlers/imap_auth.rs", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"imap_auth.rs"}<span class="source-audit-hint">{" - login, credential storage"}</span>
+                                </a>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/handlers/imap_handlers.rs", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"imap_handlers.rs"}<span class="source-audit-hint">{" - fetching, sending"}</span>
+                                </a>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/repositories/user_repository.rs#L182", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"user_repository.rs"}<span class="source-audit-hint">{" - encrypt/store/delete credentials"}</span>
+                                </a>
+                            </div>
+                            <div class="source-audit-group">
+                                <span class="source-audit-group-label">{"AI classification"}</span>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/proactive/system_behaviors.rs#L249", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"system_behaviors.rs"}<span class="source-audit-hint">{" - notification prompts"}</span>
+                                </a>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/proactive/signal_extraction.rs", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"signal_extraction.rs"}<span class="source-audit-hint">{" - urgency scoring"}</span>
+                                </a>
+                            </div>
+                            <div class="source-audit-group">
+                                <span class="source-audit-group-label">{"Messaging bridges"}</span>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/utils/bridge.rs", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"bridge.rs"}<span class="source-audit-hint">{" - message handling"}</span>
+                                </a>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/handlers/whatsapp_auth.rs", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"whatsapp_auth.rs"}
+                                </a>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/handlers/signal_auth.rs", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"signal_auth.rs"}
+                                </a>
+                                <a href={format!("https://github.com/ahtavarasmus/lightfriend/blob/{}/backend/src/handlers/telegram_auth.rs", commit)} target="_blank" rel="noopener noreferrer">
+                                    {"telegram_auth.rs"}
+                                </a>
+                            </div>
+                        </div>
+                    </Details>
+
                     <div class="pathway-label">{"import"}</div>
                     <div class="vert-flow">
                         <div class="eq-item">
@@ -947,6 +993,34 @@ const STYLES: &str = r#"
     font-size: 0.78rem; color: #1E90FF; text-decoration: none;
 }
 .cloud-links a:hover { text-decoration: underline; }
+
+/* Source audit */
+.source-audit-intro {
+    font-size: 0.78rem; color: #888; margin-bottom: 0.6rem; line-height: 1.4;
+}
+.source-audit-intro code {
+    background: rgba(255,255,255,0.08); padding: 0.1rem 0.3rem; border-radius: 3px;
+    font-size: 0.75rem; color: #aaa;
+}
+.source-audit-list {
+    display: flex; flex-direction: column; gap: 0.5rem;
+}
+.source-audit-group {
+    display: flex; flex-direction: column; gap: 0.15rem;
+}
+.source-audit-group-label {
+    font-size: 0.7rem; color: #666; text-transform: uppercase; letter-spacing: 0.05em;
+    margin-bottom: 0.1rem;
+}
+.source-audit-list a {
+    font-size: 0.78rem; color: #60a5fa; text-decoration: none; font-family: monospace;
+    padding: 0.15rem 0;
+}
+.source-audit-list a:hover { text-decoration: underline; }
+.source-audit-hint {
+    font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+    color: #555; font-size: 0.72rem;
+}
 
 /* Past enclave details */
 .past-details-links {

--- a/frontend/src/pages/trust_chain.rs
+++ b/frontend/src/pages/trust_chain.rs
@@ -197,7 +197,6 @@ pub fn trust_chain_page() -> Html {
             } else if let Some(ref d) = d {
                 {render_diagram(d)}
                 {render_verify_section(d)}
-                {render_source_audit_section(d)}
             } else {
                 <div class="tc-loading">
                     {"Could not load trust chain data. This page works best when connected to a live Lightfriend instance."}
@@ -783,102 +782,6 @@ fn render_verify_section(d: &TrustChainData) -> Html {
 }
 
 // =============================================
-// SOURCE AUDIT
-// =============================================
-
-fn render_source_audit_section(d: &TrustChainData) -> Html {
-    let commit = d.commit_sha.as_deref().unwrap_or("unknown");
-    let tree = format!("https://github.com/ahtavarasmus/lightfriend/tree/{}", commit);
-
-    // (label, icon, path, description)
-    let sections: &[(&str, &str, &[(&str, &str)])] = &[
-        (
-            "Encryption & key management",
-            "fa-solid fa-lock",
-            &[
-                ("backend/src/utils/encryption.rs", "AES-256-GCM encryption for all stored credentials"),
-            ],
-        ),
-        (
-            "Email (IMAP) connection",
-            "fa-solid fa-envelope",
-            &[
-                ("backend/src/handlers/imap_auth.rs", "IMAP login flow and credential storage"),
-                ("backend/src/handlers/imap_handlers.rs", "Email fetching and polling"),
-            ],
-        ),
-        (
-            "Messaging bridges",
-            "fa-solid fa-bridge",
-            &[
-                ("backend/src/handlers/whatsapp_auth.rs", "WhatsApp bridge authentication"),
-                ("backend/src/handlers/signal_auth.rs", "Signal bridge authentication"),
-                ("backend/src/handlers/telegram_auth.rs", "Telegram bridge authentication"),
-                ("backend/src/utils/bridge.rs", "Bridge message handling and room management"),
-            ],
-        ),
-        (
-            "AI classification & prompts",
-            "fa-solid fa-brain",
-            &[
-                ("backend/src/proactive/system_behaviors.rs", "Message classification prompts and logic"),
-                ("backend/src/proactive/signal_extraction.rs", "Sender signal analysis and urgency scoring"),
-            ],
-        ),
-        (
-            "Authentication & sessions",
-            "fa-solid fa-user-shield",
-            &[
-                ("backend/src/handlers/auth_handlers.rs", "Login, registration, JWT tokens"),
-                ("backend/src/handlers/auth_middleware.rs", "Request authentication middleware"),
-            ],
-        ),
-        (
-            "Enclave attestation",
-            "fa-solid fa-certificate",
-            &[
-                ("backend/src/handlers/attestation_handlers.rs", "Live attestation endpoint"),
-                ("tools/attestation-verifier/src/main.rs", "Independent verification tool"),
-            ],
-        ),
-    ];
-
-    html! {
-        <div class="tc-source-audit">
-            <h2><i class="fa-solid fa-code"></i>{" Browse Verified Source Code"}</h2>
-            <p class="source-audit-desc">
-                {"These links point to the exact commit ("}
-                <code>{short_hash(commit, 8)}</code>
-                {") running in the attested enclave. Read the code to verify how your data is handled."}
-            </p>
-            <div class="source-audit-grid">
-                { for sections.iter().map(|(label, icon, files)| {
-                    html! {
-                        <div class="source-audit-card">
-                            <div class="source-audit-card-header">
-                                <i class={*icon}></i>
-                                <span>{*label}</span>
-                            </div>
-                            <div class="source-audit-files">
-                                { for files.iter().map(|(path, desc)| {
-                                    let url = format!("{}/{}", tree, path);
-                                    html! {
-                                        <a href={url} target="_blank" rel="noopener noreferrer" class="source-audit-file">
-                                            <span class="source-audit-filename">{path.rsplit('/').next().unwrap_or(path)}</span>
-                                            <span class="source-audit-filedesc">{*desc}</span>
-                                        </a>
-                                    }
-                                })}
-                            </div>
-                        </div>
-                    }
-                })}
-            </div>
-        </div>
-    }
-}
-
-// =============================================
 // STYLES
 // =============================================
 
@@ -1249,53 +1152,6 @@ const STYLES: &str = r#"
 .tc-page .legal-links a { color: rgba(255,255,255,0.35); text-decoration: none; }
 .tc-page .legal-links a:hover { color: #1E90FF; }
 
-/* ---- Source Audit ---- */
-.tc-source-audit {
-    margin-top: 3rem;
-    padding: 2rem;
-    background: rgba(30, 144, 255, 0.04);
-    border: 1px solid rgba(30, 144, 255, 0.12);
-    border-radius: 12px;
-}
-.tc-source-audit h2 {
-    font-size: 1.15rem; color: #e0e0e0; margin: 0 0 0.5rem;
-}
-.tc-source-audit h2 i { color: #1E90FF; margin-right: 0.4rem; }
-.source-audit-desc {
-    font-size: 0.85rem; color: #888; margin-bottom: 1.5rem; line-height: 1.5;
-}
-.source-audit-desc code {
-    background: rgba(255,255,255,0.08); padding: 0.15rem 0.4rem; border-radius: 3px;
-    font-size: 0.8rem; color: #aaa;
-}
-.source-audit-grid {
-    display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
-    gap: 1rem;
-}
-.source-audit-card {
-    background: rgba(255,255,255,0.03); border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 8px; padding: 1rem; display: flex; flex-direction: column; gap: 0.6rem;
-}
-.source-audit-card-header {
-    display: flex; align-items: center; gap: 0.5rem;
-    font-size: 0.85rem; color: #ccc; font-weight: 500;
-}
-.source-audit-card-header i { color: #1E90FF; font-size: 0.8rem; width: 1rem; text-align: center; }
-.source-audit-files { display: flex; flex-direction: column; gap: 0.35rem; }
-.source-audit-file {
-    display: flex; flex-direction: column; gap: 0.1rem;
-    padding: 0.4rem 0.6rem; border-radius: 5px;
-    background: rgba(255,255,255,0.02); text-decoration: none;
-    transition: background 0.15s;
-}
-.source-audit-file:hover { background: rgba(30, 144, 255, 0.08); }
-.source-audit-filename {
-    font-size: 0.78rem; color: #60a5fa; font-family: monospace;
-}
-.source-audit-filedesc {
-    font-size: 0.72rem; color: #666;
-}
-
 @media (max-width: 768px) {
     .tc-page { padding: 3rem 1rem 2rem; }
     .tc-header h1 { font-size: 1.4rem; }
@@ -1303,6 +1159,5 @@ const STYLES: &str = r#"
     .att-row { flex-direction: column; gap: 0.05rem; align-items: flex-start; }
     .att-label { min-width: auto; text-align: left; }
     .inter-flow-cols { flex-direction: column; gap: 0.3rem; }
-    .source-audit-grid { grid-template-columns: 1fr; }
 }
 "#;

--- a/terraform/modules/compute/user_data.sh
+++ b/terraform/modules/compute/user_data.sh
@@ -892,6 +892,13 @@ if [ -n "$BUCKET" ] && aws s3 ls "s3://$BUCKET/config/.env" 2>/dev/null; then
     aws s3 cp "s3://$BUCKET/config/.env" /opt/lightfriend/.env
     chmod 600 /opt/lightfriend/.env
 
+    # Download Tesla private key (for vehicle command signing proxy)
+    if aws s3 ls "s3://$BUCKET/config/tesla_private_key.pem" 2>/dev/null; then
+        aws s3 cp "s3://$BUCKET/config/tesla_private_key.pem" /opt/lightfriend/seed/tesla_private_key.pem
+        chmod 600 /opt/lightfriend/seed/tesla_private_key.pem
+        echo "Tesla private key downloaded to seed directory"
+    fi
+
     EIF_MANIFEST_KEY="deploy/eif-$INSTANCE_ID.json"
     EIF_MANIFEST=""
     echo "Polling s3://$BUCKET/$EIF_MANIFEST_KEY for CI-built EIF metadata..."
@@ -997,6 +1004,12 @@ EOF
     # Re-download .env
     aws s3 cp "s3://$BUCKET/config/.env" /opt/lightfriend/.env
     chmod 600 /opt/lightfriend/.env
+
+    # Re-download Tesla private key
+    if aws s3 ls "s3://$BUCKET/config/tesla_private_key.pem" 2>/dev/null; then
+        aws s3 cp "s3://$BUCKET/config/tesla_private_key.pem" /opt/lightfriend/seed/tesla_private_key.pem
+        chmod 600 /opt/lightfriend/seed/tesla_private_key.pem
+    fi
 
     if [ "$RESTORE_TYPE" = "seed" ]; then
         # Seed mode: seed SQL should already be at /opt/lightfriend/seed/lightfriend_db.sql


### PR DESCRIPTION
## Summary

- **Tesla HTTP proxy**: Build Go binary into enclave Dockerfile, run via supervisord, persist private key via S3
- **Telegram connection monitor**: Fix room flooding bug that caused auth flow to hang - monitor was sending invalid commands every 5s, pushing the bridge's "Logged in" response out of the message check window. Also made sync errors non-fatal and narrowed error patterns
- **Telegram proxy**: Switch from DataImpulse rotating residential to Webshare static residential proxy (env updated in S3)
- **Bridge room search**: Replace Synapse admin API with standard Matrix user directory search
- **Activity feed**: Add real-time activity feed via Server-Sent Events
- **Classification prompt**: Link to exact GitHub line instead of inlining
- **Clippy fixes**: Fix let_and_return, for_kv_map, too_many_arguments warnings

## Test plan

- [ ] Verify Tesla vehicle commands work after deploy (wake, lock, climate)
- [ ] Test Telegram connection flow end-to-end (login link, phone, code, completion)
- [ ] Verify bridge room search returns results
- [ ] Check activity feed SSE endpoint