### PR TITLE
Anti-hallucination: id-verifier, sender-match hardening, digest broadening

### DIFF
--- a/backend/pg_migrations/00000000000024_strict_identity_and_mailbox/down.sql
+++ b/backend/pg_migrations/00000000000024_strict_identity_and_mailbox/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE imap_connection
+DROP CONSTRAINT IF EXISTS unique_email_mailbox_global;

--- a/backend/pg_migrations/00000000000024_strict_identity_and_mailbox/up.sql
+++ b/backend/pg_migrations/00000000000024_strict_identity_and_mailbox/up.sql
@@ -1,0 +1,8 @@
+-- Normalize existing mailbox descriptions before adding global uniqueness.
+UPDATE imap_connection
+SET description = lower(trim(description))
+WHERE description IS NOT NULL;
+
+-- Enforce that one mailbox can belong to only one user at a time.
+ALTER TABLE imap_connection
+ADD CONSTRAINT unique_email_mailbox_global UNIQUE (description);

--- a/backend/src/agent_core.rs
+++ b/backend/src/agent_core.rs
@@ -113,6 +113,15 @@ Nearby places: {nearby_places}
 - When they ask about events or calendar, use query_event.
 - Messages with sender "You" (or marked [you sent]) are messages the user sent. When summarizing back to the user, refer to these as "you said/sent..." - NEVER as "I said/sent...". You (lightfriend) did not send any of those messages; the user did. Use first-person "I" only for yourself (the assistant). Address the user in second-person ("you").
 
+### CRITICAL - Anti-fabrication for digests and summaries:
+When the user asks for a "digest", "summary", "recap", "what's new", "what did I miss", "catch me up", "any messages", "any emails", or anything similar:
+1. You MUST call a query_* tool (query_message, query_event, etc.) first. No exceptions.
+2. Report ONLY items that appeared in the tool result. Never invent senders, subjects, names, dollar amounts, companies, phone numbers, or any content that wasn't in the tool output.
+3. If the tool returns "No messages found matching your query" or an empty list, your answer is exactly "No recent messages." (or "No new events", etc.). Do NOT invent example items. Do NOT add "here's what I would expect". Do NOT give plausible-sounding placeholders.
+4. If the tool returns N items and N < 3, don't pad the answer to look fuller. List exactly those N items and stop.
+5. Never include a sender, subject, or company name the user hasn't seen before WITHOUT it being literally in the tool output. If in doubt, say "nothing new".
+6. Do not describe a "typical" digest or "what a digest would look like". If there's no data, say so.
+
 Provide all information immediately; only ask follow-ups when confirming send/create actions. Call all needed tools upfront.
 Never fabricate information. Use tools to fetch latest information before answering.
 User information: {user_given_info}

--- a/backend/src/agent_core.rs
+++ b/backend/src/agent_core.rs
@@ -122,6 +122,21 @@ When the user asks for a "digest", "summary", "recap", "what's new", "what did I
 5. Never include a sender, subject, or company name the user hasn't seen before WITHOUT it being literally in the tool output. If in doubt, say "nothing new".
 6. Do not describe a "typical" digest or "what a digest would look like". If there's no data, say so.
 
+### CRITICAL - [id=N] citation format (enforced by post-processor):
+Every time you mention a specific message, event, or person that came from a tool result, you MUST cite its `[id=N]` from the tool output on the SAME LINE as the item. This is not optional — a verifier strips any line whose `[id=N]` doesn't match what the tool returned, and the user sees a "(Stripped unverified items — ask to retry)" footer when that happens.
+Format rules:
+- Use EXACTLY the literal syntax `[id=N]` — square brackets, lowercase `id`, equals sign, digits, no spaces. NOT `(id 123)`, `[ID:123]`, `id=123`, or any other variant. Only `[id=123]` is recognized.
+- Put each item on its own line (one item per line) with its `[id=N]` on the SAME line. Don't bundle multiple items into one paragraph — the verifier strips by line, so one bad id would drop a whole paragraph of good items.
+- Copy the `N` exactly as the tool returned it. Don't renumber, round, or invent. If you don't have an id for something, don't mention it.
+- Lines without any `[id=N]` (headers, counts, closing CTAs) pass through untouched — you don't need to cite an id when the line doesn't reference a specific tool result.
+Example good output:
+  `2 msgs today:`
+  `1. Alice — quarterly review [id=7821]`
+  `2. Bob — sounds good [id=7820]`
+  `Reply to dig in.`
+Example BAD output that gets stripped:
+  `1. Alice — quarterly review (id 7821) AND Bob — sounds good [id=7820]` (wrong format on one id + multiple items on one line)
+
 Provide all information immediately; only ask follow-ups when confirming send/create actions. Call all needed tools upfront.
 Never fabricate information. Use tools to fetch latest information before answering.
 User information: {user_given_info}

--- a/backend/src/ai_config.rs
+++ b/backend/src/ai_config.rs
@@ -84,7 +84,7 @@ impl AiConfig {
             (AiProvider::OpenRouter, ModelPurpose::Default) => "openai/gpt-4o-2024-11-20",
             (AiProvider::Tinfoil, ModelPurpose::Default) => "kimi-k2-5",
             // Voice: fast non-reasoning model for low-latency responses
-            (AiProvider::Tinfoil, ModelPurpose::Voice) => "llama3-3-70b",
+            (AiProvider::Tinfoil, ModelPurpose::Voice) => "gemma4-31b",
             (AiProvider::OpenRouter, ModelPurpose::Voice) => "openai/gpt-4o-2024-11-20",
         }
     }
@@ -119,6 +119,20 @@ impl AiConfig {
                     let sanitized = Self::sanitize_content(&content);
                     msg["content"] = serde_json::Value::String(sanitized);
                 }
+            }
+        }
+    }
+
+    /// Apply model-specific request overrides for providers that expose extra controls.
+    fn apply_model_specific_request_overrides(body: &mut serde_json::Value) {
+        let model = body
+            .get("model")
+            .and_then(|m| m.as_str())
+            .unwrap_or_default();
+
+        if model == "gemma4-31b" {
+            if let Some(obj) = body.as_object_mut() {
+                obj.insert("enable_thinking".into(), serde_json::json!(false));
             }
         }
     }
@@ -165,6 +179,7 @@ impl AiConfig {
                 }
                 // Sanitize message content for Tinfoil
                 Self::sanitize_request_body(&mut body);
+                Self::apply_model_specific_request_overrides(&mut body);
                 client
                     .post(&url)
                     .header("Authorization", format!("Bearer {}", api_key))
@@ -551,6 +566,7 @@ impl AiConfig {
                 obj.remove("max_tokens");
             }
             Self::sanitize_request_body(&mut body);
+            Self::apply_model_specific_request_overrides(&mut body);
 
             let response = client
                 .post(&url)

--- a/backend/src/api/twilio_sms.rs
+++ b/backend/src/api/twilio_sms.rs
@@ -1332,19 +1332,32 @@ pub async fn process_sms(
         }
     }
 
-    // id-verifier: strip any line where the model cited an ontology
+    // id-verifier: drop any line where the model cited an ontology
     // [id=N] that doesn't match a row returned by any tool call in
     // this turn. Runs BEFORE truncation so the user-visible footer
-    // (appended when anything is stripped) participates in the SMS
+    // (appended when anything is dropped) participates in the SMS
     // length budget. Runs only on success paths — failure messages
     // are canned strings without ids.
-    let final_response = if !fail {
+    //
+    // Returns two parallel versions:
+    //   - `user_facing`: what to send over SMS. `[id=N]` markers
+    //     stripped, footer appended if any line was dropped.
+    //   - `history`: what to store in conversation history. `[id=N]`
+    //     markers PRESERVED so the LLM sees its own correctly-
+    //     formatted prior turn next time and keeps citing ids. If we
+    //     stored the stripped version, the model would quickly "learn"
+    //     from its own history that citations are optional and drop
+    //     them — which would defeat the verifier on the next turn.
+    //
+    // `history_for_storage` is used later when we build
+    // `assistant_message`. It falls back to `final_response` on the
+    // failure path (no verification ran, so history == user_facing).
+    let (final_response, history_for_storage) = if !fail {
         let valid_ids = crate::utils::id_verifier::collect_tool_result_ids(&loop_messages);
-        let (verified, _stripped) =
-            crate::utils::id_verifier::verify_and_strip(&final_response, &valid_ids);
-        verified
+        let verified = crate::utils::id_verifier::verify(&final_response, &valid_ids);
+        (verified.user_facing, verified.history)
     } else {
-        final_response
+        (final_response.clone(), final_response)
     };
 
     // Ensure response is within SMS character limit (truncate text BEFORE adding media)
@@ -1390,10 +1403,15 @@ pub async fn process_sms(
         .unwrap()
         .as_secs() as i32;
 
+    // History storage uses the verifier's `history` version (tag
+    // markers preserved, no footer, un-truncated). Next turn the LLM
+    // will see its own correctly-cited prior turn and keep citing
+    // ids — if we stored `final_response_with_notice` instead, the
+    // stripped view would train the model to drop citations.
     let assistant_message = crate::pg_models::NewPgMessageHistory {
         user_id: user.id,
         role: "assistant".to_string(),
-        encrypted_content: final_response_with_notice.clone(),
+        encrypted_content: history_for_storage.clone(),
         tool_name: None,
         tool_call_id: None,
         tool_calls_json: None,

--- a/backend/src/api/twilio_sms.rs
+++ b/backend/src/api/twilio_sms.rs
@@ -1332,6 +1332,21 @@ pub async fn process_sms(
         }
     }
 
+    // id-verifier: strip any line where the model cited an ontology
+    // [id=N] that doesn't match a row returned by any tool call in
+    // this turn. Runs BEFORE truncation so the user-visible footer
+    // (appended when anything is stripped) participates in the SMS
+    // length budget. Runs only on success paths — failure messages
+    // are canned strings without ids.
+    let final_response = if !fail {
+        let valid_ids = crate::utils::id_verifier::collect_tool_result_ids(&loop_messages);
+        let (verified, _stripped) =
+            crate::utils::id_verifier::verify_and_strip(&final_response, &valid_ids);
+        verified
+    } else {
+        final_response
+    };
+
     // Ensure response is within SMS character limit (truncate text BEFORE adding media)
     let final_response = if !fail {
         // For successful responses, use LLM condensing if needed

--- a/backend/src/handlers/imap_handlers.rs
+++ b/backend/src/handlers/imap_handlers.rs
@@ -257,6 +257,94 @@ pub fn parse_imap_message(
     })
 }
 
+/// Pure helper: given a sender's envelope `from` email address and
+/// display name, attempt to match it to one of the user's ontology
+/// Persons via the email channel handle. Returns the matched
+/// `person.id` on success or `None` if no match applies.
+///
+/// `own_emails` is the set of email addresses belonging to the user's
+/// own connected IMAP accounts (lowercased). Match behavior:
+///
+/// 1. **Self-sender guard** — if `from_email` matches any of
+///    `own_emails`, return `None`. The sender is the user themselves
+///    (legitimately self-sent, or phishing spoofing their address).
+///    We can't trust the `From:` header to identify a contact.
+///
+/// 2. **Self-handle guard** — skip any channel whose handle matches
+///    one of `own_emails`. Defends against the user misconfiguring a
+///    Person with their own email as the handle, which would
+///    otherwise collapse every incoming email onto that Person via
+///    substring containment.
+///
+/// 3. **Email handle match** — if the handle looks like an email
+///    address (contains `@`), require **exact** (case-insensitive)
+///    equality with `from_email`. No substring containment on
+///    emails — a handle of `"bob@gmail.com"` must not match a
+///    sender `"rob@gmail.com"`, and a handle of `"gmail.com"` must
+///    not match every gmail user.
+///
+/// 4. **Name handle match** — if the handle is a plain name (no
+///    `@`), do case-insensitive substring match against `from_name`
+///    (the envelope's display name). Requires the handle to be at
+///    least 3 characters long, otherwise a one-letter handle like
+///    `"a"` would match almost any name.
+///
+/// Returns the first Person whose channels produce a match, in the
+/// order `persons` were passed. Returns `None` if nothing matches.
+pub fn match_email_sender_to_person(
+    from_email: Option<&str>,
+    from_name: Option<&str>,
+    persons: &[crate::models::ontology_models::PersonWithChannels],
+    own_emails: &std::collections::HashSet<String>,
+) -> Option<i32> {
+    let from_lower = from_email.unwrap_or("").to_lowercase();
+    let from_name_lower = from_name.unwrap_or("").to_lowercase();
+
+    // Self-sender guard: if the sender is the user themselves (real
+    // or spoofed), skip the person match entirely.
+    if !from_lower.is_empty() && own_emails.iter().any(|own| from_lower.contains(own)) {
+        return None;
+    }
+
+    for pwc in persons {
+        for channel in &pwc.channels {
+            if channel.platform != "email" {
+                continue;
+            }
+            let Some(handle) = channel.handle.as_ref() else {
+                continue;
+            };
+            let handle_lower = handle.to_lowercase();
+            if handle_lower.is_empty() {
+                continue;
+            }
+
+            // Self-handle guard: a Person whose channel IS the user's
+            // own email must never match anything.
+            if own_emails.contains(&handle_lower) {
+                continue;
+            }
+
+            // Split matching by field. Emails require exact equality;
+            // plain-text names allow substring.
+            let handle_is_email = handle_lower.contains('@');
+            let email_match = if handle_is_email {
+                !from_lower.is_empty() && from_lower == handle_lower
+            } else {
+                false
+            };
+            let name_match = !handle_is_email
+                && handle_lower.chars().count() >= 3
+                && from_name_lower.contains(&handle_lower);
+
+            if email_match || name_match {
+                return Some(pwc.person.id);
+            }
+        }
+    }
+    None
+}
+
 /// Insert an email preview into `ont_messages` and emit an ontology
 /// change event so rules can react. Idempotent: if a message with the
 /// same `email_<uid>` room_id already exists for this user (e.g. the
@@ -293,27 +381,21 @@ pub async fn insert_email_into_ontology(
         Err(e) => return Err(format!("Failed to check existing email message: {}", e)),
     }
 
-    // Match an ontology Person for the sender based on email channel handle.
-    let mut matched_person_id: Option<i32> = None;
-    let from_lower = preview.from_email.as_deref().unwrap_or("").to_lowercase();
-    let from_name_lower = preview.from.as_deref().unwrap_or("").to_lowercase();
-    for pwc in persons {
-        for channel in &pwc.channels {
-            if channel.platform == "email" {
-                if let Some(ref handle) = channel.handle {
-                    let handle_lower = handle.to_lowercase();
-                    if from_lower.contains(&handle_lower) || from_name_lower.contains(&handle_lower)
-                    {
-                        matched_person_id = Some(pwc.person.id);
-                        break;
-                    }
-                }
-            }
-        }
-        if matched_person_id.is_some() {
-            break;
-        }
-    }
+    // Look up the user's own connected IMAP email addresses so
+    // `match_email_sender_to_person` can refuse self-email matches.
+    let own_emails: std::collections::HashSet<String> = state
+        .user_repository
+        .get_all_imap_credentials(user_id)
+        .ok()
+        .map(|conns| conns.into_iter().map(|c| c.email.to_lowercase()).collect())
+        .unwrap_or_default();
+
+    let matched_person_id = match_email_sender_to_person(
+        preview.from_email.as_deref(),
+        preview.from.as_deref(),
+        persons,
+        &own_emails,
+    );
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/backend/src/jobs/scheduler.rs
+++ b/backend/src/jobs/scheduler.rs
@@ -1234,10 +1234,14 @@ pub async fn build_digest_for_user(
         Vec::new()
     };
 
-    // -------- Section 4: FYI (medium urgency) --------
+    // -------- Section 4: FYI (medium + low urgency) --------
+    // We include "low" here too because otherwise users whose emails all get
+    // classified at the non-urgent end (which is most normal traffic: bills,
+    // newsletters, routine updates) would never see anything in a digest and
+    // think the feature is broken. Spam is still filtered by category below.
     let mut fyi_msgs = state
         .ontology_repository
-        .get_pending_messages_by_urgency(user_id, &["medium"], since_window, 30)
+        .get_pending_messages_by_urgency(user_id, &["medium", "low"], since_window, 30)
         .unwrap_or_default();
 
     // -------- Filter: drop messages the user has already seen via bridge read receipts --------
@@ -1419,13 +1423,26 @@ pub async fn build_digest_for_user(
 /// Deliver smart digests: check which users have pending unhandled messages
 /// and deliver a sectioned recap at the user's local digest window.
 async fn deliver_smart_digests(state: &Arc<AppState>) {
-    let users = match state.ontology_repository.get_users_with_pending_digests() {
+    // Iterate EVERY user with digest_enabled=true, not just users with
+    // pending high/medium messages. The old `get_users_with_pending_digests`
+    // gate silently dropped users whose emails all classified as
+    // urgency='low' or 'none' — they would never hit their scheduled
+    // digest time even though new emails were flowing in. The entry gate
+    // must be "is the user opted in", not "does the user have high-urgency
+    // traffic right now".
+    //
+    // `build_digest_for_user` already returns `None` for a truly empty
+    // digest, so this change doesn't produce noise for users with no
+    // activity — it just gives users with any scanned activity a real
+    // shot at receiving their scheduled digest.
+    let all_users = match state.user_core.get_all_users() {
         Ok(u) => u,
         Err(e) => {
-            error!("Failed to get users with pending digests: {}", e);
+            error!("Failed to get all users for digest delivery: {}", e);
             return;
         }
     };
+    let users: Vec<i32> = all_users.into_iter().map(|u| u.id).collect();
 
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -41,6 +41,7 @@ pub mod utils {
     pub mod country;
     pub mod email;
     pub mod encryption;
+    pub mod id_verifier;
     pub mod imap_idle;
     pub mod matrix_auth;
     pub mod notification_utils;

--- a/backend/src/ontology/registry.rs
+++ b/backend/src/ontology/registry.rs
@@ -78,7 +78,15 @@ static MESSAGE_PROPS: &[PropertyDef] = &[
 
 static MESSAGE_DEF: ObjectTypeDef = ObjectTypeDef {
     name: "Message",
-    description: "Query recent messages. All filters are optional - omit to get recent messages.",
+    description: "Query recent messages across ALL platforms — WhatsApp, Telegram, Signal, AND EMAIL. \
+        Use this tool for ANY question about the user's messages, chats, inbox, emails, digests, or \
+        'what came in'. Pass platform='email' to see only emails, or omit platform to see everything. \
+        NEVER answer from conversation history alone — always call this tool fresh, even if a prior \
+        assistant turn in history already contained a digest (that history is stale and may be hours old). \
+        Results are sorted most-recent-first and include a timestamp per row. If the default limit \
+        doesn't reach far enough back for the user's question (e.g. 'yesterday', 'past few days'), \
+        call again with a larger `limit`. Each result includes a stable [id=N] you MUST cite in your \
+        answer — the caller uses it to verify nothing was fabricated.",
     properties: MESSAGE_PROPS,
     linkable_to: &[],
 };
@@ -168,6 +176,28 @@ impl OntologyRegistry {
                 ..Default::default()
             }),
         );
+
+        // Message-specific: let the LLM control how many of the most
+        // recent messages it wants back. Single dial — no separate time
+        // window — matches Palantir's Object query tool pattern. If the
+        // result ends before the user's desired range, the LLM can call
+        // again with a bigger limit.
+        if obj.name == "Message" {
+            properties.insert(
+                "limit".to_string(),
+                Box::new(types::JSONSchemaDefine {
+                    schema_type: Some(types::JSONSchemaType::Number),
+                    description: Some(
+                        "Max messages to return, most recent first (default 20, max 100). \
+                         Increase when the result doesn't reach far enough back for the \
+                         user's question (e.g. 'yesterday' or 'past few days'). Each result \
+                         has a timestamp so you can tell whether to request more."
+                            .to_string(),
+                    ),
+                    ..Default::default()
+                }),
+            );
+        }
 
         // Add "linked_entities" array param from linkable_to
         if !obj.linkable_to.is_empty() {

--- a/backend/src/ontology/registry.rs
+++ b/backend/src/ontology/registry.rs
@@ -85,8 +85,12 @@ static MESSAGE_DEF: ObjectTypeDef = ObjectTypeDef {
         assistant turn in history already contained a digest (that history is stale and may be hours old). \
         Results are sorted most-recent-first and include a timestamp per row. If the default limit \
         doesn't reach far enough back for the user's question (e.g. 'yesterday', 'past few days'), \
-        call again with a larger `limit`. Each result includes a stable [id=N] you MUST cite in your \
-        answer — the caller uses it to verify nothing was fabricated.",
+        call again with a larger `limit`. \
+        Each result row starts with a stable `[id=N]`. When you write your answer to the user, you \
+        MUST copy that `[id=N]` verbatim onto the SAME LINE as the item you reference. Literal square \
+        brackets, lowercase `id=`, digits. No other format works — a post-processor strips any line \
+        whose id doesn't match what this tool returned. One item per line so a bad citation can't drop \
+        a paragraph of good items. Lines without an id (counts, headers, closings) pass through fine.",
     properties: MESSAGE_PROPS,
     linkable_to: &[],
 };

--- a/backend/src/repositories/user_core.rs
+++ b/backend/src/repositories/user_core.rs
@@ -17,6 +17,13 @@ define_sql_function! {
     fn lower(x: Text) -> Text;
 }
 
+fn normalize_phone(phone: &str) -> String {
+    phone
+        .chars()
+        .filter(|c| c.is_ascii_digit() || *c == '+')
+        .collect()
+}
+
 /// Type alias for tier3 settings
 pub type Tier3Settings = (
     Option<String>,
@@ -251,15 +258,16 @@ impl UserCoreOps for UserCore {
 
     fn find_by_phone_number(&self, phone_number: &str) -> Result<Option<User>, DieselError> {
         let mut pg_conn = self.pg_pool.get().expect("Failed to get PG connection");
-        let cleaned_phone = phone_number
-            .chars()
-            .filter(|c| c.is_ascii_digit() || *c == '+')
-            .collect::<String>();
-        let user = users::table
+        let cleaned_phone = normalize_phone(phone_number);
+        let matches = users::table
             .filter(users::phone_number.eq(cleaned_phone))
-            .first::<User>(&mut pg_conn)
-            .optional()?;
-        Ok(user)
+            .limit(2)
+            .load::<User>(&mut pg_conn)?;
+        match matches.len() {
+            0 => Ok(None),
+            1 => Ok(matches.into_iter().next()),
+            _ => Err(DieselError::RollbackTransaction),
+        }
     }
 
     fn find_by_magic_token(&self, token: &str) -> Result<Option<User>, DieselError> {
@@ -644,7 +652,7 @@ impl UserCoreOps for UserCore {
     fn phone_number_exists(&self, search_phone: &str) -> Result<bool, DieselError> {
         let mut pg_conn = self.pg_pool.get().expect("Failed to get PG connection");
         let existing_user: Option<User> = users::table
-            .filter(users::phone_number.eq(search_phone))
+            .filter(users::phone_number.eq(normalize_phone(search_phone)))
             .first::<User>(&mut pg_conn)
             .optional()?;
         Ok(existing_user.is_some())

--- a/backend/src/repositories/user_repository.rs
+++ b/backend/src/repositories/user_repository.rs
@@ -12,7 +12,7 @@ pub struct UsageDataPoint {
 
 use crate::{
     pg_models::{NewPgBridge, NewPgImapConnection, NewPgUsageLog, PgBridge},
-    pg_schema::usage_logs,
+    pg_schema::{imap_connection, usage_logs},
     PgDbPool,
 };
 
@@ -200,7 +200,6 @@ impl UserRepository {
         imap_server: Option<&str>,
         imap_port: Option<u16>,
     ) -> Result<i32, diesel::result::Error> {
-        use crate::pg_schema::imap_connection;
         let mut conn = self.pool.get().expect("Failed to get DB connection");
 
         // Encrypt password
@@ -212,10 +211,23 @@ impl UserRepository {
             .unwrap()
             .as_secs() as i32;
 
+        let normalized_email = email.trim().to_lowercase();
+
+        // Fail closed if this mailbox is already attached to another user.
+        let mailbox_owner = imap_connection::table
+            .filter(imap_connection::description.eq(&normalized_email))
+            .filter(imap_connection::user_id.ne(user_id))
+            .select(imap_connection::user_id)
+            .first::<i32>(&mut conn)
+            .optional()?;
+        if mailbox_owner.is_some() {
+            return Err(diesel::result::Error::RollbackTransaction);
+        }
+
         // Check if this email already exists for this user
         let existing = imap_connection::table
             .filter(imap_connection::user_id.eq(user_id))
-            .filter(imap_connection::description.eq(email))
+            .filter(imap_connection::description.eq(&normalized_email))
             .first::<crate::pg_models::PgImapConnection>(&mut conn)
             .optional()?;
 
@@ -224,7 +236,7 @@ impl UserRepository {
             diesel::update(
                 imap_connection::table
                     .filter(imap_connection::user_id.eq(user_id))
-                    .filter(imap_connection::description.eq(email)),
+                    .filter(imap_connection::description.eq(&normalized_email)),
             )
             .set((
                 imap_connection::encrypted_password.eq(&encrypted_password),
@@ -249,7 +261,7 @@ impl UserRepository {
                 status: "active".to_string(),
                 last_update: current_time,
                 created_on: current_time,
-                description: email.to_string(),
+                description: normalized_email,
                 imap_server: imap_server.map(|s| s.to_string()),
                 imap_port: imap_port.map(|p| p as i32),
             };
@@ -266,17 +278,21 @@ impl UserRepository {
         &self,
         user_id: i32,
     ) -> Result<Option<ImapCredentials>, diesel::result::Error> {
-        use crate::pg_schema::imap_connection;
         let mut conn = self.pool.get().expect("Failed to get DB connection");
 
-        // Get the active IMAP connection for the user
-        let imap_conn = imap_connection::table
+        // Fail closed if the user has multiple active accounts and the caller
+        // didn't specify which one to use.
+        let mut imap_conns = imap_connection::table
             .filter(imap_connection::user_id.eq(user_id))
             .filter(imap_connection::status.eq("active"))
-            .first::<crate::pg_models::PgImapConnection>(&mut conn)
-            .optional()?;
+            .limit(2)
+            .load::<crate::pg_models::PgImapConnection>(&mut conn)?;
 
-        if let Some(conn) = imap_conn {
+        if imap_conns.len() > 1 {
+            return Err(diesel::result::Error::RollbackTransaction);
+        }
+
+        if let Some(conn) = imap_conns.pop() {
             // Decrypt the password
             match decrypt(&conn.encrypted_password) {
                 Ok(decrypted_password) => Ok(Some((
@@ -435,10 +451,11 @@ impl UserRepository {
     ) -> Result<Option<ImapConnectionInfo>, diesel::result::Error> {
         use crate::pg_schema::imap_connection;
         let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let normalized_email = email.trim().to_lowercase();
 
         let imap_conn = imap_connection::table
             .filter(imap_connection::user_id.eq(user_id))
-            .filter(imap_connection::description.eq(email))
+            .filter(imap_connection::description.eq(normalized_email))
             .filter(imap_connection::status.eq("active"))
             .first::<crate::pg_models::PgImapConnection>(&mut conn)
             .optional()?;

--- a/backend/src/tools/ontology.rs
+++ b/backend/src/tools/ontology.rs
@@ -120,16 +120,29 @@ fn query_message(
     let sender_filter = param_str(params, "sender_name");
     let query_filter = param_str(params, "query");
 
+    // Single agent-controlled dial: how many of the most-recent messages
+    // to return. Matches Palantir's Object query tool pattern — no
+    // separate time-window dial. If the returned batch doesn't reach far
+    // enough back for the user's question, the LLM can iterate with a
+    // larger `limit`. Clamped 1..=100 so a bad tool call can't DoS the DB.
+    let limit: i64 = params
+        .get("limit")
+        .and_then(|v| v.as_i64())
+        .unwrap_or(20)
+        .clamp(1, 100);
+
+    // since_ts=0 effectively disables the time filter on the shared
+    // `get_recent_messages_filtered` helper; the row ordering and limit
+    // give us the "N most recent" semantics we want.
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs() as i32;
-    let twelve_hours_ago = now - 12 * 3600;
 
     let plat = platform_filter.as_deref().filter(|p| *p != "all");
     let messages: Vec<OntMessage> = state
         .ontology_repository
-        .get_recent_messages_filtered(user_id, plat, twelve_hours_ago, 20)
+        .get_recent_messages_filtered(user_id, plat, 0, limit)
         .map_err(|e| format!("Failed to query messages: {}", e))?;
 
     // Apply sender_name filter
@@ -162,13 +175,32 @@ fn query_message(
         messages
     };
 
-    let messages: Vec<&OntMessage> = messages.iter().take(20).collect();
+    let messages: Vec<&OntMessage> = messages.iter().take(limit as usize).collect();
 
     if messages.is_empty() {
         return Ok("No messages found matching your query.".to_string());
     }
 
-    let mut output = format!("Found {} message(s):\n\n", messages.len());
+    // Format a relative age like "5m ago" / "2h ago" / "3d ago" so the
+    // LLM can tell whether this batch reaches far enough back for the
+    // user's question, or whether to call again with a larger `limit`.
+    let age_str = |created_at: i32| -> String {
+        let secs = (now - created_at).max(0);
+        if secs < 60 {
+            format!("{}s ago", secs)
+        } else if secs < 3600 {
+            format!("{}m ago", secs / 60)
+        } else if secs < 86400 {
+            format!("{}h ago", secs / 3600)
+        } else {
+            format!("{}d ago", secs / 86400)
+        }
+    };
+
+    let mut output = format!(
+        "Found {} message(s), most recent first:\n\n",
+        messages.len()
+    );
 
     for (i, m) in messages.iter().enumerate() {
         let content_preview: String = m.content.chars().take(100).collect();
@@ -180,9 +212,10 @@ fn query_message(
             format!("[from {}]", m.sender_name)
         };
         output.push_str(&format!(
-            "{}. [id={}] {} via {} - \"{}\"",
+            "{}. [id={}] ({}) {} via {} - \"{}\"",
             i + 1,
             m.id,
+            age_str(m.created_at),
             sender_label,
             m.platform,
             content_preview
@@ -191,6 +224,16 @@ fn query_message(
         if i + 1 < messages.len() {
             output.push_str("\n\n");
         }
+    }
+
+    // Tell the LLM explicitly whether it saw all the rows for this
+    // filter set or whether there may be more — important for the
+    // "call me again with a larger limit" pattern to actually work.
+    if messages.len() == limit as usize {
+        output.push_str(&format!(
+            "\n\nResult hit the limit of {}. If you need to reach further back in time, call this tool again with a larger `limit`.",
+            limit
+        ));
     }
 
     Ok(output)

--- a/backend/src/utils/id_verifier.rs
+++ b/backend/src/utils/id_verifier.rs
@@ -57,83 +57,126 @@ pub fn collect_tool_result_ids(messages: &[ChatCompletionMessage]) -> HashSet<i6
     ids
 }
 
-/// Verify that every `[id=N]` cited in `response` appears in
-/// `valid_ids`, then strip the `[id=N]` markers themselves from
-/// surviving lines so the user never sees our internal citation
-/// plumbing. Any line containing at least one unverified id is
-/// dropped entirely (both verification and tag removal happen in one
-/// pass). If anything was dropped, a user-visible footer is appended.
-/// Lines with no ids at all are preserved as-is (counts, headers,
-/// closing CTAs).
+/// Result of running the id verifier over an LLM response.
 ///
-/// Returns `(verified_response, something_was_stripped_for_verification)`.
+/// The verifier produces two parallel outputs from a single pass over
+/// the response so that the user-facing version and the conversation-
+/// history version can diverge on tag handling without a second walk.
 ///
-/// Note: the returned bool is ONLY true when a LINE was dropped for
-/// failing verification. Stripping the `[id=N]` tags themselves from
-/// kept lines is silent — the user should never know we were citing
-/// ids in the first place.
-pub fn verify_and_strip(response: &str, valid_ids: &HashSet<i64>) -> (String, bool) {
+/// Both versions share the same line filtering: any line containing
+/// at least one `[id=N]` that isn't in the trusted set is dropped
+/// from BOTH outputs. The difference is in what kept lines look like:
+///
+/// - `user_facing` has the `[id=N]` tags stripped (internal plumbing
+///   the user should never see) and, if at least one line was
+///   dropped, an explanatory footer appended.
+/// - `history` keeps the `[id=N]` tags intact so that next turn the
+///   LLM sees its own correctly-formatted prior answer in conversation
+///   history and keeps citing ids. Without this, the model would
+///   quickly "learn" from stripped history that citations are
+///   optional and drift into uncited prose — which defeats the
+///   verifier entirely on the next turn.
+#[derive(Debug, Clone)]
+pub struct VerifiedResponse {
+    /// Send this to the user. `[id=N]` tags stripped, footer appended
+    /// if any line was dropped for failing verification.
+    pub user_facing: String,
+
+    /// Store this in conversation history. `[id=N]` tags preserved
+    /// exactly as the model wrote them on kept lines. No footer —
+    /// footers are system messages, not the LLM's words.
+    pub history: String,
+
+    /// True if at least one line was dropped for failing verification.
+    pub dropped_line: bool,
+}
+
+/// Verify every `[id=N]` cited in `response` against `valid_ids` and
+/// produce both a user-facing and a history-bound version of the text.
+/// See [`VerifiedResponse`] for the rationale behind keeping the two
+/// versions distinct.
+///
+/// Invariants:
+/// - Lines with no ids at all pass through both versions unchanged.
+/// - A line where ANY cited id is not in `valid_ids` is dropped from
+///   both versions (a line mixing real and fake ids can't be trusted
+///   in parts).
+/// - Kept lines' `[id=N]` tags are preserved in `history` and removed
+///   in `user_facing`. Tag removal also trims dangling separators
+///   ("Alice - ", "Alice —") so the user-facing line looks clean.
+/// - Triple newlines left behind by dropping sparse lines are
+///   collapsed to doubles in both versions.
+/// - The footer is appended to `user_facing` only, and only when at
+///   least one line was dropped.
+pub fn verify(response: &str, valid_ids: &HashSet<i64>) -> VerifiedResponse {
     let re = id_re();
     let mut dropped_line = false;
 
-    let kept: Vec<String> = response
-        .lines()
-        .filter_map(|line| {
-            // Collect all ids cited on this line.
-            let ids_on_line: Vec<i64> = re
-                .captures_iter(line)
-                .filter_map(|cap| cap[1].parse::<i64>().ok())
-                .collect();
+    let mut history_lines: Vec<String> = Vec::new();
+    let mut user_lines: Vec<String> = Vec::new();
 
-            if ids_on_line.is_empty() {
-                // No ids on this line — nothing to verify, pass through.
-                return Some(line.to_string());
-            }
+    for line in response.lines() {
+        let ids_on_line: Vec<i64> = re
+            .captures_iter(line)
+            .filter_map(|cap| cap[1].parse::<i64>().ok())
+            .collect();
 
-            // Every id on this line must be in the trusted set.
-            let all_ok = ids_on_line.iter().all(|id| valid_ids.contains(id));
-            if !all_ok {
-                dropped_line = true;
-                return None;
-            }
+        if ids_on_line.is_empty() {
+            // No ids on this line — pass through both versions.
+            history_lines.push(line.to_string());
+            user_lines.push(line.to_string());
+            continue;
+        }
 
-            // Line verified. Strip the `[id=N]` markers themselves
-            // from the user-visible output — internal plumbing, not
-            // noise the user should see. Also collapse any double
-            // spaces or trailing spaces that removing tokens leaves
-            // behind, and trim trailing punctuation artifacts like
-            // " - ." or " —".
-            let cleaned = re.replace_all(line, "");
-            let collapsed = cleaned.split_whitespace().collect::<Vec<&str>>().join(" ");
-            // Trim trailing dangling separators commonly left after
-            // an id was at the end of the line (e.g. "Alice - " or
-            // "Alice —").
-            let trimmed = collapsed
-                .trim_end_matches(|c: char| {
-                    c.is_whitespace() || c == '-' || c == '—' || c == '–' || c == ':'
-                })
-                .to_string();
-            Some(trimmed)
-        })
-        .collect();
+        let all_ok = ids_on_line.iter().all(|id| valid_ids.contains(id));
+        if !all_ok {
+            dropped_line = true;
+            continue; // drop from both
+        }
 
-    let mut result = kept.join("\n");
+        // History version keeps the line exactly as written so the
+        // LLM sees its own [id=N] format on the next turn.
+        history_lines.push(line.to_string());
 
-    // Clean up any run of 3+ newlines left behind by dropping sparse
-    // lines from a previously well-spaced response.
-    while result.contains("\n\n\n") {
-        result = result.replace("\n\n\n", "\n\n");
+        // User-facing version strips the tags and cleans up
+        // dangling separators left behind.
+        let cleaned = re.replace_all(line, "");
+        let collapsed = cleaned.split_whitespace().collect::<Vec<&str>>().join(" ");
+        let trimmed = collapsed
+            .trim_end_matches(|c: char| {
+                c.is_whitespace() || c == '-' || c == '—' || c == '–' || c == ':'
+            })
+            .to_string();
+        user_lines.push(trimmed);
     }
-    result = result.trim_end().to_string();
+
+    // Collapse 3+ blank lines left over from dropping, and trim the
+    // trailing whitespace. Same transform for both versions — they
+    // have the same line structure, only the content of kept lines
+    // differs.
+    fn collapse(lines: Vec<String>) -> String {
+        let mut s = lines.join("\n");
+        while s.contains("\n\n\n") {
+            s = s.replace("\n\n\n", "\n\n");
+        }
+        s.trim_end().to_string()
+    }
+
+    let history = collapse(history_lines);
+    let mut user_facing = collapse(user_lines);
 
     if dropped_line {
-        if !result.is_empty() {
-            result.push_str("\n\n");
+        if !user_facing.is_empty() {
+            user_facing.push_str("\n\n");
         }
-        result.push_str(STRIPPED_FOOTER);
+        user_facing.push_str(STRIPPED_FOOTER);
     }
 
-    (result, dropped_line)
+    VerifiedResponse {
+        user_facing,
+        history,
+        dropped_line,
+    }
 }
 
 // Tests live in `backend/tests/id_verifier_test.rs` — this repo keeps

--- a/backend/src/utils/id_verifier.rs
+++ b/backend/src/utils/id_verifier.rs
@@ -1,0 +1,141 @@
+//! Post-hoc verifier for LLM responses that cite ontology ids via the
+//! `[id=N]` convention.
+//!
+//! Why this exists: the system prompt and tool descriptions instruct the
+//! model to cite `[id=N]` for every item it mentions in a digest/summary,
+//! so that any claim about the user's data can be traced back to a row
+//! the tool actually returned. Without post-processing, this is an honor
+//! system — a confused or adversarially-jailbroken model could still
+//! output a fabricated `[id=99999]` for an email that doesn't exist.
+//!
+//! This module parses the model's final response for `[id=N]` tokens,
+//! cross-checks each id against the set of ids returned by any tool
+//! call in the current turn, and strips any line whose ids don't all
+//! verify. If stripping happened, a short user-visible footer is
+//! appended so the user knows something was redacted — which gives
+//! them a natural hook to ask a follow-up and dig in.
+//!
+//! Deliberately silent: no tracing, no alerting, no logging. The user
+//! asked for this to be invisible to ops and visible only to the user
+//! whose answer got trimmed.
+
+use openai_api_rs::v1::chat_completion::{ChatCompletionMessage, Content, MessageRole};
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::OnceLock;
+
+/// Shared compiled regex — `[id=<digits>]` with no whitespace.
+fn id_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| Regex::new(r"\[id=(\d+)\]").expect("static regex compiles"))
+}
+
+/// User-visible footer appended to a response when the verifier had to
+/// strip at least one line containing an unverified id. `pub` so the
+/// integration tests can assert against it directly.
+/// Kept short — SMS chars are expensive.
+pub const STRIPPED_FOOTER: &str = "(Stripped unverified items — ask to retry)";
+
+/// Collect every `[id=N]` that appears in any tool-role message in the
+/// current turn. These are the "trusted" ids the model is allowed to
+/// cite in its final response — everything else is a fabrication.
+pub fn collect_tool_result_ids(messages: &[ChatCompletionMessage]) -> HashSet<i64> {
+    let re = id_re();
+    let mut ids = HashSet::new();
+    for msg in messages {
+        if msg.role != MessageRole::tool {
+            continue;
+        }
+        if let Content::Text(text) = &msg.content {
+            for cap in re.captures_iter(text) {
+                if let Ok(n) = cap[1].parse::<i64>() {
+                    ids.insert(n);
+                }
+            }
+        }
+    }
+    ids
+}
+
+/// Verify that every `[id=N]` cited in `response` appears in
+/// `valid_ids`, then strip the `[id=N]` markers themselves from
+/// surviving lines so the user never sees our internal citation
+/// plumbing. Any line containing at least one unverified id is
+/// dropped entirely (both verification and tag removal happen in one
+/// pass). If anything was dropped, a user-visible footer is appended.
+/// Lines with no ids at all are preserved as-is (counts, headers,
+/// closing CTAs).
+///
+/// Returns `(verified_response, something_was_stripped_for_verification)`.
+///
+/// Note: the returned bool is ONLY true when a LINE was dropped for
+/// failing verification. Stripping the `[id=N]` tags themselves from
+/// kept lines is silent — the user should never know we were citing
+/// ids in the first place.
+pub fn verify_and_strip(response: &str, valid_ids: &HashSet<i64>) -> (String, bool) {
+    let re = id_re();
+    let mut dropped_line = false;
+
+    let kept: Vec<String> = response
+        .lines()
+        .filter_map(|line| {
+            // Collect all ids cited on this line.
+            let ids_on_line: Vec<i64> = re
+                .captures_iter(line)
+                .filter_map(|cap| cap[1].parse::<i64>().ok())
+                .collect();
+
+            if ids_on_line.is_empty() {
+                // No ids on this line — nothing to verify, pass through.
+                return Some(line.to_string());
+            }
+
+            // Every id on this line must be in the trusted set.
+            let all_ok = ids_on_line.iter().all(|id| valid_ids.contains(id));
+            if !all_ok {
+                dropped_line = true;
+                return None;
+            }
+
+            // Line verified. Strip the `[id=N]` markers themselves
+            // from the user-visible output — internal plumbing, not
+            // noise the user should see. Also collapse any double
+            // spaces or trailing spaces that removing tokens leaves
+            // behind, and trim trailing punctuation artifacts like
+            // " - ." or " —".
+            let cleaned = re.replace_all(line, "");
+            let collapsed = cleaned.split_whitespace().collect::<Vec<&str>>().join(" ");
+            // Trim trailing dangling separators commonly left after
+            // an id was at the end of the line (e.g. "Alice - " or
+            // "Alice —").
+            let trimmed = collapsed
+                .trim_end_matches(|c: char| {
+                    c.is_whitespace() || c == '-' || c == '—' || c == '–' || c == ':'
+                })
+                .to_string();
+            Some(trimmed)
+        })
+        .collect();
+
+    let mut result = kept.join("\n");
+
+    // Clean up any run of 3+ newlines left behind by dropping sparse
+    // lines from a previously well-spaced response.
+    while result.contains("\n\n\n") {
+        result = result.replace("\n\n\n", "\n\n");
+    }
+    result = result.trim_end().to_string();
+
+    if dropped_line {
+        if !result.is_empty() {
+            result.push_str("\n\n");
+        }
+        result.push_str(STRIPPED_FOOTER);
+    }
+
+    (result, dropped_line)
+}
+
+// Tests live in `backend/tests/id_verifier_test.rs` — this repo keeps
+// all tests as integration tests under `tests/` (no inline
+// `#[cfg(test)] mod tests` in source files, per CLAUDE.md).

--- a/backend/tests/id_verifier_test.rs
+++ b/backend/tests/id_verifier_test.rs
@@ -1,0 +1,181 @@
+//! Tests for the id-verifier that post-processes LLM responses.
+//!
+//! The verifier enforces the `[id=N]` citation contract: the model is
+//! instructed (via system prompt + tool description) to cite `[id=N]`
+//! after every item it mentions, and this module catches cases where
+//! the model fabricates an id that no tool call returned. Any line
+//! containing at least one unverified id is stripped entirely and a
+//! short user-visible footer is appended so the user knows something
+//! was redacted.
+
+use backend::utils::id_verifier::{collect_tool_result_ids, verify_and_strip, STRIPPED_FOOTER};
+use openai_api_rs::v1::chat_completion::{ChatCompletionMessage, Content, MessageRole};
+use std::collections::HashSet;
+
+fn tool_msg(text: &str) -> ChatCompletionMessage {
+    ChatCompletionMessage {
+        role: MessageRole::tool,
+        content: Content::Text(text.to_string()),
+        name: None,
+        tool_calls: None,
+        tool_call_id: Some("call_test".to_string()),
+    }
+}
+
+fn user_msg(text: &str) -> ChatCompletionMessage {
+    ChatCompletionMessage {
+        role: MessageRole::user,
+        content: Content::Text(text.to_string()),
+        name: None,
+        tool_calls: None,
+        tool_call_id: None,
+    }
+}
+
+#[test]
+fn collect_ids_extracts_from_tool_messages_only() {
+    // Only tool-role messages are trusted. A user turn mentioning an
+    // id (e.g. echoing back a previous digest) must NOT be treated as
+    // a valid citation source.
+    let msgs = vec![
+        user_msg("User said something mentioning [id=999]"),
+        tool_msg("Found 2 messages:\n1. [id=101] via email\n2. [id=102] via whatsapp"),
+        tool_msg("[id=103] and [id=104]"),
+    ];
+    let ids = collect_tool_result_ids(&msgs);
+    assert_eq!(ids.len(), 4);
+    assert!(ids.contains(&101));
+    assert!(ids.contains(&102));
+    assert!(ids.contains(&103));
+    assert!(ids.contains(&104));
+    assert!(!ids.contains(&999));
+}
+
+#[test]
+fn verify_strips_id_tags_from_surviving_lines() {
+    // All ids valid → no line dropped, but the `[id=N]` tags
+    // themselves are silently removed so the user never sees our
+    // internal citation plumbing in the final SMS.
+    let valid: HashSet<i64> = [101, 102].into_iter().collect();
+    let resp =
+        "You have 2 messages:\n1. Alice - quarterly review [id=101]\n2. Bob - sounds good [id=102]";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(!dropped, "no line was dropped for verification");
+    assert!(
+        !out.contains("[id="),
+        "all id tags must be removed from final output, got: {out:?}"
+    );
+    assert!(out.contains("Alice"));
+    assert!(out.contains("Bob"));
+    assert!(out.contains("quarterly review"));
+    assert!(out.contains("sounds good"));
+    // Footer should NOT appear — nothing was dropped.
+    assert!(!out.contains(STRIPPED_FOOTER));
+}
+
+#[test]
+fn verify_trims_dangling_separator_left_behind_by_tag_removal() {
+    // When a line ends with " - [id=N]" or " — [id=N]", removing the
+    // tag must not leave a dangling punctuation artifact.
+    let valid: HashSet<i64> = [101].into_iter().collect();
+    let resp = "1. Alice — [id=101]";
+    let (out, _dropped) = verify_and_strip(resp, &valid);
+    assert!(!out.contains("[id="));
+    assert!(out.contains("Alice"));
+    for line in out.lines() {
+        let last_char = line.chars().last();
+        assert!(
+            !matches!(last_char, Some('—') | Some('-') | Some('–') | Some(':')),
+            "line '{line}' has dangling separator after tag removal"
+        );
+    }
+}
+
+#[test]
+fn verify_drops_line_with_unknown_id_and_appends_footer() {
+    let valid: HashSet<i64> = [101].into_iter().collect();
+    let resp = "You have 2 messages:\n1. Alice [id=101]\n2. Phantom [id=999]";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(dropped);
+    assert!(out.contains("Alice"));
+    assert!(!out.contains("[id="), "id tags must be stripped: {out:?}");
+    assert!(!out.contains("Phantom"));
+    assert!(!out.contains("999"));
+    assert!(out.contains(STRIPPED_FOOTER));
+}
+
+#[test]
+fn verify_drops_line_even_when_one_id_is_valid() {
+    // A line citing both a real id AND a fake id is dropped wholesale
+    // — we can't trust any part of it because the model mixed fact
+    // and fabrication in one sentence.
+    let valid: HashSet<i64> = [101].into_iter().collect();
+    let resp = "1. See [id=101] and [id=999] together";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(dropped);
+    assert!(!out.contains("See"));
+    assert!(!out.contains("[id="));
+    assert!(out.contains(STRIPPED_FOOTER));
+}
+
+#[test]
+fn verify_keeps_lines_without_ids() {
+    // Headers, counts, and prose lines without `[id=N]` references
+    // are not in scope for verification and pass through unchanged.
+    // Surviving lines WITH ids get their tags stripped.
+    let valid: HashSet<i64> = [101].into_iter().collect();
+    let resp =
+        "Summary for today:\n\n1. Alice - review [id=101]\n2. Phantom [id=999]\n\nReply to dig in.";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(dropped);
+    assert!(out.contains("Summary for today:"));
+    assert!(out.contains("Alice"));
+    assert!(out.contains("review"));
+    assert!(!out.contains("[id="), "id tags must be stripped: {out:?}");
+    assert!(!out.contains("Phantom"));
+    assert!(out.contains("Reply to dig in."));
+    assert!(out.contains(STRIPPED_FOOTER));
+}
+
+#[test]
+fn verify_empty_response_with_all_invalid_becomes_footer_only() {
+    let valid: HashSet<i64> = HashSet::new();
+    let resp = "1. Phantom [id=999]";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(dropped);
+    // Footer alone — no preceding whitespace.
+    assert_eq!(out, STRIPPED_FOOTER);
+}
+
+#[test]
+fn verify_no_tool_calls_means_any_id_is_unverified() {
+    // When no tools were called, `valid_ids` is empty and any cited
+    // id must be dropped as fabrication.
+    let valid: HashSet<i64> = HashSet::new();
+    let resp = "1. Totally real thing [id=42]";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(dropped);
+    assert!(!out.contains("[id="));
+    assert!(!out.contains("Totally real thing"));
+}
+
+#[test]
+fn verify_collapses_triple_newlines_after_dropping() {
+    // When dropping a line from a previously well-spaced response,
+    // we shouldn't leave a run of 3+ blank lines behind.
+    let valid: HashSet<i64> = [101].into_iter().collect();
+    let resp = "Line A [id=101]\n\nLine B [id=999]\n\nLine C [id=101]";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(dropped);
+    assert!(!out.contains("\n\n\n"));
+    assert!(!out.contains("[id="));
+}
+
+#[test]
+fn verify_no_ids_anywhere_is_passthrough() {
+    let valid: HashSet<i64> = HashSet::new();
+    let resp = "Hello, how are you today?";
+    let (out, dropped) = verify_and_strip(resp, &valid);
+    assert!(!dropped);
+    assert_eq!(out, resp);
+}

--- a/backend/tests/id_verifier_test.rs
+++ b/backend/tests/id_verifier_test.rs
@@ -1,14 +1,14 @@
 //! Tests for the id-verifier that post-processes LLM responses.
 //!
-//! The verifier enforces the `[id=N]` citation contract: the model is
-//! instructed (via system prompt + tool description) to cite `[id=N]`
-//! after every item it mentions, and this module catches cases where
-//! the model fabricates an id that no tool call returned. Any line
-//! containing at least one unverified id is stripped entirely and a
-//! short user-visible footer is appended so the user knows something
-//! was redacted.
+//! The verifier enforces the `[id=N]` citation contract. It returns
+//! two parallel versions of each response:
+//!   - `user_facing`: what gets sent over SMS. `[id=N]` tags stripped,
+//!     footer appended if any line was dropped for failing verification.
+//!   - `history`: what gets stored in conversation history. `[id=N]`
+//!     tags preserved so the LLM sees its own correctly-formatted
+//!     prior turn next time and keeps citing ids.
 
-use backend::utils::id_verifier::{collect_tool_result_ids, verify_and_strip, STRIPPED_FOOTER};
+use backend::utils::id_verifier::{collect_tool_result_ids, verify, STRIPPED_FOOTER};
 use openai_api_rs::v1::chat_completion::{ChatCompletionMessage, Content, MessageRole};
 use std::collections::HashSet;
 
@@ -51,38 +51,43 @@ fn collect_ids_extracts_from_tool_messages_only() {
     assert!(!ids.contains(&999));
 }
 
+// =============================================================================
+// user_facing output: tag stripping
+// =============================================================================
+
 #[test]
-fn verify_strips_id_tags_from_surviving_lines() {
+fn verify_strips_id_tags_from_user_facing_when_all_valid() {
     // All ids valid → no line dropped, but the `[id=N]` tags
-    // themselves are silently removed so the user never sees our
-    // internal citation plumbing in the final SMS.
+    // themselves are silently removed from user_facing so the user
+    // never sees our internal citation plumbing.
     let valid: HashSet<i64> = [101, 102].into_iter().collect();
     let resp =
         "You have 2 messages:\n1. Alice - quarterly review [id=101]\n2. Bob - sounds good [id=102]";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(!dropped, "no line was dropped for verification");
+    let v = verify(resp, &valid);
+    assert!(!v.dropped_line, "no line was dropped for verification");
     assert!(
-        !out.contains("[id="),
-        "all id tags must be removed from final output, got: {out:?}"
+        !v.user_facing.contains("[id="),
+        "all id tags must be removed from user_facing, got: {:?}",
+        v.user_facing
     );
-    assert!(out.contains("Alice"));
-    assert!(out.contains("Bob"));
-    assert!(out.contains("quarterly review"));
-    assert!(out.contains("sounds good"));
+    assert!(v.user_facing.contains("Alice"));
+    assert!(v.user_facing.contains("Bob"));
+    assert!(v.user_facing.contains("quarterly review"));
+    assert!(v.user_facing.contains("sounds good"));
     // Footer should NOT appear — nothing was dropped.
-    assert!(!out.contains(STRIPPED_FOOTER));
+    assert!(!v.user_facing.contains(STRIPPED_FOOTER));
 }
 
 #[test]
-fn verify_trims_dangling_separator_left_behind_by_tag_removal() {
+fn verify_trims_dangling_separator_after_tag_removal_in_user_facing() {
     // When a line ends with " - [id=N]" or " — [id=N]", removing the
     // tag must not leave a dangling punctuation artifact.
     let valid: HashSet<i64> = [101].into_iter().collect();
     let resp = "1. Alice — [id=101]";
-    let (out, _dropped) = verify_and_strip(resp, &valid);
-    assert!(!out.contains("[id="));
-    assert!(out.contains("Alice"));
-    for line in out.lines() {
+    let v = verify(resp, &valid);
+    assert!(!v.user_facing.contains("[id="));
+    assert!(v.user_facing.contains("Alice"));
+    for line in v.user_facing.lines() {
         let last_char = line.chars().last();
         assert!(
             !matches!(last_char, Some('—') | Some('-') | Some('–') | Some(':')),
@@ -91,17 +96,61 @@ fn verify_trims_dangling_separator_left_behind_by_tag_removal() {
     }
 }
 
+// =============================================================================
+// history output: tags KEPT so the LLM sees its own citations next turn
+// =============================================================================
+
 #[test]
-fn verify_drops_line_with_unknown_id_and_appends_footer() {
+fn verify_history_preserves_tags_when_all_valid() {
+    let valid: HashSet<i64> = [101, 102].into_iter().collect();
+    let resp = "1. Alice [id=101]\n2. Bob [id=102]";
+    let v = verify(resp, &valid);
+    assert!(!v.dropped_line);
+    // history must contain both tags verbatim — this is what the LLM
+    // sees on the next turn as its own prior response.
+    assert!(v.history.contains("[id=101]"));
+    assert!(v.history.contains("[id=102]"));
+    // history must NOT contain the footer — that's system noise not
+    // written by the LLM.
+    assert!(!v.history.contains(STRIPPED_FOOTER));
+}
+
+#[test]
+fn verify_history_drops_invalid_lines_same_as_user_facing() {
+    // Dropped lines are dropped from BOTH versions — we don't want
+    // the LLM seeing its own fabrications in history either,
+    // otherwise it might reuse the fake ids next turn.
+    let valid: HashSet<i64> = [101].into_iter().collect();
+    let resp = "1. Alice [id=101]\n2. Phantom [id=999]";
+    let v = verify(resp, &valid);
+    assert!(v.dropped_line);
+    assert!(v.history.contains("[id=101]"));
+    assert!(v.history.contains("Alice"));
+    assert!(!v.history.contains("[id=999]"));
+    assert!(!v.history.contains("Phantom"));
+    // Footer is user-only, not in history.
+    assert!(!v.history.contains(STRIPPED_FOOTER));
+}
+
+// =============================================================================
+// Line-dropping + footer (user_facing only)
+// =============================================================================
+
+#[test]
+fn verify_drops_line_with_unknown_id_and_appends_footer_to_user_facing() {
     let valid: HashSet<i64> = [101].into_iter().collect();
     let resp = "You have 2 messages:\n1. Alice [id=101]\n2. Phantom [id=999]";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(dropped);
-    assert!(out.contains("Alice"));
-    assert!(!out.contains("[id="), "id tags must be stripped: {out:?}");
-    assert!(!out.contains("Phantom"));
-    assert!(!out.contains("999"));
-    assert!(out.contains(STRIPPED_FOOTER));
+    let v = verify(resp, &valid);
+    assert!(v.dropped_line);
+    assert!(v.user_facing.contains("Alice"));
+    assert!(
+        !v.user_facing.contains("[id="),
+        "id tags must be stripped from user_facing: {:?}",
+        v.user_facing
+    );
+    assert!(!v.user_facing.contains("Phantom"));
+    assert!(!v.user_facing.contains("999"));
+    assert!(v.user_facing.contains(STRIPPED_FOOTER));
 }
 
 #[test]
@@ -111,40 +160,57 @@ fn verify_drops_line_even_when_one_id_is_valid() {
     // and fabrication in one sentence.
     let valid: HashSet<i64> = [101].into_iter().collect();
     let resp = "1. See [id=101] and [id=999] together";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(dropped);
-    assert!(!out.contains("See"));
-    assert!(!out.contains("[id="));
-    assert!(out.contains(STRIPPED_FOOTER));
+    let v = verify(resp, &valid);
+    assert!(v.dropped_line);
+    assert!(!v.user_facing.contains("See"));
+    assert!(!v.user_facing.contains("[id="));
+    assert!(v.user_facing.contains(STRIPPED_FOOTER));
+    // history also dropped it — and still has no tags left because
+    // the whole line is gone.
+    assert!(!v.history.contains("See"));
+    assert!(!v.history.contains("[id=101]"));
+    assert!(!v.history.contains("[id=999]"));
 }
 
 #[test]
 fn verify_keeps_lines_without_ids() {
     // Headers, counts, and prose lines without `[id=N]` references
-    // are not in scope for verification and pass through unchanged.
-    // Surviving lines WITH ids get their tags stripped.
+    // are not in scope for verification and pass through unchanged
+    // in both versions.
     let valid: HashSet<i64> = [101].into_iter().collect();
     let resp =
         "Summary for today:\n\n1. Alice - review [id=101]\n2. Phantom [id=999]\n\nReply to dig in.";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(dropped);
-    assert!(out.contains("Summary for today:"));
-    assert!(out.contains("Alice"));
-    assert!(out.contains("review"));
-    assert!(!out.contains("[id="), "id tags must be stripped: {out:?}");
-    assert!(!out.contains("Phantom"));
-    assert!(out.contains("Reply to dig in."));
-    assert!(out.contains(STRIPPED_FOOTER));
+    let v = verify(resp, &valid);
+    assert!(v.dropped_line);
+
+    // user_facing: header + CTA pass through, tag stripped, footer.
+    assert!(v.user_facing.contains("Summary for today:"));
+    assert!(v.user_facing.contains("Alice"));
+    assert!(v.user_facing.contains("review"));
+    assert!(!v.user_facing.contains("[id="));
+    assert!(!v.user_facing.contains("Phantom"));
+    assert!(v.user_facing.contains("Reply to dig in."));
+    assert!(v.user_facing.contains(STRIPPED_FOOTER));
+
+    // history: same filtering, but [id=101] preserved, no footer.
+    assert!(v.history.contains("Summary for today:"));
+    assert!(v.history.contains("[id=101]"));
+    assert!(v.history.contains("Alice"));
+    assert!(!v.history.contains("Phantom"));
+    assert!(v.history.contains("Reply to dig in."));
+    assert!(!v.history.contains(STRIPPED_FOOTER));
 }
 
 #[test]
-fn verify_empty_response_with_all_invalid_becomes_footer_only() {
+fn verify_empty_response_with_all_invalid_becomes_footer_only_in_user_facing() {
     let valid: HashSet<i64> = HashSet::new();
     let resp = "1. Phantom [id=999]";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(dropped);
-    // Footer alone — no preceding whitespace.
-    assert_eq!(out, STRIPPED_FOOTER);
+    let v = verify(resp, &valid);
+    assert!(v.dropped_line);
+    // user_facing: footer alone.
+    assert_eq!(v.user_facing, STRIPPED_FOOTER);
+    // history: empty string (no footer, nothing to preserve).
+    assert_eq!(v.history, "");
 }
 
 #[test]
@@ -153,29 +219,38 @@ fn verify_no_tool_calls_means_any_id_is_unverified() {
     // id must be dropped as fabrication.
     let valid: HashSet<i64> = HashSet::new();
     let resp = "1. Totally real thing [id=42]";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(dropped);
-    assert!(!out.contains("[id="));
-    assert!(!out.contains("Totally real thing"));
+    let v = verify(resp, &valid);
+    assert!(v.dropped_line);
+    assert!(!v.user_facing.contains("[id="));
+    assert!(!v.user_facing.contains("Totally real thing"));
+    assert!(!v.history.contains("[id=42]"));
+    assert!(!v.history.contains("Totally real thing"));
 }
 
 #[test]
 fn verify_collapses_triple_newlines_after_dropping() {
     // When dropping a line from a previously well-spaced response,
-    // we shouldn't leave a run of 3+ blank lines behind.
+    // we shouldn't leave a run of 3+ blank lines behind in either
+    // version.
     let valid: HashSet<i64> = [101].into_iter().collect();
     let resp = "Line A [id=101]\n\nLine B [id=999]\n\nLine C [id=101]";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(dropped);
-    assert!(!out.contains("\n\n\n"));
-    assert!(!out.contains("[id="));
+    let v = verify(resp, &valid);
+    assert!(v.dropped_line);
+    assert!(!v.user_facing.contains("\n\n\n"));
+    assert!(!v.user_facing.contains("[id="));
+    assert!(!v.history.contains("\n\n\n"));
+    assert!(v.history.contains("[id=101]"));
+    assert!(!v.history.contains("[id=999]"));
 }
 
 #[test]
 fn verify_no_ids_anywhere_is_passthrough() {
+    // A response with zero `[id=N]` anywhere is treated as having no
+    // data claims to verify — both versions equal the original.
     let valid: HashSet<i64> = HashSet::new();
     let resp = "Hello, how are you today?";
-    let (out, dropped) = verify_and_strip(resp, &valid);
-    assert!(!dropped);
-    assert_eq!(out, resp);
+    let v = verify(resp, &valid);
+    assert!(!v.dropped_line);
+    assert_eq!(v.user_facing, resp);
+    assert_eq!(v.history, resp);
 }

--- a/backend/tests/sender_match_test.rs
+++ b/backend/tests/sender_match_test.rs
@@ -1,0 +1,290 @@
+//! Tests for `match_email_sender_to_person` — the pure helper that
+//! decides which ontology Person an incoming email should be tagged
+//! with, based on the envelope's `from` address and name.
+//!
+//! The cases here cover the two user-visible bugs we found:
+//!
+//! - Phishing / forwarding that spoofs the `From:` header to the
+//!   user's own email address
+//! - A Person erroneously saved with the user's own email as a
+//!   channel handle (user error in the settings UI)
+//!
+//! plus the general hardening of requiring exact-match on email
+//! handles instead of permissive substring containment.
+
+use backend::handlers::imap_handlers::match_email_sender_to_person;
+use backend::models::ontology_models::{OntChannel, OntPerson, PersonWithChannels};
+use std::collections::HashSet;
+
+fn person(id: i32, name: &str) -> OntPerson {
+    OntPerson {
+        id,
+        user_id: 1,
+        name: name.to_string(),
+        created_at: 0,
+        updated_at: 0,
+    }
+}
+
+fn email_channel(id: i32, person_id: i32, handle: &str) -> OntChannel {
+    OntChannel {
+        id,
+        user_id: 1,
+        person_id,
+        platform: "email".to_string(),
+        handle: Some(handle.to_string()),
+        room_id: None,
+        notification_mode: "default".to_string(),
+        notification_type: "sms".to_string(),
+        notify_on_call: 1,
+        created_at: 0,
+    }
+}
+
+fn pwc(id: i32, name: &str, email_handle: &str) -> PersonWithChannels {
+    PersonWithChannels {
+        person: person(id, name),
+        channels: vec![email_channel(id, id, email_handle)],
+        edits: vec![],
+    }
+}
+
+fn own(emails: &[&str]) -> HashSet<String> {
+    emails.iter().map(|s| s.to_lowercase()).collect()
+}
+
+// =============================================================================
+// Happy path
+// =============================================================================
+
+#[test]
+fn matches_exact_email() {
+    let persons = vec![pwc(1, "Alice", "alice@example.com")];
+    let owns = own(&["me@mydomain.com"]);
+    let id = match_email_sender_to_person(
+        Some("alice@example.com"),
+        Some("Alice Smith"),
+        &persons,
+        &owns,
+    );
+    assert_eq!(id, Some(1));
+}
+
+#[test]
+fn email_match_is_case_insensitive() {
+    let persons = vec![pwc(1, "Alice", "Alice@Example.COM")];
+    let owns = HashSet::new();
+    let id =
+        match_email_sender_to_person(Some("alice@example.com"), Some("Alice"), &persons, &owns);
+    assert_eq!(id, Some(1));
+}
+
+#[test]
+fn no_match_when_persons_empty() {
+    let persons: Vec<PersonWithChannels> = vec![];
+    let owns = HashSet::new();
+    let id =
+        match_email_sender_to_person(Some("anyone@nowhere.com"), Some("Anyone"), &persons, &owns);
+    assert_eq!(id, None);
+}
+
+// =============================================================================
+// Self-sender guard: phishing spoof + forwarding
+// =============================================================================
+
+#[test]
+fn refuses_to_match_when_sender_is_user_self_email() {
+    // Classic phishing: "From:" header spoofed to the user's own
+    // address. Our matcher must NOT attach this email to any Person,
+    // even if the user mistakenly has a Person configured with their
+    // own email as the channel handle.
+    let persons = vec![pwc(1, "mommy", "rasmus@ahtava.com")];
+    let owns = own(&["rasmus@ahtava.com"]);
+    let id = match_email_sender_to_person(Some("rasmus@ahtava.com"), Some(""), &persons, &owns);
+    assert_eq!(
+        id, None,
+        "self-email sender must not match any Person (phishing guard)"
+    );
+}
+
+#[test]
+fn refuses_to_match_when_sender_matches_one_of_multiple_own_emails() {
+    // Users with multiple connected IMAP accounts should have all of
+    // their own addresses considered "self" for this guard.
+    let persons = vec![pwc(1, "mommy", "primary@me.com")];
+    let owns = own(&["primary@me.com", "work@me.com", "backup@me.com"]);
+    let id = match_email_sender_to_person(Some("work@me.com"), Some(""), &persons, &owns);
+    assert_eq!(id, None);
+}
+
+// =============================================================================
+// Self-handle guard: user misconfigured a Person with their own email
+// =============================================================================
+
+#[test]
+fn skips_channel_whose_handle_is_user_own_email() {
+    // User mistakenly saved a Person with their own email as the
+    // channel handle. Even if the incoming email is genuinely from a
+    // different contact, that misconfigured Person must never be
+    // matched against any sender.
+    let persons = vec![
+        pwc(1, "mommy", "rasmus@ahtava.com"), // user's own email — bogus
+        pwc(2, "alice", "alice@example.com"), // legitimate
+    ];
+    let owns = own(&["rasmus@ahtava.com"]);
+
+    // Sender is Alice — mommy must be skipped, alice must match.
+    let id =
+        match_email_sender_to_person(Some("alice@example.com"), Some("Alice"), &persons, &owns);
+    assert_eq!(id, Some(2));
+}
+
+// =============================================================================
+// Email handle hardening: exact match, not substring
+// =============================================================================
+
+#[test]
+fn email_handle_does_not_substring_match() {
+    // Handle "bob@gmail.com" must NOT match "rob@gmail.com" even
+    // though the bigger string technically contains the handle
+    // (it doesn't, but this test guards against a possible future
+    // refactor that goes back to `contains`).
+    let persons = vec![pwc(1, "Bob", "bob@gmail.com")];
+    let owns = HashSet::new();
+    let id = match_email_sender_to_person(Some("rob@gmail.com"), Some("Rob"), &persons, &owns);
+    assert_eq!(id, None);
+}
+
+#[test]
+fn email_handle_does_not_match_longer_sender_containing_handle() {
+    // A partial handle must never match a longer address. Regression
+    // test for the original bug: from_email.contains(handle).
+    let persons = vec![pwc(1, "Bob", "bob@gmail.com")];
+    let owns = HashSet::new();
+    let id =
+        match_email_sender_to_person(Some("bob@gmail.com.evil.com"), Some(""), &persons, &owns);
+    assert_eq!(
+        id, None,
+        "handle 'bob@gmail.com' must NOT substring-match 'bob@gmail.com.evil.com'"
+    );
+}
+
+#[test]
+fn domain_only_handle_does_not_match_every_sender_on_that_domain() {
+    // Historical footgun: a user might try to save "gmail.com" as a
+    // handle hoping to match anyone from gmail. The old code would
+    // collapse every gmail user onto that one Person. New behavior:
+    // the handle looks like an email (contains '@'? no here — so
+    // it's treated as a name). But it's 9 chars so name match would
+    // fire on any sender name containing "gmail.com". This test
+    // documents that we DON'T match it against the from_email field.
+    let persons = vec![pwc(1, "Gmail Bucket", "gmail.com")];
+    let owns = HashSet::new();
+    // Even though from_email contains "gmail.com" literally, handle
+    // is treated as a name (no '@'), and name field doesn't contain it.
+    let id = match_email_sender_to_person(
+        Some("alice@gmail.com"),
+        Some("Alice Smith"),
+        &persons,
+        &owns,
+    );
+    assert_eq!(id, None);
+}
+
+// =============================================================================
+// Name handle match: substring on name field, length guard
+// =============================================================================
+
+#[test]
+fn name_handle_substring_matches_display_name() {
+    let persons = vec![pwc(1, "Alice", "Alice")]; // handle is a name
+    let owns = HashSet::new();
+    let id = match_email_sender_to_person(
+        Some("alice.smith@work.com"),
+        Some("Alice Smith"),
+        &persons,
+        &owns,
+    );
+    assert_eq!(id, Some(1));
+}
+
+#[test]
+fn name_handle_shorter_than_three_chars_never_matches() {
+    // "a" as a handle would match almost every sender name. We
+    // require handles of at least 3 characters for name-substring
+    // matching. This test documents that guard.
+    let persons = vec![pwc(1, "Bucket", "a")];
+    let owns = HashSet::new();
+    let id = match_email_sender_to_person(
+        Some("alice@example.com"),
+        Some("Alice Smith"),
+        &persons,
+        &owns,
+    );
+    assert_eq!(id, None);
+}
+
+#[test]
+fn name_handle_exactly_three_chars_is_allowed() {
+    // Three chars is the minimum. "Ali" matches "Alice Smith".
+    let persons = vec![pwc(1, "Alice", "Ali")];
+    let owns = HashSet::new();
+    let id = match_email_sender_to_person(
+        Some("alice@example.com"),
+        Some("Alice Smith"),
+        &persons,
+        &owns,
+    );
+    assert_eq!(id, Some(1));
+}
+
+// =============================================================================
+// Empty / missing input
+// =============================================================================
+
+#[test]
+fn empty_from_email_and_name_never_matches() {
+    let persons = vec![pwc(1, "Alice", "alice@example.com")];
+    let owns = HashSet::new();
+    let id = match_email_sender_to_person(None, None, &persons, &owns);
+    assert_eq!(id, None);
+}
+
+#[test]
+fn empty_handle_is_skipped() {
+    // A channel with handle = Some("") should not match anything.
+    let mut p = pwc(1, "Alice", "");
+    p.channels[0].handle = Some(String::new());
+    let persons = vec![p];
+    let owns = HashSet::new();
+    let id =
+        match_email_sender_to_person(Some("alice@example.com"), Some("Alice"), &persons, &owns);
+    assert_eq!(id, None);
+}
+
+#[test]
+fn channels_on_non_email_platforms_are_skipped() {
+    // A whatsapp channel should never be considered when matching
+    // an email sender, even if its handle happens to look like an
+    // email.
+    let persons = vec![PersonWithChannels {
+        person: person(1, "Alice"),
+        channels: vec![OntChannel {
+            id: 10,
+            user_id: 1,
+            person_id: 1,
+            platform: "whatsapp".to_string(),
+            handle: Some("alice@example.com".to_string()),
+            room_id: None,
+            notification_mode: "default".to_string(),
+            notification_type: "sms".to_string(),
+            notify_on_call: 1,
+            created_at: 0,
+        }],
+        edits: vec![],
+    }];
+    let owns = HashSet::new();
+    let id =
+        match_email_sender_to_person(Some("alice@example.com"), Some("Alice"), &persons, &owns);
+    assert_eq!(id, None);
+}


### PR DESCRIPTION
## Summary

Follow-up PR to #37 that hardens the LLM response path against three related bugs users reported after the IMAP IDLE rollout:

1. **Digest doesn't fire** — users whose emails all classified as low/none urgency never appeared in the scheduled digest. Fixed by iterating all `digest_enabled` users and including `low` urgency in the FYI section.
2. **Digest contains emails the user doesn't recognize** — most likely LLM fabricating plausible-sounding items when the tool result is sparse or absent. Fixed by adding a post-processor that verifies every `[id=N]` in the final SMS against the ids actually returned by tool calls in the same turn.
3. **Email sender mislabeled as "mommy via email"** — a Person configured with the user's own email address as its channel handle was matching every phishing email spoofing the user's own From header. Fixed by a two-layer guard (self-sender + self-handle) and by replacing substring containment on email handles with exact equality.

## Commits in this PR

- `62a3d1f1` Switch fast Tinfoil path to Gemma 4
- `de76faa4` Tighten digest path against LLM hallucination
- `b82b4aa1` Fail closed on ambiguous identity and mailbox selection
- `352f1ee3` Add id-verifier to post-process LLM responses against tool-returned ids
- `806383b7` id-verifier: preserve [id=N] tags in history, strip only for user
- `16e284da` Harden email sender-to-Person matching against mislabeling

## id-verifier pipeline (the big one)

Model produces response → `verify()` splits into:

- **user_facing**: `[id=N]` tags removed (internal plumbing), lines with unverified ids dropped, footer \`(Stripped unverified items — ask to retry)\` appended if anything was dropped. This is what gets sent over SMS.
- **history**: `[id=N]` tags PRESERVED on kept lines, no footer. This is what gets stored in `message_history`. Critical — storing the stripped version would train the LLM to drop citations next turn, which would defeat the verifier entirely.

## Sender-match hardening

Old matcher: \`from_email.contains(handle)\` — permissive to the point of catastrophic false positives on short or self-email handles.

New matcher (extracted as \`match_email_sender_to_person\`, 15 unit tests):

- Self-sender guard: if from_email matches any of the user's own connected IMAP addresses, return None.
- Self-handle guard: skip any Person channel whose handle is one of the user's own emails.
- Email handles (contain \`@\`): exact equality only, no substring.
- Name handles (no \`@\`): substring against from_name, minimum 3 chars.
- Non-email platforms skipped.
- Empty handles skipped.

## Digest broadening

- \`deliver_smart_digests\` iterates all users with \`digest_enabled=true\` instead of only users returned by \`get_users_with_pending_digests\` (which filtered out anyone whose emails were all low/none urgency — which is most normal traffic).
- \`build_digest_for_user\` includes \`low\` in the FYI section.

## Test plan

- [x] \`cargo test\` — 444 passing locally (up from 417 before)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean locally
- [x] Pre-push hook ran clippy and passed
- [x] New test files: \`backend/tests/id_verifier_test.rs\` (12 tests), \`backend/tests/sender_match_test.rs\` (15 tests)
- [ ] After deploy: send a digest request via SMS, verify response contains no \`[id=\` tokens, and that any "Screened message" entries in the activity feed link to the correct Person
- [ ] After deploy: watch for any \`(Stripped unverified items — ask to retry)\` footer in received SMS — if it appears frequently, the model is citing ids that don't verify