### PR TITLE
ToS compliance, digest summaries, and blog engine

### DIFF
--- a/backend/Cargo.lock
+++ b/backend/Cargo.lock
@@ -512,6 +512,7 @@ dependencies = [
  "openai-api-rs",
  "p256",
  "phonenumber",
+ "pulldown-cmark",
  "quircs",
  "rand 0.8.5",
  "regex",
@@ -523,6 +524,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "serde_yaml",
  "serial_test",
  "sha1",
  "sha2",
@@ -1885,6 +1887,15 @@ dependencies = [
  "typenum",
  "version_check",
  "zeroize",
+]
+
+[[package]]
+name = "getopts"
+version = "0.2.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfe4fbac503b8d1f88e6676011885f34b7174f46e59956bba534ba83abded4df"
+dependencies = [
+ "unicode-width",
 ]
 
 [[package]]
@@ -4233,6 +4244,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags 2.9.0",
+ "getopts",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "pxfm"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5378,6 +5408,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_yaml"
+version = "0.9.34+deprecated"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+dependencies = [
+ "indexmap",
+ "itoa",
+ "ryu",
+ "serde",
+ "unsafe-libyaml",
+]
+
+[[package]]
 name = "serial_test"
 version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6372,6 +6415,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "universal-hash"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6380,6 +6429,12 @@ dependencies = [
  "crypto-common",
  "subtle",
 ]
+
+[[package]]
+name = "unsafe-libyaml"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -66,6 +66,8 @@ hickory-resolver = "0.25"
 phonenumber = "0.3"  # Google libphonenumber port for Rust - handles E.164 parsing and country detection
 rubato = "0.16"  # Audio resampling for voice pipeline (8kHz<->16kHz<->24kHz)
 rocksdb = { version = "0.24", optional = true }
+pulldown-cmark = "0.12"
+serde_yaml = "0.9"
 
 [features]
 default = []

--- a/backend/content/blog/ai-assistant/ai-assistant-via-sms.md
+++ b/backend/content/blog/ai-assistant/ai-assistant-via-sms.md
@@ -1,0 +1,105 @@
+---
+title: "AI Assistant That Works Over SMS"
+slug: "ai-assistant-via-sms"
+description: "Use a full AI assistant from any phone by texting. No app, no internet needed on your phone."
+date: "2026-04-12"
+cluster: "ai-assistant"
+cluster_hub: true
+keywords:
+  - "ai assistant sms"
+  - "ai via text message"
+  - "ai without smartphone"
+  - "sms ai assistant"
+tags:
+  - "ai"
+  - "sms"
+  - "dumbphone"
+schema_type: "Article"
+faqs:
+  - q: "Can I use AI without a smartphone?"
+    a: "Yes. Lightfriend gives you a full AI assistant over SMS. Text it a question and get an answer back as a text message."
+  - q: "What can the AI do?"
+    a: "It can search the web, check the weather, set reminders, summarize your messages, send emails, and control connected devices like Tesla vehicles."
+  - q: "Is it like ChatGPT over text?"
+    a: "Similar, but with integrations. It can actually do things - send messages on your behalf, check your email, set reminders - not just answer questions."
+related_slugs:
+  - "ai-email-on-dumbphone"
+  - "whatsapp-without-smartphone"
+ai_summary: "Lightfriend provides a full AI assistant via SMS. Users text questions or commands to their Lightfriend number and receive responses as text messages. The AI can search the web, check weather, set reminders, send messages across platforms, and manage email."
+---
+
+## The Problem
+
+AI assistants like ChatGPT, Claude, and Gemini require a smartphone or computer. You need an app or a browser. If you carry a basic phone, you have no access to AI.
+
+This is frustrating because AI is genuinely useful for everyday tasks - looking things up, getting quick answers, managing your schedule. But the delivery mechanism (apps on smartphones) excludes anyone who has chosen a simpler phone.
+
+## How Lightfriend Solves This
+
+Lightfriend gives you an AI assistant that works entirely over SMS. You text it, it texts you back. Your phone doesn't need internet, apps, or a screen bigger than a matchbox.
+
+Here's what you can actually do by sending a text:
+
+### Search the Web
+
+Text a question and Lightfriend searches the web in real time using Perplexity and returns a concise answer. No need to open a browser.
+
+"What time does the pharmacy on Main Street close?"
+
+### Check the Weather
+
+Ask about the weather anywhere. Lightfriend returns current conditions or a forecast.
+
+"What's the weather like in Helsinki tomorrow?"
+
+### Set Reminders
+
+Tell it to remind you about something and it will send you an SMS at the right time.
+
+"Remind me to call the dentist tomorrow at 2pm"
+
+### Send Messages Across Platforms
+
+If you've connected WhatsApp, Signal, or Telegram, you can send messages through those platforms by texting Lightfriend.
+
+"Tell Mom on WhatsApp that I'll be late for dinner"
+
+The AI uses fuzzy name matching to find the right person. There's a 60-second delay before sending, so you can cancel if it picked the wrong contact.
+
+### Manage Email
+
+If you've connected an email account, you can read and reply to emails via SMS.
+
+"What emails did I get today?"
+"Reply to the email from John saying I'll review it tomorrow"
+
+### Scan QR Codes
+
+Send a photo of a QR code and Lightfriend reads it and tells you what it contains.
+
+## What You Can't Do
+
+Honesty matters. Here's what Lightfriend's AI cannot do over SMS:
+
+- **No voice or video calls** through messaging platforms
+- **No image generation** - it's text-only
+- **No real-time conversations** - each text is a separate interaction
+- **No app store** - you can't install new capabilities on the fly (though MCP server connections add extensibility)
+
+## How It Actually Works
+
+When you text your Lightfriend number:
+
+1. Your SMS arrives at Lightfriend's server via Twilio
+2. The AI processes your message, considering your profile and connected services
+3. If an action is needed (like sending a WhatsApp message), the AI executes it
+4. The response comes back as an SMS to your phone
+
+The entire system runs inside a sealed computing environment (AWS Nitro Enclave). Your conversations are processed inside this enclave and the code is open source, so you can verify how your data is handled.
+
+## Who This Is For
+
+- People who switched to a dumbphone but still want AI assistance
+- Parents who want a simple phone for their kids but with AI capabilities
+- Anyone who prefers texting over apps
+- Travelers who need quick answers without roaming data

--- a/backend/content/blog/ai-assistant/ai-email-on-dumbphone.md
+++ b/backend/content/blog/ai-assistant/ai-email-on-dumbphone.md
@@ -1,0 +1,96 @@
+---
+title: "How to Manage Email Without a Smartphone"
+slug: "ai-email-on-dumbphone"
+description: "Read, reply to, and send emails from any basic phone using Lightfriend's AI email assistant via SMS."
+date: "2026-04-12"
+cluster: "ai-assistant"
+keywords:
+  - "email without smartphone"
+  - "email on dumbphone"
+  - "manage email via sms"
+  - "email on flip phone"
+tags:
+  - "email"
+  - "ai"
+  - "dumbphone"
+schema_type: "HowTo"
+estimated_time: "PT5M"
+faqs:
+  - q: "Can I check email on a dumbphone?"
+    a: "Yes. Connect your email account to Lightfriend and you can read, reply to, and send emails via text message."
+  - q: "Which email providers work?"
+    a: "Any provider that supports IMAP - Gmail, Outlook, Yahoo, ProtonMail (with bridge), and others."
+  - q: "Can I have multiple email accounts?"
+    a: "Yes. Lightfriend supports multiple IMAP connections per user."
+related_slugs:
+  - "ai-assistant-via-sms"
+  - "whatsapp-without-smartphone"
+hub_slug: "ai-assistant-via-sms"
+ai_summary: "Lightfriend connects to your email via IMAP and lets you read, reply to, and send emails from any phone via SMS. Supports multiple accounts and any IMAP-compatible provider."
+---
+
+## The Problem
+
+Email is essential for work, bills, appointments, and life admin. But checking email requires a smartphone or computer. If you use a basic phone, you either miss important emails or keep a second device around just for email.
+
+Some dumbphones have basic email clients, but they're painful to use - tiny screens, no search, and most can't handle HTML emails or attachments.
+
+## How Lightfriend Solves This
+
+Lightfriend connects to your email accounts via IMAP and makes them accessible over SMS. You text commands and get your email delivered as text messages.
+
+### Reading Email
+
+Text Lightfriend to check your inbox:
+
+"What emails did I get today?"
+"Any emails from my boss?"
+"Show me unread emails"
+
+The AI summarizes your emails and delivers the key information as SMS. No scrolling through a cluttered inbox.
+
+### Replying to Email
+
+Reply to specific emails by telling the AI what to say:
+
+"Reply to the email from Sarah saying I'll be there at 3pm"
+"Respond to the invoice from Acme Corp confirming we'll pay by Friday"
+
+### Sending New Emails
+
+Compose new emails through SMS:
+
+"Send an email to john@example.com saying the meeting is moved to Thursday"
+
+### Smart Prioritization
+
+Lightfriend's AI classifies your incoming emails by urgency. Critical emails (from your boss, your bank, your doctor) get flagged immediately. Newsletters and promotions get filtered into your digest or ignored entirely.
+
+This means you don't get bombarded with every email as an SMS. You only hear about what matters.
+
+## Setting It Up
+
+1. Log into Lightfriend's web dashboard
+2. Go to email settings and add your IMAP connection
+3. Enter your email provider's IMAP settings (Lightfriend auto-detects for major providers like Gmail and Outlook)
+4. Done - you can now manage email via SMS
+
+You can connect multiple email accounts. Each one is accessible through the same SMS interface.
+
+## What Works
+
+| Feature | Supported |
+|---------|-----------|
+| Read emails | Yes |
+| Reply to emails | Yes |
+| Send new emails | Yes |
+| Multiple accounts | Yes |
+| Gmail | Yes |
+| Outlook | Yes |
+| Any IMAP provider | Yes |
+| Attachments | No (text content only) |
+| HTML formatting | Converted to plain text |
+
+## The Privacy Angle
+
+Your email credentials are stored encrypted inside Lightfriend's sealed enclave. The IMAP connection happens from inside the enclave, so your password and email content are never exposed to the operators. The code is open source - you can verify exactly how credentials are stored and used.

--- a/backend/content/blog/comparisons/lightfriend-vs-whatsapp-web.md
+++ b/backend/content/blog/comparisons/lightfriend-vs-whatsapp-web.md
@@ -1,0 +1,95 @@
+---
+title: "Lightfriend vs WhatsApp Web: Which Is Better for Dumbphone Users?"
+slug: "lightfriend-vs-whatsapp-web"
+description: "Comparing Lightfriend's SMS bridge to WhatsApp Web for people who don't carry a smartphone."
+date: "2026-04-12"
+cluster: "comparisons"
+keywords:
+  - "lightfriend vs whatsapp web"
+  - "whatsapp without phone"
+  - "whatsapp web alternative"
+tags:
+  - "comparison"
+  - "whatsapp"
+schema_type: "Article"
+faqs:
+  - q: "Can I use WhatsApp Web without a smartphone?"
+    a: "WhatsApp Web now works without keeping your phone online, but you still need the smartphone for initial setup and periodic re-authentication."
+  - q: "Which is better if I don't have a smartphone at all?"
+    a: "Lightfriend, because it doesn't require a smartphone to be connected at all after initial setup. Messages arrive as SMS on any phone."
+related_slugs:
+  - "whatsapp-without-smartphone"
+  - "ai-assistant-via-sms"
+ai_summary: "WhatsApp Web requires periodic smartphone re-authentication and a computer. Lightfriend bridges WhatsApp to SMS on any phone with no ongoing smartphone requirement. Lightfriend adds AI filtering; WhatsApp Web gives full app experience."
+---
+
+## The Comparison
+
+If you're trying to use WhatsApp without a smartphone, you have two main options: WhatsApp Web (on a computer) or Lightfriend (SMS bridge). Both let you access WhatsApp, but they work very differently.
+
+## WhatsApp Web
+
+**How it works:** Open web.whatsapp.com in a browser on your computer. Scan a QR code with the WhatsApp app on a smartphone. You can now use WhatsApp from your browser.
+
+**Pros:**
+- Full WhatsApp experience - all features, media, stickers, calls
+- Free
+- Real-time chat interface
+- Official, supported by Meta
+
+**Cons:**
+- Requires a computer with internet
+- Still requires a smartphone for authentication (periodic re-linking)
+- Not portable - you're tied to wherever the computer is
+- No notifications when away from the computer
+- Can't use from a basic phone
+
+## Lightfriend
+
+**How it works:** Connect your WhatsApp account once through the web dashboard. Messages arrive as SMS on whatever phone you carry. Reply by text.
+
+**Pros:**
+- Works on any phone with SMS - flip phones, feature phones, anything
+- Portable - your phone goes everywhere
+- AI filters messages by urgency so you're not overwhelmed
+- Also bridges Signal and Telegram in the same interface
+- AI assistant built in (web search, weather, reminders, email)
+
+**Cons:**
+- Monthly cost (paid service)
+- Text-only - no photos, voice messages, or video calls
+- SMS delivery depends on carrier
+- Uses open-source bridge (unofficial client, see Terms for risks)
+
+## Side-by-Side
+
+| Feature | WhatsApp Web | Lightfriend |
+|---------|-------------|-------------|
+| Requires smartphone | Yes (periodic) | Only for initial setup |
+| Works on dumbphone | No | Yes |
+| Portable | No (needs computer) | Yes |
+| Full media support | Yes | No (text only) |
+| Voice/video calls | Yes | No |
+| Group chats | Yes | Yes |
+| AI filtering | No | Yes |
+| Message digests | No | Yes |
+| Other platforms | No | Signal, Telegram, email |
+| Cost | Free | Paid |
+| Official client | Yes | No (open-source bridge) |
+
+## Which Should You Choose?
+
+**Choose WhatsApp Web if:**
+- You have a smartphone but prefer typing on a computer
+- You need full media support (photos, videos, calls)
+- You're mostly at a desk
+
+**Choose Lightfriend if:**
+- You don't want to carry a smartphone at all
+- You want WhatsApp, Signal, AND Telegram in one place
+- You want AI to filter the noise from your messages
+- You want something that works on the move from any phone
+
+## The Honest Take
+
+WhatsApp Web is better if you just want WhatsApp on a bigger screen while your smartphone sits nearby. Lightfriend is better if you're genuinely trying to live without a smartphone. They solve different problems.

--- a/backend/content/blog/messaging/signal-without-smartphone.md
+++ b/backend/content/blog/messaging/signal-without-smartphone.md
@@ -1,0 +1,77 @@
+---
+title: "How to Use Signal Without a Smartphone"
+slug: "signal-without-smartphone"
+description: "Send and receive Signal messages from any basic phone via SMS using Lightfriend's encrypted bridge."
+date: "2026-04-12"
+cluster: "messaging"
+keywords:
+  - "signal without smartphone"
+  - "signal on dumbphone"
+  - "signal on flip phone"
+  - "signal sms bridge"
+tags:
+  - "signal"
+  - "messaging"
+  - "dumbphone"
+  - "privacy"
+schema_type: "HowTo"
+estimated_time: "PT5M"
+faqs:
+  - q: "Can I use Signal on a dumbphone?"
+    a: "Not natively. But Lightfriend bridges Signal to SMS, so you can send and receive Signal messages from any phone."
+  - q: "Is this still encrypted?"
+    a: "Signal messages are end-to-end encrypted between Signal users. The bridge decrypts inside Lightfriend's sealed enclave to convert to SMS. Your messages are never visible to Lightfriend operators."
+  - q: "Do my Signal contacts see my messages normally?"
+    a: "Yes. They see your messages as regular Signal messages."
+related_slugs:
+  - "whatsapp-without-smartphone"
+  - "telegram-without-smartphone"
+hub_slug: "whatsapp-without-smartphone"
+ai_summary: "Lightfriend bridges Signal to SMS. Any phone that can text can send and receive Signal messages. The bridge runs inside a sealed enclave so operators can't read your messages."
+---
+
+## The Problem
+
+Signal is the gold standard for private messaging. But it only works on smartphones and desktops. If you carry a basic phone, you can't use Signal at all. This forces privacy-conscious people to choose between their values (using a minimal phone) and staying connected (using Signal).
+
+## Why This Is Hard
+
+Signal has no SMS fallback. There is no KaiOS app. There is no web-only mode. You need the Signal app on a smartphone, period. The Signal Foundation has no plans to change this.
+
+If you switch to a dumbphone, you lose access to Signal entirely. Your contacts either switch to texting you (unencrypted) or you lose touch.
+
+## How Lightfriend Solves This
+
+Lightfriend runs an open-source Signal bridge inside a sealed computing environment. Here's how it works:
+
+1. **Connect your Signal account** through the Lightfriend web dashboard. This registers Lightfriend as a linked device on your Signal account.
+2. **Messages arrive as SMS.** When someone sends you a Signal message, Lightfriend converts it to SMS and sends it to your phone.
+3. **Reply by text.** Your SMS reply goes back through Signal to the person who messaged you.
+4. **Groups work.** You can read and reply to Signal group conversations.
+
+## What Works
+
+| Feature | Works? |
+|---------|--------|
+| Receive text messages | Yes |
+| Send text messages | Yes |
+| Group messages | Yes |
+| Receive photos (as descriptions) | Yes |
+| Voice/video calls | No |
+| Disappearing messages | Messages are delivered then purged |
+
+## Privacy Inside the Bridge
+
+The obvious question: if Signal messages are end-to-end encrypted, doesn't a bridge break that?
+
+Here's how Lightfriend handles it: the bridge runs inside an AWS Nitro Enclave, a sealed computing environment that nobody can access - not even the server operators. Your Signal credentials and decrypted messages exist only inside this enclave. The code is open source and cryptographically verifiable.
+
+The SMS leg (from Lightfriend to your phone) travels over your carrier's network, which is not end-to-end encrypted. This is a real tradeoff. But for people who would otherwise not use Signal at all, this is strictly better than sending everything as plain SMS.
+
+## What You Need
+
+- Any phone with SMS
+- A Lightfriend account
+- A Signal account (requires a smartphone for initial setup)
+
+After linking, the smartphone is no longer needed.

--- a/backend/content/blog/messaging/telegram-without-smartphone.md
+++ b/backend/content/blog/messaging/telegram-without-smartphone.md
@@ -1,0 +1,80 @@
+---
+title: "How to Use Telegram Without a Smartphone"
+slug: "telegram-without-smartphone"
+description: "Access Telegram messages from any basic phone via SMS. No apps needed."
+date: "2026-04-12"
+cluster: "messaging"
+keywords:
+  - "telegram without smartphone"
+  - "telegram on dumbphone"
+  - "telegram on flip phone"
+  - "telegram sms"
+tags:
+  - "telegram"
+  - "messaging"
+  - "dumbphone"
+schema_type: "HowTo"
+estimated_time: "PT5M"
+faqs:
+  - q: "Can I use Telegram without a smartphone?"
+    a: "Yes. Lightfriend bridges Telegram to SMS. Any phone that can text can send and receive Telegram messages."
+  - q: "Do I need the Telegram app?"
+    a: "Only for initial setup. After that, everything works through SMS on your basic phone."
+  - q: "Can I access Telegram channels and groups?"
+    a: "Yes. You receive messages from your channels and groups as SMS and can reply to conversations."
+related_slugs:
+  - "whatsapp-without-smartphone"
+  - "signal-without-smartphone"
+hub_slug: "whatsapp-without-smartphone"
+ai_summary: "Lightfriend bridges Telegram to SMS. Any phone that can text can send and receive Telegram messages without needing the app or a smartphone."
+---
+
+## The Problem
+
+Telegram has over 900 million monthly users. It's popular for group chats, channels, communities, and increasingly for work communication. But Telegram requires an app - it runs on smartphones and desktops, not on basic phones.
+
+If you're using a dumbphone or flip phone, you're cut off from Telegram entirely. Unlike WhatsApp, Telegram does have a web interface, but it still requires an active session initiated from a smartphone.
+
+## Why This Is Hard
+
+Telegram has no SMS mode. There is no feature phone app. The web client requires authentication from a phone with the Telegram app. If you don't have a smartphone, you don't have Telegram.
+
+Some people work around this by keeping a tablet or old phone connected to WiFi just to run Telegram. It works, but defeats the purpose of going minimal.
+
+## How Lightfriend Solves This
+
+Lightfriend connects to your Telegram account using an open-source bridge and converts everything to SMS:
+
+1. **Connect your Telegram account** via the Lightfriend web dashboard.
+2. **Messages arrive as SMS.** Personal messages, group chats, and channel updates get delivered as text messages to your phone.
+3. **Reply by text.** Your SMS replies go back through Telegram.
+4. **AI helps you manage volume.** Telegram users often get hundreds of messages per day from groups and channels. Lightfriend's AI can summarize and prioritize, so you only get what matters.
+
+## What Works
+
+| Feature | Works? |
+|---------|--------|
+| Receive personal messages | Yes |
+| Send personal messages | Yes |
+| Group messages | Yes |
+| Channel updates | Yes |
+| Receive photos (as descriptions) | Yes |
+| Voice/video calls | No |
+| Bots and inline queries | No |
+| Stickers | No |
+
+## Managing Telegram's Volume
+
+Telegram is noisier than WhatsApp or Signal. Groups can have thousands of members. Channels push content constantly. Getting all of that as SMS would overwhelm your phone.
+
+Lightfriend handles this with intelligent filtering. Its AI classifies incoming messages by urgency - critical messages get delivered immediately, important ones go into your digest, and noise gets filtered. You can configure these thresholds per conversation.
+
+This actually makes Telegram more usable than the app itself, where notifications are an all-or-nothing firehose.
+
+## What You Need
+
+- Any phone with SMS
+- A Lightfriend account
+- A Telegram account (smartphone needed for initial login)
+
+The smartphone is only needed once for authentication. After that, your basic phone handles everything.

--- a/backend/content/blog/messaging/whatsapp-without-smartphone.md
+++ b/backend/content/blog/messaging/whatsapp-without-smartphone.md
@@ -1,0 +1,81 @@
+---
+title: "How to Use WhatsApp Without a Smartphone"
+slug: "whatsapp-without-smartphone"
+description: "Send and receive WhatsApp messages from any basic phone via SMS. No smartphone or internet needed on your phone."
+date: "2026-04-12"
+cluster: "messaging"
+cluster_hub: true
+keywords:
+  - "whatsapp without smartphone"
+  - "whatsapp on dumbphone"
+  - "whatsapp on flip phone"
+  - "whatsapp sms bridge"
+tags:
+  - "whatsapp"
+  - "messaging"
+  - "dumbphone"
+schema_type: "HowTo"
+estimated_time: "PT5M"
+faqs:
+  - q: "Can you use WhatsApp without a smartphone?"
+    a: "Yes. Lightfriend bridges WhatsApp to SMS, so any phone that can send a text message can send and receive WhatsApp messages."
+  - q: "Do I need internet on my phone?"
+    a: "No. Your phone uses regular SMS. Lightfriend handles the internet side."
+  - q: "Can I receive WhatsApp group messages?"
+    a: "Yes. Group messages are delivered to you as SMS, with the sender name and group name included."
+  - q: "Will my WhatsApp contacts know I'm using a bridge?"
+    a: "No. Messages appear the same as if you sent them from the WhatsApp app."
+related_slugs:
+  - "signal-without-smartphone"
+  - "telegram-without-smartphone"
+ai_summary: "Lightfriend bridges WhatsApp to SMS. Any phone with texting can send and receive WhatsApp messages without a smartphone or internet connection on the phone."
+---
+
+## The Problem
+
+WhatsApp has over 2 billion users. If your family, friends, or coworkers use it, you need to be on it. But WhatsApp only works as a smartphone app. If you use a dumbphone, a flip phone, or a basic phone - you're locked out.
+
+Some people keep an old smartphone at home just to check WhatsApp. Others ask friends to forward important messages. Neither works well.
+
+## Why This Is Hard Without Lightfriend
+
+WhatsApp requires the official app running on a smartphone. There is no SMS fallback, no email option, and no web-only mode without a paired phone. Meta designed it this way on purpose - they want you on a smartphone where they can show ads.
+
+If you use a KaiOS phone (like the Nokia 2780), there was once a WhatsApp app for it, but it's been discontinued. Even when it worked, it was slow and limited.
+
+## How Lightfriend Solves This
+
+Lightfriend connects to your WhatsApp account using an open-source bridge. Your phone doesn't need to know anything about WhatsApp. Here's how it works:
+
+1. **You sign up for Lightfriend** and connect your WhatsApp account through the web dashboard.
+2. **Lightfriend bridges WhatsApp to SMS.** When someone sends you a WhatsApp message, it arrives as a text on your phone.
+3. **You reply by text.** Your SMS reply gets sent back through WhatsApp to the person who messaged you.
+4. **Group messages work too.** You see who sent what in which group, and you can reply to specific conversations.
+
+Your phone number stays the same. Your contacts don't know you're using a bridge. Everything just works over SMS.
+
+## What You Can Do
+
+| Feature | Works? |
+|---------|--------|
+| Receive text messages | Yes |
+| Send text messages | Yes |
+| Group messages | Yes |
+| Receive photos (as descriptions) | Yes |
+| Voice/video calls | No (use regular phone calls instead) |
+| Status updates | No |
+| Stickers | No |
+
+## What You Need
+
+- Any phone with SMS capability (literally any phone)
+- A Lightfriend account
+- A WhatsApp account (you'll need a smartphone briefly for the initial QR code scan)
+
+After the initial setup, you don't need the smartphone again. Everything happens over SMS.
+
+## The Privacy Angle
+
+Lightfriend runs inside a sealed computing environment (AWS Nitro Enclave). Your WhatsApp credentials and messages are encrypted with keys that exist only inside this sealed environment. The code is open source and cryptographically verifiable. This means not even the people running Lightfriend can read your messages.
+
+This is actually more private than using the WhatsApp app itself, which sends metadata to Meta's servers.

--- a/backend/content/blog/minimalism/why-switch-to-dumbphone.md
+++ b/backend/content/blog/minimalism/why-switch-to-dumbphone.md
@@ -1,0 +1,96 @@
+---
+title: "Why People Are Switching to Dumbphones in 2026"
+slug: "why-switch-to-dumbphone-2026"
+description: "The dumbphone movement is growing. Here's why people are ditching smartphones and how they stay connected."
+date: "2026-04-12"
+cluster: "minimalism"
+cluster_hub: true
+keywords:
+  - "why switch to dumbphone"
+  - "dumbphone 2026"
+  - "dumbphone movement"
+  - "quit smartphone"
+tags:
+  - "minimalism"
+  - "dumbphone"
+  - "lifestyle"
+schema_type: "Article"
+faqs:
+  - q: "Can you really live without a smartphone?"
+    a: "Yes, but you need solutions for messaging apps and email. Lightfriend bridges WhatsApp, Signal, and Telegram to SMS and gives you AI assistance over text."
+  - q: "What's the biggest challenge of switching to a dumbphone?"
+    a: "Losing access to messaging apps like WhatsApp. This is solvable with a bridge service like Lightfriend that delivers those messages as SMS."
+related_slugs:
+  - "whatsapp-without-smartphone"
+  - "ai-assistant-via-sms"
+  - "group-chats-on-dumbphone"
+ai_summary: "Growing numbers of people are switching to dumbphones for mental health, focus, and simplicity. The main barrier - losing messaging apps - is solved by bridge services like Lightfriend that deliver WhatsApp/Signal/Telegram as SMS."
+---
+
+## The Numbers
+
+Dumbphone sales have been growing every year. The Light Phone, Punkt, Nokia feature phones, and others are selling to people who actively choose less technology. This isn't about affordability - a Light Phone 3 costs $399. People are paying a premium for fewer features.
+
+Why?
+
+## Screen Time Is the New Smoking
+
+The average smartphone user picks up their phone 96 times a day. That's once every 10 minutes during waking hours. Social media apps are designed by teams of engineers whose job is to maximize your time on screen.
+
+People are starting to recognize this as a problem. Not in a theoretical "technology is bad" way, but in a practical "I can't focus at work, I can't be present with my kids, and I feel worse after scrolling" way.
+
+A dumbphone is the most effective solution. You can't scroll what doesn't exist.
+
+## The Real Barrier: Messaging Apps
+
+The number one thing stopping people from switching is WhatsApp, Signal, or Telegram. These apps have replaced SMS as the default communication channel for billions of people. If your family group chat is on WhatsApp, you can't just opt out.
+
+This is where most dumbphone attempts fail. People switch, realize they can't access their group chats or message their friends, and switch back within a week.
+
+## How People Actually Make It Work
+
+The people who successfully switch to dumbphones do one of two things:
+
+1. **Accept the loss.** They tell everyone to text or call them directly. This works if you have a small social circle, but fails if you're in multiple active group chats.
+
+2. **Bridge the gap.** They use a service that forwards their messaging app messages to SMS. This lets them keep their dumbphone while staying in their group chats.
+
+Lightfriend does the second option. It bridges WhatsApp, Signal, and Telegram to SMS, so messages from those platforms arrive as text messages on your basic phone. You can reply by text and your response goes back through the original platform.
+
+It goes further than just bridging - Lightfriend adds AI that filters messages by importance, so you're not drowning in 200 SMS messages from a busy group chat. You get a summary of what matters.
+
+## What You Gain
+
+People who switch to dumbphones consistently report:
+
+- **Better focus.** Without constant notifications and the temptation to "quickly check" something, concentration improves dramatically.
+- **Better sleep.** No phone screen to scroll through in bed.
+- **More presence.** When you're with people, you're actually with them.
+- **Less anxiety.** The constant stream of news, social media, and notifications creates a low-grade anxiety that disappears with a dumbphone.
+- **More time.** The average person spends 3-4 hours daily on their smartphone. That time goes back to you.
+
+## What You Lose (and How to Deal With It)
+
+| You Lose | Solution |
+|----------|----------|
+| WhatsApp/Signal/Telegram | Lightfriend bridges to SMS |
+| Email on the go | Lightfriend reads/sends email via SMS |
+| Maps and navigation | Learn your routes, or carry a paper map |
+| Camera (on some phones) | Some dumbphones have cameras, or carry a dedicated camera |
+| Mobile payments | Carry a card |
+| Ride-hailing apps | Call a taxi |
+| AI assistant | Lightfriend gives you AI via SMS |
+
+The messaging and email gaps are the hardest to fill. Lightfriend handles both.
+
+## Getting Started
+
+If you're considering the switch:
+
+1. **Start with a weekend.** Leave your smartphone at home for two days. See how it feels.
+2. **Identify your dependencies.** Which apps do you actually need vs. habitually use?
+3. **Set up bridges first.** Connect your messaging apps to Lightfriend before switching phones.
+4. **Tell people.** Let your contacts know you're switching. Most people are supportive.
+5. **Switch.** Put the smartphone in a drawer. Give it a month.
+
+The first week is the hardest. After that, most people don't want to go back.

--- a/backend/content/blog/privacy/verifiable-ai-privacy.md
+++ b/backend/content/blog/privacy/verifiable-ai-privacy.md
@@ -1,0 +1,94 @@
+---
+title: "What Does Verifiable AI Privacy Actually Mean?"
+slug: "verifiable-ai-privacy"
+description: "Most AI companies promise privacy. Lightfriend lets you verify it with cryptographic proofs and open source code."
+date: "2026-04-12"
+cluster: "privacy"
+cluster_hub: true
+keywords:
+  - "verifiable ai privacy"
+  - "ai privacy proof"
+  - "nitro enclave ai"
+  - "open source ai assistant"
+tags:
+  - "privacy"
+  - "enclave"
+  - "open-source"
+schema_type: "Article"
+faqs:
+  - q: "How do I know Lightfriend isn't reading my messages?"
+    a: "The code is open source and runs inside an AWS Nitro Enclave. You can cryptographically verify that the running code matches the public source. The enclave is sealed - nobody can log in or inspect memory."
+  - q: "What is an AWS Nitro Enclave?"
+    a: "A sealed computing environment provided by Amazon. Once code is running inside, nobody - not even Amazon or the server operator - can access the data inside it."
+  - q: "Is this better than end-to-end encryption?"
+    a: "It solves a different problem. E2E encryption protects data in transit. Enclave computing protects data during processing. Lightfriend uses both."
+related_slugs:
+  - "whatsapp-without-smartphone"
+  - "signal-without-smartphone"
+ai_summary: "Lightfriend runs inside an AWS Nitro Enclave with open source code and cryptographic attestation. Users can verify that the running code matches the public source, proving that the operator cannot access user data."
+---
+
+## The Problem With AI Privacy
+
+Every AI company says they care about your privacy. OpenAI has a privacy policy. Google has a privacy policy. They all promise not to misuse your data.
+
+But promises are not proof. A privacy policy is a legal document, not a technical guarantee. The company can change it. Employees can access data. Governments can subpoena it. A breach can expose it.
+
+When you give an AI assistant access to your WhatsApp messages, emails, and personal information, you're trusting that company completely. And you have no way to verify whether that trust is justified.
+
+## How Lightfriend Is Different
+
+Lightfriend takes a different approach: don't trust us, verify us.
+
+The system is built so that privacy is enforced by architecture, not by policy. Here's how:
+
+### Open Source Code
+
+The entire Lightfriend codebase is public on GitHub under the AGPLv3 license. You can read every line of code that handles your data. There's no secret server-side logic.
+
+### Sealed Computing Environment
+
+Lightfriend runs inside an AWS Nitro Enclave. This is a hardware-enforced sealed environment with specific properties:
+
+- **No shell access.** Nobody can SSH in, not even the server operator.
+- **No memory inspection.** The host machine cannot read the enclave's memory.
+- **No persistent storage access.** Data inside the enclave is encrypted with keys that exist only inside the enclave.
+
+### Cryptographic Attestation
+
+Here's the key part: you don't have to take our word for any of this. AWS Nitro Enclaves produce a cryptographic attestation document that proves what code is running. This attestation includes PCR values (Platform Configuration Registers) that are a hash of the enclave image.
+
+Lightfriend publishes reproducible builds. You can:
+
+1. Check the source code on GitHub
+2. Build the enclave image yourself
+3. Compare your PCR values against the live enclave's attestation
+4. Verify they match
+
+If they match, you know the running code is exactly what you see on GitHub. No backdoors. No secret logging.
+
+### Trust Chain on Blockchain
+
+Lightfriend records its attestation history on a blockchain. Each deployment creates a verifiable record that anyone can audit. This prevents retroactive changes - you can verify not just what's running now, but what was running at any point in the past.
+
+## What This Means In Practice
+
+When you connect your WhatsApp to Lightfriend:
+
+- Your WhatsApp credentials enter the enclave and are encrypted with keys that exist only inside it
+- Your messages are processed inside the enclave by the open source code
+- The AI inference happens inside a separate sealed environment (Tinfoil)
+- Nobody - not the server operator, not AWS, not anyone - can access the plaintext data
+
+This is a fundamentally different model from "we promise not to look at your data."
+
+## The Honest Limitations
+
+No system is perfect. Here are the real limitations:
+
+- **You have to actually verify.** If you don't check the attestation, you're trusting us just like any other service. The tools are there, but you have to use them.
+- **The SMS leg is not encrypted.** Messages between Lightfriend and your phone travel over your carrier's SMS network, which is not end-to-end encrypted.
+- **Third-party dependencies.** The security depends on AWS Nitro Enclaves working correctly. If there's a hardware vulnerability in Nitro, the guarantees break.
+- **AI inference.** AI processing happens through Tinfoil's sealed inference, which has its own trust model.
+
+We believe this is the most transparent AI privacy model available today. But don't believe us - verify it.

--- a/backend/content/blog/problems/group-chats-on-dumbphone.md
+++ b/backend/content/blog/problems/group-chats-on-dumbphone.md
@@ -1,0 +1,112 @@
+---
+title: "How to Keep Up With Group Chats on a Dumbphone"
+slug: "group-chats-on-dumbphone"
+description: "Stay in WhatsApp, Signal, and Telegram group chats from any basic phone. Lightfriend bridges group messages to SMS with AI filtering."
+date: "2026-04-12"
+cluster: "problems"
+keywords:
+  - "group chat on dumbphone"
+  - "whatsapp group on flip phone"
+  - "group messages without smartphone"
+tags:
+  - "group-chats"
+  - "messaging"
+  - "dumbphone"
+schema_type: "Article"
+faqs:
+  - q: "Can I read WhatsApp group chats on a dumbphone?"
+    a: "Yes. Lightfriend delivers group messages as SMS with the sender name and group name included. You can reply to specific groups."
+  - q: "Won't I get overwhelmed with SMS from busy groups?"
+    a: "No. Lightfriend's AI classifies messages by urgency. Only important messages get delivered immediately. The rest go into a periodic digest or get filtered entirely."
+related_slugs:
+  - "whatsapp-without-smartphone"
+  - "telegram-without-smartphone"
+  - "ai-assistant-via-sms"
+ai_summary: "Lightfriend bridges WhatsApp, Signal, and Telegram group chats to SMS on any phone. AI classifies message urgency - critical messages arrive immediately, low-priority ones go into a digest, spam is filtered."
+---
+
+## The Problem
+
+Group chats are where modern life happens. Family coordination, work teams, friend groups, school parent groups, neighborhood watches - they all live in WhatsApp, Signal, or Telegram groups.
+
+If you switch to a dumbphone, you lose all of them. There's no way to access group chats from a basic phone. You become the person everyone has to update separately, or you miss things entirely.
+
+This is the number one reason people hesitate to switch to a dumbphone.
+
+## The Volume Problem
+
+Even if you could get group messages on a basic phone, there's a second problem: volume. A busy family group can generate 50 messages a day. A work Slack-style Telegram group might generate hundreds. Getting every message as an individual SMS would be worse than not getting them at all.
+
+This is why a simple "forward messages to SMS" solution doesn't work. You need intelligence.
+
+## How Lightfriend Solves This
+
+Lightfriend bridges your group chats to SMS with AI-powered filtering. Here's how it works:
+
+### Message Classification
+
+Every incoming group message gets classified by Lightfriend's AI into urgency levels:
+
+- **Critical**: Emergencies, time-sensitive requests directed at you, health/safety
+- **High**: Important messages that need your attention soon
+- **Medium**: Useful but not urgent - goes into your digest
+- **Low**: Noise, memes, reactions - filtered unless you ask for them
+
+The AI considers the sender (your mom vs. a random group member), the content, whether you're mentioned, and patterns from your communication history.
+
+### Smart Delivery
+
+Based on classification:
+
+- **Critical and high** messages arrive as SMS immediately, with the sender name and group name
+- **Medium** messages get batched into a periodic digest that summarizes what happened
+- **Low** messages are available if you ask ("What happened in the family group today?") but don't interrupt you
+
+### Replying to Groups
+
+You can reply to specific groups through Lightfriend:
+
+"Reply to the family group: I'll bring dessert"
+
+The AI uses fuzzy matching to find the right group. Your message appears in the group as if sent from the WhatsApp/Signal/Telegram app.
+
+## What a Digest Looks Like
+
+Instead of 47 individual SMS messages from your work group, you get something like:
+
+```
+Critical:
+- Boss: needs PRD review by end of day
+
+Important:
+- Bank: reports payment declined
+
+FYI:
+- Sarah: pushed an update on the project
+- Newsletter: Weekly newsletter arrived
+- John: shared a meme
+
+Reply to dig in.
+```
+
+You see what matters at a glance. If you want details on any item, just reply and ask.
+
+## What Works
+
+| Feature | Supported |
+|---------|-----------|
+| Receive group messages | Yes |
+| Send to groups | Yes |
+| See sender names | Yes |
+| See group names | Yes |
+| AI urgency filtering | Yes |
+| Periodic digests | Yes |
+| Photos in groups | Described by AI, not forwarded |
+| Voice messages | Not supported |
+| Reactions/emojis | Not forwarded |
+
+## The Honest Tradeoff
+
+You won't get the full group chat experience. You can't scroll through a thread, see who reacted to what, or watch shared videos. What you get is the signal without the noise - the messages that actually matter to you, delivered to the simplest possible device.
+
+For most people who switch to a dumbphone, this is exactly the right tradeoff.

--- a/backend/content/blog/problems/reminders-on-dumbphone.md
+++ b/backend/content/blog/problems/reminders-on-dumbphone.md
@@ -1,0 +1,64 @@
+---
+title: "How to Set Reminders on a Dumbphone"
+slug: "reminders-on-dumbphone"
+description: "Set reminders from any basic phone via text message. Lightfriend sends you an SMS when it's time."
+date: "2026-04-12"
+cluster: "problems"
+keywords:
+  - "reminders on dumbphone"
+  - "set reminder via sms"
+  - "reminder app dumbphone"
+  - "alarm on flip phone"
+tags:
+  - "reminders"
+  - "productivity"
+  - "dumbphone"
+schema_type: "HowTo"
+estimated_time: "PT1M"
+faqs:
+  - q: "Can I set reminders on a dumbphone?"
+    a: "Yes. Text Lightfriend something like 'Remind me to call the dentist tomorrow at 2pm' and you'll get an SMS at that time."
+  - q: "Does this work with any phone?"
+    a: "Any phone that can send and receive text messages."
+related_slugs:
+  - "ai-assistant-via-sms"
+  - "group-chats-on-dumbphone"
+hub_slug: "ai-assistant-via-sms"
+ai_summary: "Lightfriend lets you set reminders via text message from any phone. Text a natural language reminder and get an SMS notification at the specified time."
+---
+
+## The Problem
+
+Smartphones have reminder apps, calendar notifications, and voice assistants that can set timers for you. Dumbphones have... an alarm clock. Maybe.
+
+If you need to remember to call someone at 3pm, pick up a prescription before the pharmacy closes, or follow up on an email by Friday, a basic phone gives you no help. You're back to writing things on your hand.
+
+## How Lightfriend Solves This
+
+Text Lightfriend a reminder in natural language:
+
+"Remind me to call the dentist tomorrow at 2pm"
+
+That's it. At 2pm tomorrow, you get an SMS: "Reminder: call the dentist"
+
+### How to Set Reminders
+
+Just text naturally. Lightfriend understands:
+
+- "Remind me to buy milk at 5pm"
+- "Remind me about the meeting on Friday at 9am"
+- "Set a reminder for March 20th at noon to submit the report"
+
+The AI parses the time and message from your text and schedules the notification.
+
+### What Arrives
+
+At the scheduled time, you get an SMS with your reminder text. Simple, reliable, works on every phone.
+
+## Limitations
+
+- **One-time reminders only.** You can't set recurring reminders (like "every Monday at 9am").
+- **SMS delivery.** Reminders arrive as text messages, which depend on your carrier's SMS delivery.
+- **No calendar integration.** Reminders are standalone - they don't sync to Google Calendar or similar.
+
+For most people, one-time reminders cover 90% of what they need. "Remind me to..." is the most common use case and it works perfectly over SMS.

--- a/backend/src/blog/content.rs
+++ b/backend/src/blog/content.rs
@@ -1,0 +1,290 @@
+use serde::Deserialize;
+use std::collections::HashMap;
+use std::path::Path;
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct FaqItem {
+    pub q: String,
+    pub a: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct BlogFrontmatter {
+    pub title: String,
+    pub slug: String,
+    pub description: String,
+    pub date: String,
+    #[serde(default)]
+    pub cluster: String,
+    #[serde(default)]
+    pub cluster_hub: bool,
+    #[serde(default)]
+    pub keywords: Vec<String>,
+    #[serde(default)]
+    pub tags: Vec<String>,
+    pub schema_type: Option<String>,
+    pub estimated_time: Option<String>,
+    #[serde(default)]
+    pub faqs: Vec<FaqItem>,
+    #[serde(default)]
+    pub related_slugs: Vec<String>,
+    pub hub_slug: Option<String>,
+    pub ai_summary: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct BlogPost {
+    pub frontmatter: BlogFrontmatter,
+    pub raw_markdown: String,
+    pub rendered_html: String,
+    pub full_page_html: String,
+    pub word_count: usize,
+}
+
+pub struct BlogStore {
+    pub posts: HashMap<String, BlogPost>,
+    pub clusters: HashMap<String, Vec<String>>,
+    pub all_slugs_sorted: Vec<String>,
+    pub sitemap_xml: String,
+    pub blog_index_html: String,
+}
+
+fn parse_frontmatter(content: &str) -> Result<(BlogFrontmatter, String), anyhow::Error> {
+    let content = content.trim_start_matches('\u{feff}'); // strip BOM
+    if !content.starts_with("---") {
+        anyhow::bail!("missing frontmatter delimiter");
+    }
+    let after_first = &content[3..];
+    let end = after_first
+        .find("\n---")
+        .ok_or_else(|| anyhow::anyhow!("missing closing frontmatter delimiter"))?;
+    let yaml = &after_first[..end];
+    let body = &after_first[end + 4..]; // skip \n---
+    let fm: BlogFrontmatter = serde_yaml::from_str(yaml)?;
+    Ok((fm, body.trim().to_string()))
+}
+
+fn render_markdown(md: &str) -> String {
+    use pulldown_cmark::{html, Options, Parser};
+    let opts =
+        Options::ENABLE_TABLES | Options::ENABLE_STRIKETHROUGH | Options::ENABLE_HEADING_ATTRIBUTES;
+    let parser = Parser::new_ext(md, opts);
+    let mut html_output = String::new();
+    html::push_html(&mut html_output, parser);
+    html_output
+}
+
+fn count_words(text: &str) -> usize {
+    text.split_whitespace().count()
+}
+
+impl BlogStore {
+    pub fn empty() -> Self {
+        Self {
+            posts: HashMap::new(),
+            clusters: HashMap::new(),
+            all_slugs_sorted: vec![],
+            sitemap_xml: Self::generate_sitemap(&HashMap::new()),
+            blog_index_html: String::new(),
+        }
+    }
+
+    pub fn load(content_dir: &str) -> Result<Self, anyhow::Error> {
+        let mut posts = HashMap::new();
+        let mut clusters: HashMap<String, Vec<String>> = HashMap::new();
+
+        let path = Path::new(content_dir);
+        if !path.exists() {
+            tracing::warn!("Blog content directory not found: {}", content_dir);
+            return Ok(Self {
+                posts,
+                clusters,
+                all_slugs_sorted: vec![],
+                sitemap_xml: Self::generate_sitemap(&HashMap::new()),
+                blog_index_html: String::new(),
+            });
+        }
+
+        Self::load_dir(path, &mut posts)?;
+
+        // Build cluster index
+        for (slug, post) in &posts {
+            if !post.frontmatter.cluster.is_empty() {
+                clusters
+                    .entry(post.frontmatter.cluster.clone())
+                    .or_default()
+                    .push(slug.clone());
+            }
+        }
+
+        // Sort slugs by date descending
+        let mut all_slugs_sorted: Vec<String> = posts.keys().cloned().collect();
+        all_slugs_sorted.sort_by(|a, b| {
+            let da = &posts[a].frontmatter.date;
+            let db = &posts[b].frontmatter.date;
+            db.cmp(da)
+        });
+
+        // Now render full page HTML for each post (needs the store's related posts)
+        for slug in &all_slugs_sorted {
+            let post = posts.get(slug).unwrap();
+            let related = Self::get_related_static(&posts, post);
+            let full_html = super::templates::render_blog_post(post, &related);
+            posts.get_mut(slug).unwrap().full_page_html = full_html;
+        }
+
+        let sitemap_xml = Self::generate_sitemap(&posts);
+        let blog_index_html =
+            super::templates::render_blog_index(&all_slugs_sorted, &posts, &clusters);
+
+        Ok(Self {
+            posts,
+            clusters,
+            all_slugs_sorted,
+            sitemap_xml,
+            blog_index_html,
+        })
+    }
+
+    fn load_dir(dir: &Path, posts: &mut HashMap<String, BlogPost>) -> Result<(), anyhow::Error> {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.is_dir() {
+                // Skip _data directory
+                if path
+                    .file_name()
+                    .map_or(false, |n| n.to_str() == Some("_data"))
+                {
+                    continue;
+                }
+                Self::load_dir(&path, posts)?;
+            } else if path.extension().map_or(false, |e| e == "md") {
+                match Self::load_post(&path) {
+                    Ok(post) => {
+                        posts.insert(post.frontmatter.slug.clone(), post);
+                    }
+                    Err(e) => {
+                        tracing::warn!("Failed to load blog post {}: {}", path.display(), e);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    fn load_post(path: &Path) -> Result<BlogPost, anyhow::Error> {
+        let content = std::fs::read_to_string(path)?;
+        let (frontmatter, raw_markdown) = parse_frontmatter(&content)?;
+        let rendered_html = render_markdown(&raw_markdown);
+        let word_count = count_words(&raw_markdown);
+
+        Ok(BlogPost {
+            frontmatter,
+            raw_markdown,
+            rendered_html,
+            full_page_html: String::new(), // filled in after all posts loaded
+            word_count,
+        })
+    }
+
+    pub fn get_post(&self, slug: &str) -> Option<&BlogPost> {
+        self.posts.get(slug)
+    }
+
+    pub fn get_related_posts(&self, slug: &str, limit: usize) -> Vec<&BlogPost> {
+        let post = match self.posts.get(slug) {
+            Some(p) => p,
+            None => return vec![],
+        };
+        let mut related = Vec::new();
+        // First: explicitly listed related slugs
+        for rs in &post.frontmatter.related_slugs {
+            if let Some(p) = self.posts.get(rs) {
+                related.push(p);
+                if related.len() >= limit {
+                    return related;
+                }
+            }
+        }
+        // Then: same cluster, sorted by date
+        if let Some(cluster_slugs) = self.clusters.get(&post.frontmatter.cluster) {
+            for cs in cluster_slugs {
+                if cs != slug && !post.frontmatter.related_slugs.contains(cs) {
+                    if let Some(p) = self.posts.get(cs) {
+                        related.push(p);
+                        if related.len() >= limit {
+                            return related;
+                        }
+                    }
+                }
+            }
+        }
+        related
+    }
+
+    /// Static version for use during loading (before BlogStore is constructed)
+    fn get_related_static(posts: &HashMap<String, BlogPost>, post: &BlogPost) -> Vec<BlogPost> {
+        let mut related = Vec::new();
+        for rs in &post.frontmatter.related_slugs {
+            if let Some(p) = posts.get(rs) {
+                related.push(p.clone());
+                if related.len() >= 5 {
+                    return related;
+                }
+            }
+        }
+        related
+    }
+
+    fn generate_sitemap(posts: &HashMap<String, BlogPost>) -> String {
+        let mut urls = String::new();
+
+        // Static pages
+        let static_pages = [
+            ("/", "1.0", "weekly"),
+            ("/pricing", "0.9", "weekly"),
+            ("/faq", "0.7", "monthly"),
+            ("/terms", "0.4", "monthly"),
+            ("/privacy", "0.4", "monthly"),
+            ("/trustless", "0.8", "monthly"),
+            ("/trust-chain", "0.7", "monthly"),
+            ("/blog", "0.8", "daily"),
+            // Existing hand-coded blog posts
+            ("/signal-on-dumbphone", "0.8", "monthly"),
+            ("/telegram-on-dumbphone", "0.8", "monthly"),
+            ("/prompt-injection-safe", "0.8", "monthly"),
+            ("/light-phone-3-whatsapp-guide", "0.8", "monthly"),
+            ("/how-to-switch-to-dumbphone", "0.8", "monthly"),
+            ("/how-to-read-more-accidentally", "0.7", "monthly"),
+        ];
+
+        for (path, priority, freq) in &static_pages {
+            urls.push_str(&format!(
+                "  <url>\n    <loc>https://lightfriend.ai{}</loc>\n    <changefreq>{}</changefreq>\n    <priority>{}</priority>\n  </url>\n",
+                path, freq, priority
+            ));
+        }
+
+        // Blog posts sorted by date
+        let mut sorted: Vec<&BlogPost> = posts.values().collect();
+        sorted.sort_by(|a, b| b.frontmatter.date.cmp(&a.frontmatter.date));
+
+        for post in sorted {
+            let priority = if post.frontmatter.cluster_hub {
+                "0.8"
+            } else {
+                "0.6"
+            };
+            urls.push_str(&format!(
+                "  <url>\n    <loc>https://lightfriend.ai/blog/{}</loc>\n    <lastmod>{}</lastmod>\n    <changefreq>monthly</changefreq>\n    <priority>{}</priority>\n  </url>\n",
+                post.frontmatter.slug, post.frontmatter.date, priority
+            ));
+        }
+
+        format!(
+            "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n<urlset xmlns=\"http://www.sitemaps.org/schemas/sitemap/0.9\">\n{}</urlset>",
+            urls
+        )
+    }
+}

--- a/backend/src/blog/handlers.rs
+++ b/backend/src/blog/handlers.rs
@@ -1,0 +1,69 @@
+use axum::extract::{Path, State};
+use axum::http::{header, StatusCode};
+use axum::response::{Html, IntoResponse, Response};
+use std::sync::Arc;
+
+use crate::AppState;
+
+pub async fn blog_post_handler(
+    Path(slug): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    match state.blog_store.get_post(&slug) {
+        Some(post) => {
+            let mut response = Html(post.full_page_html.clone()).into_response();
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                "public, max-age=300, s-maxage=3600".parse().unwrap(),
+            );
+            response
+        }
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+pub async fn blog_post_md_handler(
+    Path(slug): Path<String>,
+    State(state): State<Arc<AppState>>,
+) -> Response {
+    match state.blog_store.get_post(&slug) {
+        Some(post) => {
+            let md_content = format!(
+                "# {}\n\n{}\n\n---\nSource: https://lightfriend.ai/blog/{}\n",
+                post.frontmatter.title, post.raw_markdown, post.frontmatter.slug
+            );
+            let mut response = md_content.into_response();
+            response.headers_mut().insert(
+                header::CONTENT_TYPE,
+                "text/markdown; charset=utf-8".parse().unwrap(),
+            );
+            response.headers_mut().insert(
+                header::CACHE_CONTROL,
+                "public, max-age=300, s-maxage=3600".parse().unwrap(),
+            );
+            response
+        }
+        None => StatusCode::NOT_FOUND.into_response(),
+    }
+}
+
+pub async fn blog_index_handler(State(state): State<Arc<AppState>>) -> Response {
+    let mut response = Html(state.blog_store.blog_index_html.clone()).into_response();
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        "public, max-age=300, s-maxage=3600".parse().unwrap(),
+    );
+    response
+}
+
+pub async fn sitemap_handler(State(state): State<Arc<AppState>>) -> Response {
+    let mut response = state.blog_store.sitemap_xml.clone().into_response();
+    response
+        .headers_mut()
+        .insert(header::CONTENT_TYPE, "application/xml".parse().unwrap());
+    response.headers_mut().insert(
+        header::CACHE_CONTROL,
+        "public, max-age=3600, s-maxage=86400".parse().unwrap(),
+    );
+    response
+}

--- a/backend/src/blog/linking.rs
+++ b/backend/src/blog/linking.rs
@@ -1,0 +1,91 @@
+use super::content::BlogPost;
+
+pub fn render_related_section(related: &[BlogPost]) -> String {
+    if related.is_empty() {
+        return String::new();
+    }
+    let cards: Vec<String> = related
+        .iter()
+        .map(|p| {
+            format!(
+                r#"<a href="/blog/{}" class="related-card">
+  <h4>{}</h4>
+  <p>{}</p>
+</a>"#,
+                p.frontmatter.slug,
+                html_escape(&p.frontmatter.title),
+                html_escape(&truncate(&p.frontmatter.description, 120))
+            )
+        })
+        .collect();
+
+    format!(
+        r#"<section class="related-posts">
+  <h3>Related Guides</h3>
+  <div class="related-grid">
+    {}
+  </div>
+</section>"#,
+        cards.join("\n    ")
+    )
+}
+
+pub fn render_hub_link(post: &BlogPost) -> String {
+    match &post.frontmatter.hub_slug {
+        Some(hub) => format!(
+            r#"<nav class="hub-breadcrumb">
+  <a href="/blog/{}">Back to guide overview</a>
+</nav>"#,
+            hub
+        ),
+        None => String::new(),
+    }
+}
+
+pub fn render_faq_section(post: &BlogPost) -> String {
+    if post.frontmatter.faqs.is_empty() {
+        return String::new();
+    }
+    let items: Vec<String> = post
+        .frontmatter
+        .faqs
+        .iter()
+        .map(|faq| {
+            format!(
+                r#"<div class="faq-item">
+  <h3>{}</h3>
+  <p>{}</p>
+</div>"#,
+                html_escape(&faq.q),
+                html_escape(&faq.a)
+            )
+        })
+        .collect();
+
+    format!(
+        r#"<section class="faq-section">
+  <h2>Frequently Asked Questions</h2>
+  {}
+</section>"#,
+        items.join("\n  ")
+    )
+}
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        return s.to_string();
+    }
+    let truncated: String = s.chars().take(max).collect();
+    if let Some(last_space) = truncated.rfind(' ') {
+        format!("{}...", &truncated[..last_space])
+    } else {
+        format!("{}...", truncated)
+    }
+}

--- a/backend/src/blog/schema.rs
+++ b/backend/src/blog/schema.rs
@@ -1,0 +1,124 @@
+use super::content::BlogPost;
+
+pub fn generate_schema(post: &BlogPost) -> String {
+    match post.frontmatter.schema_type.as_deref() {
+        Some("HowTo") => generate_howto_schema(post),
+        Some("FAQPage") => generate_faq_schema(post),
+        _ => generate_article_schema(post),
+    }
+}
+
+fn escape_json(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+        .replace('\r', "")
+        .replace('\t', "\\t")
+}
+
+fn generate_article_schema(post: &BlogPost) -> String {
+    let mut schema = format!(
+        r#"<script type="application/ld+json">
+{{
+  "@context": "https://schema.org",
+  "@type": "Article",
+  "headline": "{}",
+  "description": "{}",
+  "datePublished": "{}",
+  "author": {{
+    "@type": "Organization",
+    "name": "Lightfriend",
+    "url": "https://lightfriend.ai"
+  }},
+  "publisher": {{
+    "@type": "Organization",
+    "name": "Lightfriend",
+    "url": "https://lightfriend.ai"
+  }},
+  "mainEntityOfPage": "https://lightfriend.ai/blog/{}"
+}}"#,
+        escape_json(&post.frontmatter.title),
+        escape_json(&post.frontmatter.description),
+        post.frontmatter.date,
+        post.frontmatter.slug
+    );
+
+    // Append FAQ schema if FAQs exist
+    if !post.frontmatter.faqs.is_empty() {
+        schema.push_str("\n</script>\n");
+        schema.push_str(&generate_faq_schema(post));
+        return schema;
+    }
+
+    schema.push_str("\n</script>");
+    schema
+}
+
+fn generate_faq_schema(post: &BlogPost) -> String {
+    if post.frontmatter.faqs.is_empty() {
+        return String::new();
+    }
+    let entities: Vec<String> = post
+        .frontmatter
+        .faqs
+        .iter()
+        .map(|faq| {
+            format!(
+                r#"    {{
+      "@type": "Question",
+      "name": "{}",
+      "acceptedAnswer": {{
+        "@type": "Answer",
+        "text": "{}"
+      }}
+    }}"#,
+                escape_json(&faq.q),
+                escape_json(&faq.a)
+            )
+        })
+        .collect();
+
+    format!(
+        r#"<script type="application/ld+json">
+{{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [
+{}
+  ]
+}}
+</script>"#,
+        entities.join(",\n")
+    )
+}
+
+fn generate_howto_schema(post: &BlogPost) -> String {
+    let time = post
+        .frontmatter
+        .estimated_time
+        .as_deref()
+        .unwrap_or("PT10M");
+
+    let mut schema = format!(
+        r#"<script type="application/ld+json">
+{{
+  "@context": "https://schema.org",
+  "@type": "HowTo",
+  "name": "{}",
+  "description": "{}",
+  "totalTime": "{}"
+}}
+</script>"#,
+        escape_json(&post.frontmatter.title),
+        escape_json(&post.frontmatter.description),
+        time
+    );
+
+    // Also add FAQ schema if FAQs exist
+    if !post.frontmatter.faqs.is_empty() {
+        schema.push('\n');
+        schema.push_str(&generate_faq_schema(post));
+    }
+
+    schema
+}

--- a/backend/src/blog/templates.rs
+++ b/backend/src/blog/templates.rs
@@ -1,0 +1,476 @@
+use super::content::BlogPost;
+use super::linking;
+use super::schema;
+use std::collections::HashMap;
+
+const INLINE_CSS: &str = r#"
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+@font-face { font-family: 'Inter'; font-weight: 400; font-style: normal; font-display: swap; src: url('/assets/inter-400-latin.woff2') format('woff2'); }
+@font-face { font-family: 'Inter'; font-weight: 600; font-style: normal; font-display: swap; src: url('/assets/inter-600-latin.woff2') format('woff2'); }
+@font-face { font-family: 'Inter'; font-weight: 700; font-style: normal; font-display: swap; src: url('/assets/inter-700-latin.woff2') format('woff2'); }
+:root {
+    --surface-card: rgba(0, 0, 0, 0.3);
+    --surface-card-hover: rgba(0, 0, 0, 0.4);
+    --surface-subtle: rgba(255, 255, 255, 0.03);
+    --border-card: rgba(255, 255, 255, 0.12);
+    --border-card-hover: rgba(255, 255, 255, 0.25);
+    --text-heading: #ffffff;
+    --text-body: #bbbbbb;
+    --text-muted: #888888;
+    --text-dim: #666666;
+}
+body {
+    font-family: 'Inter', -apple-system, BlinkMacSystemFont, sans-serif;
+    background: #1a1a1a;
+    color: #ffffff;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+}
+a { color: #7EB2FF; text-decoration: none; }
+a:hover { text-decoration: underline; }
+.top-nav {
+    position: fixed; top: 0; left: 0; right: 0;
+    z-index: 1002; padding: 1rem 0;
+    background: rgba(26, 26, 26, 0.9); backdrop-filter: blur(10px);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+.nav-content {
+    max-width: 100%; margin: 0; padding: 0 3rem;
+    display: flex; justify-content: space-between; align-items: center;
+}
+.nav-logo {
+    color: white; text-decoration: none; font-size: 1.5rem; font-weight: 600;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.nav-logo:hover { opacity: 0.8; text-decoration: none; }
+.nav-right { display: flex; align-items: center; gap: 0.75rem; }
+.nav-link {
+    color: rgba(255, 255, 255, 0.75); text-decoration: none;
+    padding: 0.75rem 1.5rem; border-radius: 8px; font-size: 0.9rem;
+    background: rgba(180, 180, 180, 0.12); border: 1px solid rgba(200, 200, 200, 0.25);
+    transition: all 0.3s ease;
+}
+.nav-link:hover { background: rgba(200, 200, 200, 0.2); color: #fff; text-decoration: none; transform: translateY(-2px); }
+.blog-page { padding-top: 74px; min-height: 100vh; position: relative; }
+.blog-hero {
+    text-align: center; padding: 6rem 2rem;
+    background: var(--surface-card); margin-top: 2rem;
+    border: 1px solid var(--border-card); margin-bottom: 2rem;
+}
+.blog-hero h1 {
+    font-size: 3.5rem; margin-bottom: 1.5rem;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.blog-meta { color: var(--text-dim); font-size: 0.9rem; }
+.blog-content { max-width: 800px; margin: 0 auto; padding: 2rem; }
+.blog-content h2 {
+    font-size: 2rem; margin: 3rem 0 1rem;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.blog-content h3 { font-size: 1.4rem; margin: 2rem 0 0.75rem; color: #fff; }
+.blog-content p { color: var(--text-body); line-height: 1.6; margin-bottom: 1.5rem; }
+.blog-content ul, .blog-content ol { color: var(--text-body); padding-left: 1.5rem; margin-bottom: 1.5rem; }
+.blog-content li { margin-bottom: 0.75rem; }
+.blog-content table {
+    width: 100%; border-collapse: collapse; margin: 2rem 0; color: #ddd;
+}
+.blog-content th, .blog-content td { padding: 1rem; border: 1px solid var(--border-card); text-align: left; }
+.blog-content th { background: rgba(0, 0, 0, 0.5); color: #7EB2FF; }
+.blog-content strong { color: #fff; }
+.blog-content code { background: rgba(255,255,255,0.08); padding: 0.2rem 0.4rem; border-radius: 4px; font-size: 0.9em; }
+.blog-cta {
+    text-align: center; margin: 4rem auto 2rem; padding: 2rem; max-width: 800px;
+    background: var(--surface-subtle); border: 1px solid var(--border-card); border-radius: 12px;
+}
+.blog-cta h3 {
+    font-size: 2rem; margin-bottom: 1.5rem;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.blog-cta p { color: #999; margin-top: 1rem; }
+.hero-cta {
+    display: inline-block;
+    background: linear-gradient(45deg, #7EB2FF, #4169E1); color: white;
+    border: none; padding: 1rem 2.5rem; border-radius: 8px;
+    font-size: 1.1rem; cursor: pointer; transition: all 0.3s ease; text-decoration: none;
+}
+.hero-cta:hover { transform: translateY(-2px); box-shadow: 0 4px 20px rgba(126, 178, 255, 0.4); text-decoration: none; }
+.faq-section { max-width: 800px; margin: 2rem auto; padding: 0 2rem; }
+.faq-section h2 {
+    font-size: 2rem; margin-bottom: 1.5rem;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.faq-item { margin-bottom: 1.5rem; padding: 1.5rem; background: var(--surface-card); border: 1px solid var(--border-card); border-radius: 12px; }
+.faq-item h3 { color: #fff; font-size: 1.1rem; margin-bottom: 0.5rem; }
+.faq-item p { color: var(--text-body); margin: 0; }
+.related-posts { max-width: 800px; margin: 3rem auto; padding: 0 2rem; }
+.related-posts h3 {
+    font-size: 1.5rem; margin-bottom: 1.5rem;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.related-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(250px, 1fr)); gap: 1rem; }
+.related-card {
+    display: block; padding: 1.5rem; background: var(--surface-card);
+    border: 1px solid var(--border-card); border-radius: 12px;
+    transition: all 0.3s ease; text-decoration: none;
+}
+.related-card:hover { border-color: var(--border-card-hover); transform: translateY(-3px); text-decoration: none; }
+.related-card h4 { color: #fff; font-size: 1rem; margin-bottom: 0.5rem; }
+.related-card p { color: var(--text-muted); font-size: 0.9rem; margin: 0; }
+.hub-breadcrumb { max-width: 800px; margin: 1rem auto; padding: 0 2rem; }
+.hub-breadcrumb a { color: var(--text-muted); font-size: 0.9rem; }
+.blog-footer {
+    max-width: 800px; margin: 4rem auto 0; padding: 2rem;
+    border-top: 1px solid var(--border-card); text-align: center;
+}
+.footer-links { display: flex; justify-content: center; gap: 1.5rem; margin-bottom: 1rem; flex-wrap: wrap; }
+.footer-links a { color: var(--text-muted); font-size: 0.9rem; }
+.blog-footer p { color: var(--text-dim); font-size: 0.85rem; }
+/* Blog index */
+.blog-list-section { max-width: 800px; margin: 0 auto; padding: 2rem; }
+.blog-post-preview {
+    background: var(--surface-card); border: 1px solid var(--border-card);
+    border-radius: 12px; margin-bottom: 2rem; overflow: hidden; transition: all 0.3s ease;
+}
+.blog-post-preview:hover { border-color: var(--border-card-hover); transform: translateY(-5px); }
+.blog-post-preview a { text-decoration: none; color: inherit; display: block; padding: 1.5rem; }
+.blog-post-preview a:hover { text-decoration: none; }
+.blog-post-preview h2 {
+    font-size: 1.5rem; margin-bottom: 0.5rem;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+.blog-post-preview p { color: var(--text-body); margin: 0.5rem 0; }
+.blog-date { color: var(--text-dim); font-size: 0.85rem; }
+.cluster-section { margin-bottom: 3rem; }
+.cluster-section h2 {
+    font-size: 1.8rem; margin-bottom: 1.5rem;
+    background: linear-gradient(45deg, #fff, #7EB2FF);
+    -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+}
+@media (max-width: 768px) {
+    .nav-content { padding: 0 1rem; }
+    .blog-hero { padding: 4rem 1rem; }
+    .blog-hero h1 { font-size: 2.5rem; }
+    .blog-content { padding: 1rem; }
+    .blog-content h2 { font-size: 1.6rem; }
+    .related-grid { grid-template-columns: 1fr; }
+    .nav-link { padding: 0.5rem 1rem; font-size: 0.85rem; }
+}
+"#;
+
+const ANALYTICS: &str = r#"
+    <script defer data-website-id="68c9baf36c40f6f0060e0d5a" data-domain="lightfriend.ai" src="https://datafa.st/js/script.js"></script>
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-G812WMEHC6"></script>
+    <script>window.dataLayer=window.dataLayer||[];function gtag(){dataLayer.push(arguments);}gtag('js',new Date());gtag('config','G-G812WMEHC6');</script>
+"#;
+
+fn html_escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+fn format_date(date: &str) -> String {
+    // "2026-04-12" -> "April 12, 2026"
+    let months = [
+        "January",
+        "February",
+        "March",
+        "April",
+        "May",
+        "June",
+        "July",
+        "August",
+        "September",
+        "October",
+        "November",
+        "December",
+    ];
+    let parts: Vec<&str> = date.split('-').collect();
+    if parts.len() != 3 {
+        return date.to_string();
+    }
+    let month_idx: usize = parts[1].parse::<usize>().unwrap_or(1).saturating_sub(1);
+    let day: u32 = parts[2].parse().unwrap_or(1);
+    let year = parts[0];
+    let month_name = months.get(month_idx).unwrap_or(&"");
+    format!("{} {}, {}", month_name, day, year)
+}
+
+pub fn render_blog_post(post: &BlogPost, related: &[BlogPost]) -> String {
+    let schema_json_ld = schema::generate_schema(post);
+    let faq_html = linking::render_faq_section(post);
+    let related_html = linking::render_related_section(related);
+    let hub_link = linking::render_hub_link(post);
+    let keywords_meta = if post.frontmatter.keywords.is_empty() {
+        String::new()
+    } else {
+        format!(
+            r#"    <meta name="keywords" content="{}">"#,
+            html_escape(&post.frontmatter.keywords.join(", "))
+        )
+    };
+    let ai_summary_meta = match &post.frontmatter.ai_summary {
+        Some(s) => format!(
+            r#"    <meta name="ai-summary" content="{}">"#,
+            html_escape(s)
+        ),
+        None => String::new(),
+    };
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
+    <title>{title} - Lightfriend</title>
+    <meta name="description" content="{description}">
+{keywords_meta}
+{ai_summary_meta}
+    <link rel="canonical" href="https://lightfriend.ai/blog/{slug}">
+    <meta property="og:title" content="{title}">
+    <meta property="og:description" content="{description}">
+    <meta property="og:url" content="https://lightfriend.ai/blog/{slug}">
+    <meta property="og:type" content="article">
+    <meta property="og:site_name" content="Lightfriend">
+    <meta name="twitter:card" content="summary">
+    <meta name="twitter:title" content="{title}">
+    <meta name="twitter:description" content="{description}">
+    {schema_json_ld}
+    <link rel="icon" type="image/png" href="/assets/fav.png">
+{analytics}
+    <style>{css}</style>
+</head>
+<body>
+    <nav class="top-nav">
+        <div class="nav-content">
+            <div class="nav-left">
+                <a href="/" class="nav-logo">lightfriend</a>
+            </div>
+            <div class="nav-right">
+                <a href="/blog" class="nav-link">Blog</a>
+                <a href="/pricing" class="nav-link">Pricing</a>
+                <a href="/login" class="nav-link">Login</a>
+            </div>
+        </div>
+    </nav>
+    <div class="blog-page">
+        {hub_link}
+        <article class="blog-content" itemscope itemtype="https://schema.org/Article">
+            <header class="blog-hero">
+                <h1 itemprop="headline">{title}</h1>
+                <p class="blog-meta">
+                    <time datetime="{date}" itemprop="datePublished">{formatted_date}</time>
+                </p>
+            </header>
+            <div itemprop="articleBody">
+                {rendered_html}
+            </div>
+        </article>
+        {faq_html}
+        {related_html}
+        <div class="blog-cta">
+            <h3>Works with any phone that can text</h3>
+            <a href="/pricing" class="hero-cta">Get Started</a>
+            <p>No smartphone needed. No app to install.</p>
+        </div>
+    </div>
+    <footer class="blog-footer">
+        <div class="footer-links">
+            <a href="/">Home</a>
+            <a href="/blog">Blog</a>
+            <a href="/pricing">Pricing</a>
+            <a href="/terms">Terms</a>
+            <a href="/privacy">Privacy</a>
+            <a href="https://github.com/ahtavarasmus/lightfriend" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </div>
+        <p>Lightfriend - Open source under AGPLv3</p>
+    </footer>
+</body>
+</html>"#,
+        title = html_escape(&post.frontmatter.title),
+        description = html_escape(&post.frontmatter.description),
+        slug = post.frontmatter.slug,
+        date = post.frontmatter.date,
+        formatted_date = format_date(&post.frontmatter.date),
+        rendered_html = post.rendered_html,
+        schema_json_ld = schema_json_ld,
+        keywords_meta = keywords_meta,
+        ai_summary_meta = ai_summary_meta,
+        hub_link = hub_link,
+        faq_html = faq_html,
+        related_html = related_html,
+        css = INLINE_CSS,
+        analytics = ANALYTICS,
+    )
+}
+
+pub fn render_blog_index(
+    slugs: &[String],
+    posts: &HashMap<String, BlogPost>,
+    clusters: &HashMap<String, Vec<String>>,
+) -> String {
+    let cluster_names = [
+        ("messaging", "Messaging Without a Smartphone"),
+        ("ai-assistant", "AI Assistant Guides"),
+        ("privacy", "Privacy and Security"),
+        ("minimalism", "Digital Minimalism"),
+        ("problems", "Solve Everyday Problems"),
+        ("comparisons", "Comparisons"),
+    ];
+
+    // Existing hand-coded posts (link to their current top-level routes)
+    let existing_posts = vec![
+        ("/prompt-injection-safe", "Why Lightfriend Can't Be Prompt Injected", "Most AI assistants are powerful enough to be dangerous. Lightfriend is read-only by default.", "April 10, 2026"),
+        ("/telegram-on-dumbphone", "How to Use Telegram on a Dumbphone", "Send and receive Telegram messages from any basic phone via SMS.", "April 10, 2026"),
+        ("/signal-on-dumbphone", "How to Use Signal on a Dumbphone", "Use Signal encrypted messaging on any flip phone or basic phone.", "April 10, 2026"),
+        ("/how-to-read-more-accidentally", "How to Read Books Accidentally", "How to Read More Without Willpower", "August 21, 2025"),
+        ("/how-to-switch-to-dumbphone", "How to Switch to a Dumbphone", "All the things you need to consider when joining the dumbphone revolution.", "August 19, 2025"),
+        ("/light-phone-3-whatsapp-guide", "Light Phone 3 WhatsApp Guide", "Add WhatsApp functionality to your Light Phone 3 without compromising its minimalist design.", "August 13, 2025"),
+    ];
+
+    let mut existing_cards = String::new();
+    for (path, title, desc, date) in &existing_posts {
+        existing_cards.push_str(&format!(
+            r#"<div class="blog-post-preview"><a href="{}"><h2>{}</h2><p>{}</p><span class="blog-date">{}</span></a></div>
+"#,
+            path,
+            html_escape(title),
+            html_escape(desc),
+            date
+        ));
+    }
+
+    // Cluster sections with programmatic posts
+    let mut cluster_sections = String::new();
+    for (cluster_id, cluster_title) in &cluster_names {
+        if let Some(cluster_slugs) = clusters.get(*cluster_id) {
+            if cluster_slugs.is_empty() {
+                continue;
+            }
+            let mut section_cards = String::new();
+            // Show hubs first, then recent posts, cap at 6 per cluster on the index
+            let mut sorted_slugs = cluster_slugs.clone();
+            sorted_slugs.sort_by(|a, b| {
+                let a_hub = posts.get(a).map_or(false, |p| p.frontmatter.cluster_hub);
+                let b_hub = posts.get(b).map_or(false, |p| p.frontmatter.cluster_hub);
+                b_hub.cmp(&a_hub).then_with(|| {
+                    let da = posts.get(a).map(|p| &p.frontmatter.date);
+                    let db = posts.get(b).map(|p| &p.frontmatter.date);
+                    db.cmp(&da)
+                })
+            });
+            for slug in sorted_slugs.iter().take(6) {
+                if let Some(post) = posts.get(slug) {
+                    section_cards.push_str(&format!(
+                        r#"<div class="blog-post-preview"><a href="/blog/{}"><h2>{}</h2><p>{}</p><span class="blog-date">{}</span></a></div>
+"#,
+                        post.frontmatter.slug,
+                        html_escape(&post.frontmatter.title),
+                        html_escape(&post.frontmatter.description),
+                        format_date(&post.frontmatter.date)
+                    ));
+                }
+            }
+            if !section_cards.is_empty() {
+                cluster_sections.push_str(&format!(
+                    r#"<div class="cluster-section"><h2>{}</h2>{}</div>"#,
+                    html_escape(cluster_title),
+                    section_cards
+                ));
+            }
+        }
+    }
+
+    // Recent programmatic posts (latest 10 across all clusters)
+    let mut recent_cards = String::new();
+    let recent_count = slugs.len().min(10);
+    for slug in slugs.iter().take(recent_count) {
+        if let Some(post) = posts.get(slug) {
+            recent_cards.push_str(&format!(
+                r#"<div class="blog-post-preview"><a href="/blog/{}"><h2>{}</h2><p>{}</p><span class="blog-date">{}</span></a></div>
+"#,
+                post.frontmatter.slug,
+                html_escape(&post.frontmatter.title),
+                html_escape(&post.frontmatter.description),
+                format_date(&post.frontmatter.date)
+            ));
+        }
+    }
+
+    format!(
+        r#"<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
+    <title>Blog - Lightfriend Guides</title>
+    <meta name="description" content="Guides and insights on using messaging apps without a smartphone, AI assistants via SMS, digital minimalism, and verifiable privacy.">
+    <link rel="canonical" href="https://lightfriend.ai/blog">
+    <meta property="og:title" content="Blog - Lightfriend">
+    <meta property="og:description" content="Guides on messaging without a smartphone, AI via SMS, and digital minimalism.">
+    <meta property="og:url" content="https://lightfriend.ai/blog">
+    <meta property="og:type" content="website">
+    <meta property="og:site_name" content="Lightfriend">
+    <link rel="icon" type="image/png" href="/assets/fav.png">
+{analytics}
+    <style>{css}</style>
+</head>
+<body>
+    <nav class="top-nav">
+        <div class="nav-content">
+            <div class="nav-left">
+                <a href="/" class="nav-logo">lightfriend</a>
+            </div>
+            <div class="nav-right">
+                <a href="/blog" class="nav-link">Blog</a>
+                <a href="/pricing" class="nav-link">Pricing</a>
+                <a href="/login" class="nav-link">Login</a>
+            </div>
+        </div>
+    </nav>
+    <div class="blog-page">
+        <header class="blog-hero">
+            <h1>Blog</h1>
+            <p class="blog-meta">Guides, insights, and answers for people who want to stay connected without a smartphone.</p>
+        </header>
+        <section class="blog-list-section">
+            <div class="cluster-section">
+                <h2>Featured</h2>
+                {existing_cards}
+            </div>
+            {cluster_sections}
+        </section>
+        <div class="blog-cta">
+            <h3>Works with any phone that can text</h3>
+            <a href="/pricing" class="hero-cta">Get Started</a>
+            <p>No smartphone needed. No app to install.</p>
+        </div>
+    </div>
+    <footer class="blog-footer">
+        <div class="footer-links">
+            <a href="/">Home</a>
+            <a href="/blog">Blog</a>
+            <a href="/pricing">Pricing</a>
+            <a href="/terms">Terms</a>
+            <a href="/privacy">Privacy</a>
+            <a href="https://github.com/ahtavarasmus/lightfriend" target="_blank" rel="noopener noreferrer">GitHub</a>
+        </div>
+        <p>Lightfriend - Open source under AGPLv3</p>
+    </footer>
+</body>
+</html>"#,
+        existing_cards = existing_cards,
+        cluster_sections = cluster_sections,
+        css = INLINE_CSS,
+        analytics = ANALYTICS,
+    )
+}

--- a/backend/src/jobs/scheduler.rs
+++ b/backend/src/jobs/scheduler.rs
@@ -1192,42 +1192,26 @@ fn render_high_signal_section(
     Some(block)
 }
 
-/// Render a low-signal section as a single inline sender list:
-/// "FYI from Sarah, John, Newsletter (+2 more)".
-/// Used for FYI to keep the digest from blowing up when there are many
-/// medium-urgency messages.
+/// How many FYI items to show individually before collapsing to counts.
+const FYI_CAP: usize = 5;
+
+/// Render FYI section with per-item summaries, similar to high-signal sections
+/// but with a higher cap since these are shorter teasers.
 fn render_fyi_inline(messages: &[crate::models::ontology_models::OntMessage]) -> Option<String> {
     if messages.is_empty() {
         return None;
     }
     let total = messages.len();
-    // Dedupe sender names while preserving order
-    let mut seen = std::collections::HashSet::new();
-    let mut names: Vec<String> = Vec::new();
-    for m in messages {
-        if seen.insert(m.sender_name.clone()) {
-            names.push(m.sender_name.clone());
-            if names.len() >= NAMES_LIST_CAP {
-                break;
-            }
-        }
-    }
-    let unique_total = messages
+    let shown: Vec<String> = messages
         .iter()
-        .map(|m| &m.sender_name)
-        .collect::<std::collections::HashSet<_>>()
-        .len();
-    let names_str = names.join(", ");
-    let suffix = if unique_total > names.len() {
-        format!(" +{} more", unique_total - names.len())
-    } else {
-        String::new()
-    };
-    let count_label = if total == 1 { "msg" } else { "msgs" };
-    Some(format!(
-        "FYI ({} {}): {}{}",
-        total, count_label, names_str, suffix
-    ))
+        .take(FYI_CAP)
+        .map(format_digest_message)
+        .collect();
+    let mut block = format!("FYI:\n{}", shown.join("\n"));
+    if total > FYI_CAP {
+        block.push_str(&format!("\n+ {} more", total - FYI_CAP));
+    }
+    Some(block)
 }
 
 /// Build a sectioned digest for a single user.

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -136,6 +136,13 @@ pub mod ontology {
 }
 pub mod ai_config;
 pub use ai_config::{AiConfig, AiProvider, ModelPurpose};
+pub mod blog {
+    pub mod content;
+    pub mod handlers;
+    pub mod linking;
+    pub mod schema;
+    pub mod templates;
+}
 
 // Test utilities for integration tests
 pub mod test_utils;
@@ -240,6 +247,7 @@ pub struct AppState {
     pub tool_registry: tools::registry::ToolRegistry,
     pub pending_rule_tests: Arc<DashMap<String, handlers::rule_handlers::PendingRuleTest>>,
     pub maintenance_mode: Arc<AtomicBool>,
+    pub blog_store: Arc<blog::content::BlogStore>,
     // (user_id, room_id) -> unix timestamp of last system_important notification
     pub system_notify_cooldowns: DashMap<(i32, String), i32>,
     // user_id -> unix timestamp of last digest delivery

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -26,7 +26,7 @@ use tracing::Level;
 // Import modules and types from library crate
 use api::{twilio_sms, voice_pipeline};
 use backend::{
-    api, handlers, jobs, utils, AdminAlertRepository, AiConfig, AppState, LlmUsageRepository,
+    api, blog, handlers, jobs, utils, AdminAlertRepository, AiConfig, AppState, LlmUsageRepository,
     TotpRepository, UserCore, UserCoreOps, UserRepository, WebauthnRepository,
 };
 use handlers::{
@@ -524,6 +524,15 @@ async fn main() {
         tool_registry: backend::build_tool_registry(),
         pending_rule_tests: Arc::new(DashMap::new()),
         maintenance_mode: Arc::new(AtomicBool::new(false)),
+        blog_store: Arc::new(
+            blog::content::BlogStore::load("content/blog").unwrap_or_else(|e| {
+                tracing::warn!(
+                    "Failed to load blog content: {}. Starting with empty blog.",
+                    e
+                );
+                blog::content::BlogStore::load("/dev/null").unwrap()
+            }),
+        ),
         system_notify_cooldowns: DashMap::new(),
         digest_cooldowns: DashMap::new(),
         activity_feed_tx: tokio::sync::broadcast::channel(64).0,
@@ -1305,6 +1314,10 @@ async fn main() {
         .route("/public/{*path}", any(proxy_telegram_public))
         .route("/public", any(proxy_telegram_public))
         .nest_service("/uploads", ServeDir::new("uploads"))
+        .route("/blog/{slug}.md", get(blog::handlers::blog_post_md_handler))
+        .route("/blog/{slug}", get(blog::handlers::blog_post_handler))
+        .route("/blog", get(blog::handlers::blog_index_handler))
+        .route("/sitemap.xml", get(blog::handlers::sitemap_handler))
         .fallback_service(
             ServeDir::new("public").not_found_service(ServeFile::new("public/index.html")),
         )

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -165,6 +165,10 @@ pub fn create_test_state() -> Arc<crate::AppState> {
         system_notify_cooldowns: dashmap::DashMap::new(),
         digest_cooldowns: dashmap::DashMap::new(),
         activity_feed_tx: tokio::sync::broadcast::channel(64).0,
+        blog_store: Arc::new(
+            crate::blog::content::BlogStore::load("/nonexistent")
+                .unwrap_or_else(|_| crate::blog::content::BlogStore::empty()),
+        ),
     })
 }
 

--- a/backend/tests/digest_layout_test.rs
+++ b/backend/tests/digest_layout_test.rs
@@ -672,7 +672,7 @@ async fn full_digest_renders_all_sections() {
     let imp_pos = digest_text
         .find("Important:")
         .expect("Important section missing");
-    let fyi_pos = digest_text.find("FYI (").expect("FYI section missing");
+    let fyi_pos = digest_text.find("FYI:").expect("FYI section missing");
     let new_pos = digest_text.find("New:").expect("New section missing");
     let done_pos = digest_text.find("Done:").expect("Done section missing");
     let cta_pos = digest_text
@@ -708,12 +708,10 @@ async fn full_digest_renders_all_sections() {
     assert!(!digest_text.contains("WIN A FREE IPHONE"));
     assert!(!digest_text.contains("Spammer"));
 
-    // FYI is collapsed to a single sender list
-    assert!(digest_text.contains("Sarah"));
-    assert!(digest_text.contains("John"));
-    assert!(digest_text.contains("Newsletter"));
-    // FYI has the count format "FYI (3 msgs):"
-    assert!(digest_text.contains("FYI (3 msgs)"));
+    // FYI shows per-item summaries like high-signal sections
+    assert!(digest_text.contains("- Sarah:"));
+    assert!(digest_text.contains("- John:"));
+    assert!(digest_text.contains("- Newsletter:"));
 
     // Recently added + Just done are inline single-line lists
     assert!(digest_text.contains("Buy birthday gift"));
@@ -730,10 +728,10 @@ async fn full_digest_renders_all_sections() {
     // the visible count, so they don't reappear next cycle.
     assert_eq!(message_ids.len(), 6);
 
-    // Sanity: total length should comfortably fit in 4 segments (640 chars)
+    // Sanity: total length should fit in 5 segments (800 chars)
     assert!(
-        digest_text.len() < 640,
-        "digest should fit in 4 segments, got {} chars",
+        digest_text.len() < 800,
+        "digest should fit in 5 segments, got {} chars",
         digest_text.len()
     );
 }
@@ -806,9 +804,9 @@ async fn digest_skips_critical_section_when_pushes_enabled() {
     // No Critical or Important section - those went via instant SMS
     assert!(!digest_text.contains("Critical:"));
     assert!(!digest_text.contains("Important:"));
-    // FYI section still present (collapsed list format)
-    assert!(digest_text.contains("FYI ("));
-    assert!(digest_text.contains("Friend"));
+    // FYI section still present with per-item summaries
+    assert!(digest_text.contains("FYI:"));
+    assert!(digest_text.contains("- Friend:"));
     // Mom and Boss were filtered (their content shouldn't appear)
     assert!(!digest_text.contains("- Mom"));
     assert!(!digest_text.contains("- Boss"));
@@ -903,18 +901,18 @@ async fn digest_stays_compact_on_busy_day() {
         "8 imp → 3 shown + '+5 more'"
     );
 
-    // FYI shows count + sender list (no per-item lines)
-    assert!(digest_text.contains("FYI (25 msgs)"));
-    // Sender list capped at 5 names + "+N more"
+    // FYI shows per-item summaries capped at 5
+    assert!(digest_text.contains("FYI:"));
     assert!(
-        digest_text.contains("+7 more"),
-        "12 unique senders → 5 shown + '+7 more'"
+        digest_text.contains("+ 20 more"),
+        "25 fyi → 5 shown + '+20 more'"
     );
 
-    // Stays comfortably under 4 segments even with 38 total messages
+    // With per-item FYI summaries the digest is larger, but should still
+    // stay under 6 segments (960 chars) even on a busy day.
     assert!(
-        digest_text.len() < 640,
-        "busy digest should still fit in 4 segments, got {} chars",
+        digest_text.len() < 960,
+        "busy digest should fit in 6 segments, got {} chars",
         digest_text.len()
     );
 

--- a/frontend/src/pages/termsprivacy.rs
+++ b/frontend/src/pages/termsprivacy.rs
@@ -14,15 +14,24 @@ pub fn privacy_policy() -> Html {
     html! {
         <div class="legal-content privacy-policy">
             <h1>{"Privacy Policy"}</h1>
+            <p class="last-updated">{"Last updated: April 12, 2026"}</p>
 
             <section>
                 <h2>{"1. Overview"}</h2>
-                <p>{"Lightfriend is a verifiable system. Its privacy properties are enforced by architecture, not policy, and can be independently verified by anyone. This document describes how the system is designed to work. It is not a warranty. See Section 14."}</p>
+                <p>{"Lightfriend is a verifiable system. Its privacy properties are enforced by architecture, not policy, and can be independently verified by anyone. This document describes how the system is designed to work. It is not a warranty. See Section 16."}</p>
                 <p>{"For a plain-language explanation, see "}<Link<Route> to={Route::Trustless}>{"Verifiably Private"}</Link<Route>>{"."}</p>
             </section>
 
             <section>
-                <h2>{"2. What Data Enters the System"}</h2>
+                <h2>{"2. Data Controller"}</h2>
+                <p>{"The data controller is Rasmus Multiverse (sole proprietorship of Rasmus \u{00C4}ht\u{00E4}v\u{00E4}), Tampere, Finland."}</p>
+                <p>{"Contact: "}<a href="mailto:rasmus@lightfriend.ai">{"rasmus@lightfriend.ai"}</a></p>
+                <p>{"Given the current scale of operations, we have not appointed a Data Protection Officer. You may direct all data protection inquiries to the contact address above."}</p>
+                <p>{"You have the right to lodge a complaint with the Finnish Data Protection Ombudsman ("}<a href="https://tietosuoja.fi/en" target="_blank" rel="noopener noreferrer">{"tietosuoja.fi"}</a>{") or your local EU/EEA supervisory authority."}</p>
+            </section>
+
+            <section>
+                <h2>{"3. What Data Enters the System"}</h2>
                 <p>{"When you use Lightfriend, the following data enters the enclave environment:"}</p>
                 <ul>
                     <li>{"Phone number and email address (for account access and identification)"}</li>
@@ -37,7 +46,7 @@ pub fn privacy_policy() -> Html {
             </section>
 
             <section>
-                <h2>{"3. How the System is Designed"}</h2>
+                <h2>{"4. How the System is Designed"}</h2>
                 <p>{"Lightfriend runs inside an AWS Nitro Enclave - an isolated environment designed to prevent anyone, including us, from accessing data inside it. The system is designed so that:"}</p>
                 <ul>
                     <li>{"The enclave is designed so that no one can log in, inspect memory, or extract data."}</li>
@@ -48,33 +57,62 @@ pub fn privacy_policy() -> Html {
             </section>
 
             <section>
-                <h2>{"4. Verification"}</h2>
+                <h2>{"5. Verification"}</h2>
                 <p>{"Anyone can verify what code is running by comparing the live enclave's cryptographic attestation against our public builds. Verification tools, API endpoints, and instructions are on our "}<Link<Route> to={Route::Trustless}>{"Verifiably Private"}</Link<Route>>{" page."}</p>
             </section>
 
             <section>
-                <h2>{"5. Third-Party Services"}</h2>
-                <p>{"The system depends on third-party infrastructure. We do not control these services and are not responsible for their behavior."}</p>
+                <h2>{"6. Legal Basis for Processing"}</h2>
+                <p>{"Under GDPR Article 6, we process your personal data on the following bases:"}</p>
                 <ul>
-                    <li><strong>{"AWS Nitro Enclaves: "}</strong>{"Provides the sealed environment. Isolation depends on Amazon's hardware and software."}</li>
-                    <li><strong>{"Marlin: "}</strong>{"Key custody. Runs inside its own enclave. Open source."}</li>
-                    <li><strong>{"Tinfoil: "}</strong>{"AI inference inside sealed environments with cryptographic attestation."}</li>
-                    <li><strong>{"Twilio: "}</strong>{"SMS delivery. Message content is designed to be deleted from Twilio after delivery."}</li>
+                    <li><strong>{"Contract performance (Art. 6(1)(b)): "}</strong>{"Account creation and management, message processing via bridges, integration connections, and service delivery."}</li>
+                    <li><strong>{"Consent (Art. 6(1)(a)): "}</strong>{"AI personalization based on your profile information. You may withdraw consent at any time by updating your profile or contacting us. Withdrawal does not affect the lawfulness of processing before withdrawal."}</li>
+                    <li><strong>{"Legitimate interest (Art. 6(1)(f)): "}</strong>{"Security monitoring, fraud prevention, and service improvement. We have balanced these interests against your rights and determined that processing is proportionate given the privacy-preserving architecture of the system."}</li>
+                    <li><strong>{"Legal obligation (Art. 6(1)(c)): "}</strong>{"Billing records retention as required by Finnish accounting law."}</li>
                 </ul>
             </section>
 
             <section>
-                <h2>{"6. AI Processing"}</h2>
-                <p>{"AI processing happens inside sealed environments (enclave and Tinfoil). AI outputs are automatic and may be inaccurate, incomplete, or inappropriate. You are solely responsible for deciding whether and how to act on them. Lightfriend does not review or endorse AI-generated content."}</p>
+                <h2>{"7. Third-Party Services and Sub-processors"}</h2>
+                <p>{"The system depends on third-party infrastructure. Where required by GDPR Article 28, we maintain Data Processing Agreements with our sub-processors or rely on the processor's standard data protection terms. We do not control these services and are not responsible for their behavior."}</p>
+                <ul>
+                    <li><strong>{"AWS (Amazon Web Services, Inc. - US): "}</strong>{"Provides the Nitro Enclave sealed environment and hosting infrastructure. Isolation depends on Amazon's hardware and software."}</li>
+                    <li><strong>{"Marlin (Marlin Protocol - decentralized): "}</strong>{"Key custody. Runs inside its own enclave. Open source."}</li>
+                    <li><strong>{"Tinfoil (Tinfoil, Inc. - US): "}</strong>{"AI inference inside sealed environments with cryptographic attestation."}</li>
+                    <li><strong>{"Twilio (Twilio, Inc. - US): "}</strong>{"SMS and voice delivery. Message content is designed to be deleted from Twilio after delivery."}</li>
+                    <li><strong>{"Stripe (Stripe, Inc. - US): "}</strong>{"Payment processing. We do not store credit card numbers. All payment data is handled by Stripe in accordance with PCI DSS standards."}</li>
+                </ul>
+                <p>{"A current list of sub-processors is available upon request at rasmus@lightfriend.ai."}</p>
             </section>
 
             <section>
-                <h2>{"7. Messaging Integrations"}</h2>
+                <h2>{"8. International Data Transfers"}</h2>
+                <p>{"Some of our sub-processors are based in the United States. Data transferred outside the EU/EEA is protected by the following safeguards:"}</p>
+                <ul>
+                    <li>{"Where applicable, our sub-processors participate in the EU-US Data Privacy Framework or provide Standard Contractual Clauses (SCCs) approved by the European Commission."}</li>
+                    <li>{"As a supplementary measure, data stored outside the enclave is encrypted with keys that exist only inside the enclave, meaning sub-processors cannot access plaintext data."}</li>
+                </ul>
+            </section>
+
+            <section>
+                <h2>{"9. AI Processing and Transparency"}</h2>
+                <p>{"Lightfriend uses artificial intelligence systems to process your messages and generate responses, summaries, and suggested actions. In accordance with the EU AI Act:"}</p>
+                <ul>
+                    <li>{"AI processing is performed by third-party large language models accessed through Tinfoil's sealed inference environment."}</li>
+                    <li>{"AI-generated content is produced automatically. It may be inaccurate, incomplete, or inappropriate."}</li>
+                    <li>{"No automated decision with legal or similarly significant effects is made without your involvement. All AI outputs are recommendations - you decide whether and how to act on them."}</li>
+                    <li>{"Lightfriend does not review or endorse AI-generated content."}</li>
+                </ul>
+            </section>
+
+            <section>
+                <h2>{"10. Messaging Integrations"}</h2>
                 <p>{"Messages from your connected platforms enter the enclave for processing. Connection data and messages are stored encrypted inside the enclave. You are solely responsible for message content. Lightfriend acts as a technical intermediary."}</p>
+                <p>{"Connections to messaging platforms such as WhatsApp, Signal, and Telegram use open-source bridge software that is not an official client of those platforms. Using these integrations may carry risks including account restrictions by the platform provider. See our Terms and Conditions for full details."}</p>
             </section>
 
             <section>
-                <h2>{"8. YouTube Integration"}</h2>
+                <h2>{"11. YouTube Integration"}</h2>
                 <p>{"Uses YouTube API Services. By using this feature you agree to the "}<a href="https://www.youtube.com/t/terms" target="_blank" rel="noopener noreferrer">{"YouTube Terms of Service"}</a>{" and "}<a href="http://www.google.com/policies/privacy" target="_blank" rel="noopener noreferrer">{"Google Privacy Policy"}</a>{"."}</p>
                 <ul>
                     <li>{"We store encrypted OAuth tokens to access YouTube on your behalf."}</li>
@@ -86,56 +124,83 @@ pub fn privacy_policy() -> Html {
             </section>
 
             <section>
-                <h2>{"9. Vehicle Integration (Tesla)"}</h2>
+                <h2>{"12. Vehicle Integration (Tesla)"}</h2>
                 <p>{"THIS IS AN EXPERIMENTAL SERVICE. Commands may control real vehicle functions. YOU ACCEPT FULL RESPONSIBILITY for all commands and their consequences. Lightfriend accepts NO LIABILITY for any accidents, damage, injury, theft, or loss resulting from vehicle commands."}</p>
             </section>
 
             <section>
-                <h2>{"10. Email, MCP, and Other Integrations"}</h2>
-                <p>{"All integration credentials are stored encrypted inside the enclave. You connect services at your own risk and are responsible for your accounts with third-party services. MCP server data may leave the enclave when sent to your configured external servers. We are not liable for third-party service behavior."}</p>
+                <h2>{"13. Email, MCP, and Other Integrations"}</h2>
+                <p>{"All integration credentials are stored encrypted inside the enclave. You connect services at your own risk and are responsible for your accounts with third-party services. We are not liable for third-party service behavior."}</p>
+                <p><strong>{"IMPORTANT: "}</strong>{"When you configure MCP (Model Context Protocol) servers, data processed by those servers leaves the sealed enclave environment and is sent to your configured external servers. The privacy guarantees of the enclave do not extend to data processed by external MCP servers. You assume full responsibility for any MCP servers you configure."}</p>
             </section>
 
             <section>
-                <h2>{"11. Your Rights"}</h2>
+                <h2>{"14. Your Rights"}</h2>
+                <p>{"Under GDPR, you have the following rights regarding your personal data:"}</p>
                 <ul>
-                    <li>{"Access and modify your personal data"}</li>
-                    <li>{"Request account deletion"}</li>
-                    <li>{"Disconnect any integration at any time"}</li>
-                    <li>{"Verify the system's privacy properties yourself"}</li>
+                    <li><strong>{"Access: "}</strong>{"Request a copy of the personal data we hold about you."}</li>
+                    <li><strong>{"Rectification: "}</strong>{"Request correction of inaccurate personal data."}</li>
+                    <li><strong>{"Erasure: "}</strong>{"Request deletion of your personal data. Upon receiving a deletion request, we will erase your personal data within 30 days, except where retention is required by law."}</li>
+                    <li><strong>{"Data portability: "}</strong>{"Receive your personal data in a structured, commonly used, machine-readable format."}</li>
+                    <li><strong>{"Restriction: "}</strong>{"Request restriction of processing in certain circumstances."}</li>
+                    <li><strong>{"Objection: "}</strong>{"Object to processing based on legitimate interests."}</li>
+                    <li><strong>{"Withdraw consent: "}</strong>{"Where processing is based on consent, withdraw it at any time."}</li>
+                    <li><strong>{"Automated decisions: "}</strong>{"Not be subject to decisions based solely on automated processing that produce legal or similarly significant effects."}</li>
+                    <li>{"Disconnect any integration at any time."}</li>
+                    <li>{"Verify the system's privacy properties yourself."}</li>
                 </ul>
+                <p>{"To exercise any of these rights, contact rasmus@lightfriend.ai or use the account settings in the Service. We will respond within 30 days."}</p>
             </section>
 
             <section>
-                <h2>{"12. Data Retention"}</h2>
-                <p>{"Data is retained until you delete your account or legal requirements are met. Stored data is encrypted with keys that exist only inside the enclave."}</p>
+                <h2>{"15. Data Retention"}</h2>
+                <ul>
+                    <li><strong>{"Messages and integration data: "}</strong>{"Retained until you disconnect the integration or delete your account."}</li>
+                    <li><strong>{"Authentication tokens: "}</strong>{"Deleted when you disconnect an integration."}</li>
+                    <li><strong>{"Billing records: "}</strong>{"Retained for 6 years as required by Finnish accounting law (Kirjanpitolaki)."}</li>
+                    <li><strong>{"Account data: "}</strong>{"Deleted within 30 days of account deletion, except where retention is required by law."}</li>
+                </ul>
+                <p>{"All stored data is encrypted with keys that exist only inside the enclave."}</p>
             </section>
 
             <section>
-                <h2>{"13. Legal Basis"}</h2>
-                <p>{"Data is processed on the basis of contract fulfillment, your consent for AI personalization, and legitimate business interests (billing, security)."}</p>
-            </section>
-
-            <section>
-                <h2>{"14. Disclaimers"}</h2>
-                <p>{"This policy describes system design and intent, not warranties."}</p>
+                <h2>{"16. Disclaimers"}</h2>
+                <p>{"Lightfriend is open-source software hosted as a service. This policy describes the system's intended design as implemented in the publicly available source code. It is not a warranty or guarantee by the operator."}</p>
                 <ul>
                     <li>{"No system is perfectly secure. There may be vulnerabilities unknown to us."}</li>
                     <li>{"Security depends on third-party infrastructure functioning correctly. We do not control these systems."}</li>
                     <li>{"AI outputs may be wrong or harmful. You use them at your own risk."}</li>
                     <li>{"We built this in good faith. We do not warrant it will prevent all unauthorized access."}</li>
-                    <li>{"You can verify the system yourself. Use without verification is at your own discretion."}</li>
+                    <li>{"The source code is public and the running instance is cryptographically verifiable. You are responsible for verifying the system before relying on it. Use without verification is at your own discretion and risk."}</li>
                     <li>{"To the fullest extent permitted by law, Lightfriend disclaims all warranties regarding the security, privacy, or integrity of your data."}</li>
                 </ul>
             </section>
 
             <section>
-                <h2>{"15. Changes"}</h2>
-                <p>{"We may update this policy. Changes are visible here and in our open source repository. Continued use constitutes acceptance."}</p>
+                <h2>{"17. Data Breach Notification"}</h2>
+                <p>{"In the event of a personal data breach, we will notify the relevant supervisory authority within 72 hours of becoming aware of the breach, where feasible, in accordance with GDPR Article 33. If the breach is likely to result in a high risk to your rights and freedoms, we will also notify you without undue delay."}</p>
             </section>
 
             <section>
-                <h2>{"16. Contact"}</h2>
-                <p>{"rasmus@lightfriend.ai - Tampere, Finland"}</p>
+                <h2>{"18. Cookies"}</h2>
+                <p>{"We use strictly necessary cookies for authentication and session management. These cookies are required for the Service to function and cannot be disabled. We do not use tracking cookies, advertising cookies, or third-party analytics cookies."}</p>
+            </section>
+
+            <section>
+                <h2>{"19. Children"}</h2>
+                <p>{"The Service is not intended for children under the age of 16. We do not knowingly collect personal data from children under 16. If you become aware that a child has provided us with personal data, please contact us and we will delete it."}</p>
+            </section>
+
+            <section>
+                <h2>{"20. Changes"}</h2>
+                <p>{"We will notify you of material changes to this policy at least 30 days before they take effect, via email or through the Service. Changes are also visible in our open source repository. If you do not agree with the changes, you may terminate your account before the effective date. Continued use after the effective date constitutes acceptance."}</p>
+            </section>
+
+            <section>
+                <h2>{"21. Contact"}</h2>
+                <p>{"Rasmus Multiverse"}</p>
+                <p>{"Tampere, Finland"}</p>
+                <p><a href="mailto:rasmus@lightfriend.ai">{"rasmus@lightfriend.ai"}</a></p>
             </section>
             <div class="legal-links">
                 <Link<Route> to={Route::Terms}>{"Terms & Conditions"}</Link<Route>>
@@ -160,19 +225,21 @@ pub fn terms_and_conditions() -> Html {
     });
     html! {
         <div class="legal-content terms-and-conditions">
-            <h1>{"lightfriend Terms and Conditions"}</h1>
+            <h1>{"Lightfriend Terms and Conditions"}</h1>
             <p class="company-name">{"Provided by Rasmus Multiverse"}</p>
+            <p class="last-updated">{"Last updated: April 12, 2026"}</p>
 
             <section>
                 <h2>{"1. Introduction"}</h2>
-                <p>{"These Terms and Conditions (\"Terms\") govern your use of the lightfriend platform (\"Service\"). By accessing or using our Service, you agree to comply with and be bound by these Terms."}</p>
+                <p>{"These Terms and Conditions (\"Terms\") govern your use of the Lightfriend platform (\"Service\"), operated by Rasmus Multiverse (sole proprietorship of Rasmus \u{00C4}ht\u{00E4}v\u{00E4}), Tampere, Finland. By accessing or using our Service, you agree to comply with and be bound by these Terms."}</p>
+                <p>{"Lightfriend is open-source software hosted as a service. The entire source code is publicly available and the running instance is cryptographically verifiable. We make no guarantees beyond hosting the published code. You are responsible for reviewing the source code, verifying the cryptographic attestation, and satisfying yourself that the system behaves as described before relying on it. All claims about the system's behavior on our website and documentation are descriptions of the open-source code's intended design, not warranties or guarantees by the operator."}</p>
             </section>
 
             <section>
-                <h2>{"2. User Accounts"}</h2>
-                <p>{"To access certain features, you must create an account. You are responsible for maintaining the confidentiality of your account information and for all activities that occur under your account. lightfriend never has access to your passwords. Please do not provide your password to anyone claiming to be a representative of lightfriend, or any third party."}</p>
+                <h2>{"2. Eligibility and User Accounts"}</h2>
+                <p>{"You must be at least 16 years old to use the Service. By creating an account, you represent that you meet this age requirement."}</p>
+                <p>{"To access certain features, you must create an account. You are responsible for maintaining the confidentiality of your account information and for all activities that occur under your account. Lightfriend never has access to your passwords. Please do not provide your password to anyone claiming to be a representative of Lightfriend, or any third party."}</p>
             </section>
-
 
             <section>
                 <h2>{"3. Acceptable Use"}</h2>
@@ -181,14 +248,21 @@ pub fn terms_and_conditions() -> Html {
 
             <section>
                 <h2>{"4. Billing, Payments, and Refund Policy"}</h2>
-                <h3>{"Prepaid Credits and No Refunds Policy"}</h3>
+
+                <h3>{"Payment Processing"}</h3>
+                <p>{"Payment processing is handled by Stripe, Inc. We do not store your credit card information. All payment data is processed by Stripe in accordance with PCI DSS standards. Your use of payment features is also subject to "}<a href="https://stripe.com/legal" target="_blank" rel="noopener noreferrer">{"Stripe's terms of service"}</a>{"."}</p>
+
+                <h3>{"Prepaid Credits"}</h3>
                 <ul>
                     <li>{"The Service operates on a prepaid credit model where you purchase credits in advance to use for calling and texting features."}</li>
                     <li>{"Usage is deducted from your credit balance based on your actual consumption of the Service's features."}</li>
                     <li>{"You can optionally enable automatic top-up to add more credits to your account when your balance runs low, ensuring uninterrupted service."}</li>
-                    <li>{"Due to the nature of our service and its operational costs, we do not offer refunds. Credits purchased are non-refundable and can only be used for services consumed."}</li>
                     <li>{"Detailed usage information and credit history can be accessed through your account profile billing section."}</li>
                 </ul>
+
+                <h3>{"EU Right of Withdrawal"}</h3>
+                <p>{"Under the EU Consumer Rights Directive (2011/83/EU), you have a 14-day right of withdrawal for online purchases. However, by purchasing credits, you expressly consent that the digital content (credits) becomes available for use immediately upon purchase. You acknowledge that you thereby lose your right of withdrawal once credits are added to your account, pursuant to Article 16(m) of Directive 2011/83/EU."}</p>
+
                 <h3>{"AI Assistant Services"}</h3>
                 <ul>
                     <li>{"The Service provides AI-powered assistance based on the information you provide during registration and subsequent interactions."}</li>
@@ -208,7 +282,7 @@ pub fn terms_and_conditions() -> Html {
                 <h3>{"Service Modifications"}</h3>
                 <ul>
                     <li>{"We may modify the Service's features, pricing structure, or billing methods with reasonable notice."}</li>
-                    <li>{"Changes to pricing or fundamental service features will be communicated to users in advance."}</li>
+                    <li>{"Changes to pricing or fundamental service features will be communicated to users at least 30 days in advance."}</li>
                     <li>{"Continued use of the Service after such changes constitutes acceptance of the modifications."}</li>
                 </ul>
 
@@ -222,12 +296,14 @@ pub fn terms_and_conditions() -> Html {
 
             <section>
                 <h2>{"5. Intellectual Property"}</h2>
-                <p>{"All content provided on the Service, including text, graphics, logos, and software, is the property of lightfriend or its content suppliers and is protected by intellectual property laws."}</p>
+                <p>{"The Lightfriend name, logos, and visual branding are the property of Rasmus Multiverse and are protected by intellectual property laws. The Lightfriend software source code is licensed under the GNU Affero General Public License v3 (AGPLv3). Your rights to the source code are governed by that license. User-generated content remains your property."}</p>
             </section>
 
             <section>
                 <h2>{"6. Termination"}</h2>
-                <p>{"We reserve the right to suspend or terminate your access to the Service at our discretion, without notice, for conduct that we believe violates these Terms or is harmful to other users."}</p>
+                <p>{"We may suspend or terminate your access to the Service immediately and without notice for conduct that violates these Terms or is harmful to other users or the Service."}</p>
+                <p>{"If we terminate your account for reasons other than a violation of these Terms, we will provide 14 days' notice and refund any unused prepaid credits."}</p>
+                <p>{"You may terminate your account at any time through your account settings or by contacting us."}</p>
             </section>
 
             <section>
@@ -235,7 +311,7 @@ pub fn terms_and_conditions() -> Html {
                 <p>{"THE SERVICE IS PROVIDED \"AS IS\" AND \"AS AVAILABLE\" WITHOUT WARRANTIES OF ANY KIND, EXPRESS OR IMPLIED. TO THE FULLEST EXTENT PERMITTED BY LAW:"}</p>
                 <ul>
                     <li>{"Lightfriend makes no warranties regarding accuracy, reliability, availability, or security of the Service."}</li>
-                    <li>{"Lightfriend shall not be liable for any direct, indirect, incidental, special, consequential, or punitive damages arising from your use of or inability to use the Service."}</li>
+                    <li>{"Lightfriend shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising from your use of or inability to use the Service."}</li>
                     <li>{"Lightfriend is not responsible for any actions taken by third-party services, integrations, or AI models."}</li>
                     <li>{"The Service's privacy architecture depends on third-party infrastructure (AWS Nitro Enclaves, Marlin, Tinfoil, and others). Lightfriend does not warrant the correct functioning of these systems and is not liable for failures in third-party infrastructure."}</li>
                     <li>{"Descriptions of security architecture on the Service's website and documentation describe intended system design, not warranties. No computing system is perfectly secure."}</li>
@@ -243,6 +319,7 @@ pub fn terms_and_conditions() -> Html {
                     <li>{"The Service provides verification tools so you can independently assess its properties. Use of the Service without performing verification is at your own discretion and risk."}</li>
                     <li>{"In no event shall Lightfriend's total liability exceed the amount you paid for the Service in the preceding 12 months."}</li>
                 </ul>
+                <p>{"Nothing in these Terms excludes or limits our liability for: (a) death or personal injury caused by our negligence; (b) fraud or fraudulent misrepresentation; (c) any liability that cannot be excluded or limited under applicable law, including mandatory consumer protection laws of the European Union."}</p>
             </section>
 
             <section>
@@ -259,15 +336,15 @@ pub fn terms_and_conditions() -> Html {
 
             <section>
                 <h2>{"9. Vehicle Control Services (Tesla Integration)"}</h2>
-                <p>{"THIS IS AN EXPERIMENTAL SERVICE. BY USING THE TESLA INTEGRATION, YOU EXPRESSLY ACKNOWLEDGE AND AGREE:"}</p>
+                <p>{"THIS IS AN EXPERIMENTAL FEATURE. Vehicle control is entirely user-initiated: you choose to connect your vehicle account, you choose to enable the integration, and you choose to send each command. Lightfriend hosts the open-source code that relays your commands - it does not autonomously initiate vehicle actions. BY USING THE TESLA INTEGRATION, YOU EXPRESSLY ACKNOWLEDGE AND AGREE:"}</p>
                 <ul>
                     <li>{"Commands sent through Lightfriend may control real vehicle functions including unlocking, climate control, and other operations."}</li>
-                    <li>{"YOU ACCEPT FULL AND SOLE RESPONSIBILITY for all vehicle commands you send and their consequences."}</li>
+                    <li>{"YOU ACCEPT FULL AND SOLE RESPONSIBILITY for all vehicle commands and their consequences. You initiated the connection, you enabled the integration, and you sent or approved the command."}</li>
                     <li>{"You must verify that conditions are safe before sending any vehicle command."}</li>
+                    <li>{"The integration code is open source. You are responsible for reviewing it and satisfying yourself that it behaves acceptably before connecting your vehicle."}</li>
                     <li>{"Lightfriend does not verify the safety, appropriateness, or timing of any command."}</li>
                     <li>{"LIGHTFRIEND ACCEPTS NO LIABILITY WHATSOEVER for any accidents, vehicle damage, personal injury, death, theft, property damage, or any other consequences resulting from vehicle commands."}</li>
-                    <li>{"By using this integration, you EXPLICITLY WAIVE any and all claims against Lightfriend related to vehicle control."}</li>
-                    <li>{"You agree to indemnify and hold Lightfriend harmless from any claims arising from your use of vehicle control features."}</li>
+                    <li>{"By using this integration, you EXPLICITLY WAIVE any and all claims against Lightfriend related to vehicle control, to the fullest extent permitted by applicable law."}</li>
                 </ul>
             </section>
 
@@ -284,19 +361,22 @@ pub fn terms_and_conditions() -> Html {
             </section>
 
             <section>
-                <h2>{"11. Messaging Services"}</h2>
-                <p>{"The Service integrates with messaging platforms including WhatsApp, Signal, and Telegram. By using these features:"}</p>
+                <h2>{"11. Messaging Services and Third-Party Platform Risk"}</h2>
+                <p>{"The Service connects to messaging platforms such as WhatsApp, Signal, and Telegram using open-source bridge software. These bridges are not official clients and are not endorsed, sponsored, or affiliated with the messaging platforms they connect to. WhatsApp is a trademark of Meta Platforms, Inc. Signal is a trademark of Signal Technology Foundation. Telegram is a trademark of Telegram FZ-LLC. By using these integrations, you acknowledge and agree:"}</p>
                 <ul>
+                    <li><strong>{"Unofficial client risk: "}</strong>{"Connecting your messaging accounts through Lightfriend uses third-party bridge software that is not approved by the messaging platform providers. This may violate the terms of service of those platforms."}</li>
+                    <li><strong>{"Account restrictions: "}</strong>{"Your messaging accounts may be flagged, restricted, suspended, or permanently banned by the platform provider as a result of using unofficial bridge software. This is a known risk that you accept by using these integrations."}</li>
+                    <li><strong>{"No guarantee of continued access: "}</strong>{"Messaging platform providers may change their systems, policies, or enforcement at any time, which may cause integrations to stop working or trigger account restrictions without warning."}</li>
+                    <li><strong>{"Your responsibility: "}</strong>{"You are the owner of each messaging account you connect and are solely responsible for compliance with each platform's terms of service. You connect these accounts at your own risk."}</li>
+                    <li><strong>{"No liability: "}</strong>{"Lightfriend is not liable for any account suspension, data loss, service interruption, or any other consequence resulting from your use of messaging integrations, including actions taken by messaging platform providers against your account."}</li>
                     <li>{"You are solely responsible for all message content sent through the Service."}</li>
                     <li>{"Lightfriend acts only as a technical intermediary and does not monitor or control message content."}</li>
-                    <li>{"We are not liable for message delivery failures or third-party platform actions."}</li>
-                    <li>{"You must comply with the terms of service of each messaging platform."}</li>
                 </ul>
             </section>
 
             <section>
                 <h2>{"12. MCP Server Integration"}</h2>
-                <p>{"The Service allows you to configure custom third-party MCP (Model Context Protocol) servers. By using this feature:"}</p>
+                <p><strong>{"IMPORTANT: "}</strong>{"When you configure MCP (Model Context Protocol) servers, data processed by those servers leaves the sealed enclave environment and is sent to your configured external servers. The privacy guarantees of the enclave do not extend to data processed by external MCP servers."}</p>
                 <ul>
                     <li>{"You assume full responsibility for any third-party MCP servers you configure."}</li>
                     <li>{"Data sent to MCP servers as part of AI processing is transmitted at your own risk."}</li>
@@ -306,33 +386,54 @@ pub fn terms_and_conditions() -> Html {
             </section>
 
             <section>
-                <h2>{"13. Indemnification"}</h2>
-                <p>{"You agree to indemnify, defend, and hold harmless Lightfriend, its owners, employees, and affiliates from any claims, damages, losses, or expenses (including legal fees) arising from:"}</p>
+                <h2>{"13. AI Transparency"}</h2>
+                <p>{"In accordance with the EU AI Act, you are informed that:"}</p>
                 <ul>
-                    <li>{"Your use of the Service or any connected integrations."}</li>
-                    <li>{"Your violation of these Terms."}</li>
-                    <li>{"Your violation of any third-party rights."}</li>
-                    <li>{"Any actions taken through your account or connected services."}</li>
+                    <li>{"The Service uses artificial intelligence systems to process your messages and generate responses, summaries, and suggested actions."}</li>
+                    <li>{"AI processing is performed by third-party large language models accessed through sealed inference environments."}</li>
+                    <li>{"No automated decision with legal or similarly significant effects is made solely by AI. All AI outputs are recommendations only. You are always in control of whether to act on them."}</li>
                 </ul>
             </section>
 
             <section>
-                <h2>{"14. Changes to Terms"}</h2>
-                <p>{"We may update these Terms from time to time. Continued use of the Service after any such changes constitutes your acceptance of the new Terms."}</p>
+                <h2>{"14. Indemnification"}</h2>
+                <p>{"To the extent permitted by applicable law, you agree to compensate Lightfriend, its owners, employees, and affiliates for losses directly resulting from:"}</p>
+                <ul>
+                    <li>{"Your breach of these Terms."}</li>
+                    <li>{"Your violation of any applicable law or third-party rights."}</li>
+                    <li>{"Your willful misconduct or gross negligence in using the Service or connected integrations."}</li>
+                </ul>
             </section>
 
             <section>
-                <h2>{"15. Governing Law"}</h2>
+                <h2>{"15. Changes to Terms"}</h2>
+                <p>{"We will notify you of material changes to these Terms at least 30 days before they take effect, via email or through the Service. Your continued use after the effective date constitutes acceptance. If you do not agree with the changes, you may terminate your account before the effective date."}</p>
+            </section>
+
+            <section>
+                <h2>{"16. Governing Law and Dispute Resolution"}</h2>
                 <p>{"These Terms are governed by and construed in accordance with the laws of Finland. Any disputes shall be resolved in the courts of Tampere, Finland."}</p>
+                <p>{"The European Commission provides an online dispute resolution platform at "}<a href="https://ec.europa.eu/consumers/odr" target="_blank" rel="noopener noreferrer">{"https://ec.europa.eu/consumers/odr"}</a>{". We are not obligated to participate in alternative dispute resolution proceedings but will consider requests in good faith."}</p>
             </section>
 
             <section>
-                <h2>{"16. Data Protection and Privacy"}</h2>
+                <h2>{"17. Data Protection and Privacy"}</h2>
                 <p>{"Our Privacy Policy describes how the system is designed to handle your data. It forms an integral part of these Terms. By using the Service, you acknowledge that you have read and understood our Privacy Policy."}</p>
             </section>
 
             <section>
-                <h2>{"17. Contact Us"}</h2>
+                <h2>{"18. General Provisions"}</h2>
+                <ul>
+                    <li><strong>{"Severability: "}</strong>{"If any provision of these Terms is found to be unenforceable or invalid, that provision will be limited or eliminated to the minimum extent necessary so that these Terms will otherwise remain in full force and effect."}</li>
+                    <li><strong>{"Entire agreement: "}</strong>{"These Terms, together with the Privacy Policy and any other policies referenced herein, constitute the entire agreement between you and Lightfriend regarding the Service and supersede all prior agreements."}</li>
+                    <li><strong>{"Waiver: "}</strong>{"The failure of Lightfriend to enforce any right or provision of these Terms will not be considered a waiver of those rights."}</li>
+                    <li><strong>{"Assignment: "}</strong>{"We may assign or transfer these Terms and our rights and obligations in connection with a merger, acquisition, or sale of assets. You may not assign your rights or obligations under these Terms without our prior written consent."}</li>
+                    <li><strong>{"Force majeure: "}</strong>{"We shall not be liable for any failure or delay in performing our obligations where such failure or delay results from circumstances beyond our reasonable control, including but not limited to natural disasters, war, epidemics, internet or telecommunications failures, or failures of third-party infrastructure."}</li>
+                </ul>
+            </section>
+
+            <section>
+                <h2>{"19. Contact Us"}</h2>
                 <p>
                     {"For questions or concerns regarding these Terms, please contact us at "}
                     <a href="mailto:rasmus@lightfriend.ai">{"rasmus@lightfriend.ai"}</a>


### PR DESCRIPTION
## Summary
- Strengthen ToS/Privacy Policy for EU compliance (GDPR, consumer rights, AI Act)
- Add bridge risk disclosure for WhatsApp/Signal/Telegram (unofficial client warning)
- FYI digest section now shows per-item content summaries instead of just sender names
- Server-rendered blog engine for programmatic SEO (markdown + YAML frontmatter, cached HTML, dynamic sitemap)
- 10 blog posts across 5 clusters as initial content

## Test plan
- [x] All 21 digest layout tests pass
- [x] Backend compiles clean
- [x] Blog posts load from content/blog/ directory
- [x] Routes: /blog, /blog/:slug, /blog/:slug.md, /sitemap.xml