### PR TITLE
Harden deploy: redact presigned URLs, cleanup host state, shorten URL…

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -272,7 +272,8 @@
       "Bash(do echo:*)",
       "Read(//Users/ahtavarasmus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-imap-0.10.4/src/**)",
       "Read(//Users/ahtavarasmus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-imap-0.10.4/examples/**)",
-      "Read(//Users/ahtavarasmus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-imap-0.10.4/**)"
+      "Read(//Users/ahtavarasmus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-imap-0.10.4/**)",
+      "Bash(gh run:*)"
     ],
     "deny": [
       "Read(.env)",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,8 @@ jobs:
           PG_DATABASE_URL: postgres://lightfriend:test@localhost:5432/lightfriend_test
           ENCRYPTION_KEY: ci-test-key-not-real-000000000000
           JWT_SECRET: ci-test-jwt-secret
+          ADMIN_EMAILS: ci-test@example.com
+          BOOTSTRAP_ADMIN_PASSWORD: ci-test-password
           PORT: 3199
         run: |
           # Build the binary (should be cached from test compilation)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -89,6 +89,7 @@ jobs:
           JWT_SECRET: ci-test-jwt-secret
           ADMIN_EMAILS: ci-test@example.com
           BOOTSTRAP_ADMIN_PASSWORD: ci-test-password
+          TINFOIL_API_KEY: ci-test-not-real
           PORT: 3199
         run: |
           # Build the binary (should be cached from test compilation)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           ADMIN_EMAILS: ci-test@example.com
           BOOTSTRAP_ADMIN_PASSWORD: ci-test-password
           TINFOIL_API_KEY: ci-test-not-real
+          SERVER_URL: http://localhost:3199
           PORT: 3199
         run: |
           # Build the binary (should be cached from test compilation)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,39 @@ jobs:
           TEST_PG_DATABASE_URL: postgres://lightfriend:test@localhost:5432/lightfriend_test
         run: cargo test --test migration_test
 
+      - name: Startup smoke test
+        working-directory: backend
+        env:
+          PG_DATABASE_URL: postgres://lightfriend:test@localhost:5432/lightfriend_test
+          ENCRYPTION_KEY: ci-test-key-not-real-000000000000
+          JWT_SECRET: ci-test-jwt-secret
+          PORT: 3199
+        run: |
+          # Build the binary (should be cached from test compilation)
+          cargo build --bin backend --quiet
+
+          # Start the backend and check if it boots without panicking
+          timeout 15 ./target/debug/backend &
+          PID=$!
+          sleep 5
+
+          # Check if process is still alive (panics would have killed it)
+          if ! kill -0 $PID 2>/dev/null; then
+            echo "FATAL: Backend crashed on startup"
+            wait $PID 2>/dev/null || true
+            exit 1
+          fi
+
+          # Try the health endpoint
+          if curl -sf --max-time 5 http://localhost:3199/api/health >/dev/null 2>&1; then
+            echo "Startup smoke test passed: health check OK"
+          else
+            echo "WARNING: Health endpoint not reachable (may need more env vars) but process is alive - no panic"
+          fi
+
+          kill $PID 2>/dev/null || true
+          wait $PID 2>/dev/null || true
+
   # Frontend WASM check - runs in parallel with backend
   wasm-check:
     name: Frontend WASM Check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,18 @@ jobs:
       - name: Startup smoke test
         working-directory: backend
         env:
+          # Core vars (validate_env in main.rs)
+          JWT_SECRET_KEY: ci-test-jwt-secret-key-000000000
+          JWT_REFRESH_KEY: ci-test-jwt-refresh-key-00000000
           PG_DATABASE_URL: postgres://lightfriend:test@localhost:5432/lightfriend_test
           ENCRYPTION_KEY: ci-test-key-not-real-000000000000
-          JWT_SECRET: ci-test-jwt-secret
+          MATRIX_SHARED_SECRET: ci-test-matrix-secret
+          # App startup vars
           ADMIN_EMAILS: ci-test@example.com
           BOOTSTRAP_ADMIN_PASSWORD: ci-test-password
           TINFOIL_API_KEY: ci-test-not-real
           SERVER_URL: http://localhost:3199
+          ENVIRONMENT: development
           PORT: 3199
         run: |
           # Build the binary (should be cached from test compilation)
@@ -112,7 +117,7 @@ jobs:
           if curl -sf --max-time 5 http://localhost:3199/api/health >/dev/null 2>&1; then
             echo "Startup smoke test passed: health check OK"
           else
-            echo "WARNING: Health endpoint not reachable (may need more env vars) but process is alive - no panic"
+            echo "WARNING: Health endpoint not reachable but process is alive - no startup panic"
           fi
 
           kill $PID 2>/dev/null || true

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -421,6 +421,16 @@ jobs:
 
           aws s3 rm "s3://$S3_BUCKET/deploy/deploy-state.json" 2>/dev/null || true
 
+          # Clean stale export trigger from host filesystem
+          # (S3 cleanup above only cleans S3, not the host file that the export-watcher polls)
+          if [ -n "$CURRENT_LIVE" ]; then
+            echo "Cleaning stale export trigger from host..."
+            aws ssm send-command --instance-ids "$CURRENT_LIVE" \
+              --document-name "AWS-RunShellScript" \
+              --parameters 'commands=["rm -f /opt/lightfriend/seed/export-request.json"]' \
+              --timeout-seconds 15 2>/dev/null || true
+          fi
+
       # ── Step 0: Ensure launch template is up to date ──
       # Skipped until TF_API_TOKEN is configured. Run terraform apply manually
       # when user_data.sh changes. See DEPLOY_CLEANUP.md for details.
@@ -597,8 +607,8 @@ jobs:
               BACKUP_S3_KEY="backups/deploy/lightfriend-full-backup-${BACKUP_TIMESTAMP}.tar.gz.enc"
               COMPLETE_S3_KEY="deploy/export-complete.json"
 
-              PRESIGNED_PUT_BACKUP=$(python3 -c "import boto3; print(boto3.client('s3').generate_presigned_url('put_object', Params={'Bucket':'$S3_BUCKET','Key':'$BACKUP_S3_KEY','ContentType':'application/octet-stream'}, ExpiresIn=3600))")
-              PRESIGNED_PUT_COMPLETE=$(python3 -c "import boto3; print(boto3.client('s3').generate_presigned_url('put_object', Params={'Bucket':'$S3_BUCKET','Key':'$COMPLETE_S3_KEY','ContentType':'application/json'}, ExpiresIn=3600))")
+              PRESIGNED_PUT_BACKUP=$(python3 -c "import boto3; print(boto3.client('s3').generate_presigned_url('put_object', Params={'Bucket':'$S3_BUCKET','Key':'$BACKUP_S3_KEY','ContentType':'application/octet-stream'}, ExpiresIn=900))")
+              PRESIGNED_PUT_COMPLETE=$(python3 -c "import boto3; print(boto3.client('s3').generate_presigned_url('put_object', Params={'Bucket':'$S3_BUCKET','Key':'$COMPLETE_S3_KEY','ContentType':'application/json'}, ExpiresIn=900))")
 
               echo "Generated presigned URLs (valid 1 hour)"
               echo "  Backup key: $BACKUP_S3_KEY"
@@ -648,7 +658,10 @@ jobs:
                     LIVE_EXPORT_OK=true
                     break
                   elif [ "$COMPLETE_STATUS" = "FAILED" ]; then
-                    echo "WARNING: Live export failed inside enclave, will fall back to S3 backup"
+                    echo "WARNING: Live export failed inside enclave"
+                    echo "Exit code: $(echo "$COMPLETE_JSON" | jq -r '.exit_code // "unknown"')"
+                    echo "Error (URLs redacted):"
+                    echo "$COMPLETE_JSON" | jq -r '.error // "no details"' | sed 's|https://[^ ]*|[REDACTED]|g'
                     break
                   fi
                 fi
@@ -881,6 +894,14 @@ jobs:
           aws s3 rm "s3://$S3_BUCKET/deploy/restore-$NEW_INSTANCE.json" 2>/dev/null || true
           aws s3 rm "s3://$S3_BUCKET/deploy/export-complete.json" 2>/dev/null || true
           aws s3 rm "s3://$S3_BUCKET/deploy/export-request.json" 2>/dev/null || true
+
+          # Clean stale export trigger from host so export-watcher doesn't re-process it
+          if [ -n "$OLD_INSTANCE" ]; then
+            aws ssm send-command --instance-ids "$OLD_INSTANCE" \
+              --document-name "AWS-RunShellScript" \
+              --parameters 'commands=["rm -f /opt/lightfriend/seed/export-request.json"]' \
+              --timeout-seconds 15 2>/dev/null || true
+          fi
 
           echo "## ROLLBACK - old instance $OLD_INSTANCE restored" >> $GITHUB_STEP_SUMMARY
 

--- a/enclave/export-watcher.sh
+++ b/enclave/export-watcher.sh
@@ -46,7 +46,7 @@ while true; do
             echo "export-watcher: ${EXPORT_TYPE} export FAILED (exit ${EXIT_CODE}) at ${FINISHED_AT}"
 
             # Try to upload failure status via presigned URL (use jq for safe JSON encoding)
-            ERROR_TAIL=$(tail -40 /tmp/export-watcher-last-run.log 2>/dev/null | tr '\n' ' ' | head -c 4000 || echo "no output")
+            ERROR_TAIL=$(tail -40 /tmp/export-watcher-last-run.log 2>/dev/null | sed 's|https://[^ ]*|[REDACTED_URL]|g' | tr '\n' ' ' | head -c 4000 || echo "no output")
 
             # For deploy: write failure to completion URL
             if [ -n "${PRESIGNED_PUT_COMPLETE}" ]; then


### PR DESCRIPTION
… lifetime

- Redact presigned URLs from export error logs before uploading to S3 (export.sh uses set -x which traces curl commands with full URLs)
- Clean stale export-request.json from host on both cleanup and rollback (prevents export-watcher from re-processing stale triggers)
- Shorten presigned URL lifetime from 1 hour to 15 minutes
- Log redacted export errors in CI for debugging failed exports