### PR TITLE
Trust chain redesign, security hardening, hallucination retry, markdown chat

### DIFF
--- a/backend/src/agent_core.rs
+++ b/backend/src/agent_core.rs
@@ -122,20 +122,15 @@ When the user asks for a "digest", "summary", "recap", "what's new", "what did I
 5. Never include a sender, subject, or company name the user hasn't seen before WITHOUT it being literally in the tool output. If in doubt, say "nothing new".
 6. Do not describe a "typical" digest or "what a digest would look like". If there's no data, say so.
 
-### CRITICAL - [id=N] citation format (enforced by post-processor):
-Every time you mention a specific message, event, or person that came from a tool result, you MUST cite its `[id=N]` from the tool output on the SAME LINE as the item. This is not optional — a verifier strips any line whose `[id=N]` doesn't match what the tool returned, and the user sees a "(Stripped unverified items — ask to retry)" footer when that happens.
-Format rules:
-- Use EXACTLY the literal syntax `[id=N]` — square brackets, lowercase `id`, equals sign, digits, no spaces. NOT `(id 123)`, `[ID:123]`, `id=123`, or any other variant. Only `[id=123]` is recognized.
-- Put each item on its own line (one item per line) with its `[id=N]` on the SAME line. Don't bundle multiple items into one paragraph — the verifier strips by line, so one bad id would drop a whole paragraph of good items.
-- Copy the `N` exactly as the tool returned it. Don't renumber, round, or invent. If you don't have an id for something, don't mention it.
-- Lines without any `[id=N]` (headers, counts, closing CTAs) pass through untouched — you don't need to cite an id when the line doesn't reference a specific tool result.
-Example good output:
+### Output format — [id=N] references:
+When you mention a specific message, event, or person from a tool result, include its `[id=N]` from the tool output on the same line. This keeps your answers grounded in real data. One item per line.
+- Format: `[id=N]` — square brackets, lowercase `id`, equals sign, digits. Copy the number exactly as the tool returned it.
+- If you don't have an id for something, don't mention it.
+Example:
   `2 msgs today:`
   `1. Alice — quarterly review [id=7821]`
   `2. Bob — sounds good [id=7820]`
   `Reply to dig in.`
-Example BAD output that gets stripped:
-  `1. Alice — quarterly review (id 7821) AND Bob — sounds good [id=7820]` (wrong format on one id + multiple items on one line)
 
 Provide all information immediately; only ask follow-ups when confirming send/create actions. Call all needed tools upfront.
 Never fabricate information. Use tools to fetch latest information before answering.

--- a/backend/src/api/twilio_sms.rs
+++ b/backend/src/api/twilio_sms.rs
@@ -1354,7 +1354,88 @@ pub async fn process_sms(
     // failure path (no verification ran, so history == user_facing).
     let (final_response, history_for_storage) = if !fail {
         let valid_ids = crate::utils::id_verifier::collect_tool_result_ids(&loop_messages);
-        let verified = crate::utils::id_verifier::verify(&final_response, &valid_ids);
+        let mut verified = crate::utils::id_verifier::verify(&final_response, &valid_ids);
+
+        // If the verifier stripped hallucinated content, retry the LLM
+        // with a correction hint. Up to 3 retries. If it still fails,
+        // silently drop the bad lines (no user-visible disclaimer).
+        if verified.dropped_line {
+            for retry in 1..=3 {
+                tracing::info!("Id verifier stripped content, retry {}/3", retry);
+                options.emit_status(ChatStatus::Retrying {
+                    attempt: retry,
+                    max: 3,
+                });
+
+                loop_messages.push(chat_completion::ChatCompletionMessage {
+                    role: chat_completion::MessageRole::assistant,
+                    content: chat_completion::Content::Text(final_response.clone()),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+                loop_messages.push(chat_completion::ChatCompletionMessage {
+                    role: chat_completion::MessageRole::system,
+                    content: chat_completion::Content::Text(
+                        "Your previous response contained fabricated information that was automatically detected and rejected. Rewrite your answer based strictly on what the tools actually returned. Do not make anything up.".to_string()
+                    ),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+
+                match llm_call_with_retry(
+                    state,
+                    ctx.provider,
+                    &model,
+                    &loop_messages,
+                    &tools,
+                    &reasoning_tx,
+                    &mut options,
+                    MAX_RETRIES,
+                    user.id,
+                )
+                .await
+                {
+                    Ok(r) => {
+                        if let Some(text) = &r.choices[0].message.content {
+                            let retry_verified =
+                                crate::utils::id_verifier::verify(text, &valid_ids);
+                            // Remove the correction messages for next iteration
+                            loop_messages.pop();
+                            loop_messages.pop();
+                            if !retry_verified.dropped_line {
+                                verified = retry_verified;
+                                break;
+                            }
+                            verified = retry_verified;
+                        } else {
+                            loop_messages.pop();
+                            loop_messages.pop();
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        loop_messages.pop();
+                        loop_messages.pop();
+                        break;
+                    }
+                }
+            }
+
+            // After retries, if still dropping lines, silently strip
+            // without the footer - assume there's no valid content for
+            // those items
+            if verified.dropped_line {
+                tracing::info!("Id verifier still stripping after 3 retries, silently dropping");
+                verified.user_facing = verified
+                    .user_facing
+                    .replace(crate::utils::id_verifier::STRIPPED_FOOTER, "")
+                    .trim_end()
+                    .to_string();
+            }
+        }
+
         (verified.user_facing, verified.history)
     } else {
         (final_response.clone(), final_response)

--- a/backend/src/context.rs
+++ b/backend/src/context.rs
@@ -452,7 +452,7 @@ pub fn convert_history(
                 }
             }
 
-            let context_content = format!("[Previous result: {}]", msg.encrypted_content);
+            let context_content = msg.encrypted_content.clone();
             out.push(ChatCompletionMessage {
                 role: chat_completion::MessageRole::assistant,
                 content: chat_completion::Content::Text(context_content),

--- a/backend/src/tools/ontology.rs
+++ b/backend/src/tools/ontology.rs
@@ -231,7 +231,7 @@ fn query_message(
     // "call me again with a larger limit" pattern to actually work.
     if messages.len() == limit as usize {
         output.push_str(&format!(
-            "\n\nResult hit the limit of {}. If you need to reach further back in time, call this tool again with a larger `limit`.",
+            "\n\nResult hit the limit of {}. There may be older messages not shown.",
             limit
         ));
     }

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "boolinator"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,7 @@ dependencies = [
  "gloo-timers",
  "js-sys",
  "log",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -791,6 +798,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1072,12 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -57,5 +57,6 @@ log = "0.4"
 console_log = "1.0"
 serde-wasm-bindgen = "0.6.5"
 chrono-tz = "0.10.2"
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 base64 = "0.22"
 regex = "1.10"

--- a/frontend/src/dashboard/chat_box.rs
+++ b/frontend/src/dashboard/chat_box.rs
@@ -8,6 +8,14 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlTextAreaElement;
 use yew::prelude::*;
 
+fn render_markdown(text: &str) -> Html {
+    use pulldown_cmark::{Parser, Options, html::push_html};
+    let parser = Parser::new_ext(text, Options::empty());
+    let mut html_output = String::new();
+    push_html(&mut html_output, parser);
+    Html::from_html_unchecked(AttrValue::from(html_output))
+}
+
 // @mention system - available mentions
 const MENTION_OPTIONS: &[(&str, &str, &str)] = &[
     ("tesla", "Tesla Controls", "fa-car"),
@@ -53,6 +61,16 @@ const CHAT_STYLES: &str = r#"
     margin-right: auto;
     border-bottom-left-radius: 4px;
 }
+.chat-msg.markdown p { margin: 0.3em 0; }
+.chat-msg.markdown p:first-child { margin-top: 0; }
+.chat-msg.markdown p:last-child { margin-bottom: 0; }
+.chat-msg.markdown ul, .chat-msg.markdown ol { margin: 0.3em 0; padding-left: 1.3em; }
+.chat-msg.markdown li { margin: 0.15em 0; }
+.chat-msg.markdown strong { color: #fff; }
+.chat-msg.markdown code { background: rgba(255,255,255,0.1); padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }
+.chat-msg.markdown pre { background: rgba(0,0,0,0.2); padding: 0.5em; border-radius: 4px; overflow-x: auto; margin: 0.3em 0; }
+.chat-msg.markdown pre code { background: none; padding: 0; }
+.chat-msg.markdown h1, .chat-msg.markdown h2, .chat-msg.markdown h3 { margin: 0.4em 0 0.2em; font-size: 1em; color: #fff; }
 .chat-msg.loading {
     opacity: 0.6;
 }
@@ -1172,7 +1190,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                         match ((*chat_user_msg).clone(), (*chat_bot_reply).clone(), *chat_loading) {
                             // Task edit mode: only show bot reply (must come before wildcard)
                             (None, Some(bot_reply), false) => html! {
-                                <div class="chat-msg assistant">{bot_reply}</div>
+                                <div class="chat-msg assistant markdown">{render_markdown(&bot_reply)}</div>
                             },
                             // Loading state in task edit mode (no user message shown)
                             (None, None, true) => html! {
@@ -1191,7 +1209,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                             (Some(user_msg), Some(bot_reply), _) => html! {
                                 <>
                                     <div class="chat-msg user">{user_msg}</div>
-                                    <div class="chat-msg assistant">{bot_reply}</div>
+                                    <div class="chat-msg assistant markdown">{render_markdown(&bot_reply)}</div>
                                 </>
                             },
                             // Regular chat: user message, no response yet


### PR DESCRIPTION
## Summary

- **Trust chain page redesign** - Tinfoil-style UI with green intro box, dashed architecture diagram, three clickable verification pillars (Code is Auditable, Runtime is Isolated, Data is Encrypted), all showing the same Image ID fingerprint from different sources. On-chain build history timeline.
- **Nav link** - "Verifiably Private" badge now links to /trust-chain for logged-out users, shield icon for logged-in users
- **Security hardening** - Explicit HS256 for refresh token validation, SHA-256 hashed magic tokens, println->tracing::debug in handlers, updated E2EE comments
- **Hallucination handling** - Auto-retry up to 3x when id verifier detects fabricated content, vague retry message that doesn't reveal verification mechanism, silent drop after retries
- **Chat UX** - Markdown rendering via pulldown-cmark (lists, bold, code blocks), removed tool output leaking to users, cleaned up limit text
- **AI audit instructions** - "Audit the code with AI" section in verify yourself block

## Test plan

- [ ] Verify trust chain page renders correctly at /trust-chain
- [ ] Click each pillar box - same Image ID shown with different source labels
- [ ] Check on-chain history timeline displays
- [ ] Test chat - ask "summarize my emails" and verify markdown formatting
- [ ] Verify no "(Stripped unverified items)" disclaimer reaches users
- [ ] Check nav shield icon appears for logged-in users
- [ ] Mobile responsive - title clears nav bar