### PR TITLE
Fix enclave disk leak, add backup health monitoring

### DIFF
--- a/.github/workflows/ec2-watchdog.yml
+++ b/.github/workflows/ec2-watchdog.yml
@@ -104,3 +104,107 @@ jobs:
             --ssl-reqd
 
           echo "Alert email sent to rasmus@lightfriend.ai"
+
+  check-backup-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Check backup health
+        env:
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          S3_BUCKET: lightfriend-prod-backups
+        run: |
+          set -euo pipefail
+
+          ALERT=""
+          NOW=$(date +%s)
+
+          # ── Check backup-health.json for recent failures ──
+          HEALTH=$(aws s3 cp "s3://$S3_BUCKET/backups/backup-health.json" - 2>/dev/null || echo "")
+          if [ -n "$HEALTH" ]; then
+            LAST_FAILURE=$(echo "$HEALTH" | jq -r '.last_failure // "none"')
+            LAST_SUCCESS=$(echo "$HEALTH" | jq -r '.last_success // "none"')
+            EXIT_CODE=$(echo "$HEALTH" | jq -r '.exit_code // "unknown"')
+
+            if [ "$LAST_FAILURE" != "none" ] && [ "$LAST_FAILURE" != "null" ]; then
+              # Check if the failure is recent (within last 2 hours)
+              FAIL_EPOCH=$(date -d "$LAST_FAILURE" +%s 2>/dev/null || echo "0")
+              FAIL_AGE_MIN=$(( (NOW - FAIL_EPOCH) / 60 ))
+
+              if [ "$FAIL_AGE_MIN" -lt 120 ]; then
+                ALERT="BACKUP FAILURE DETECTED\n\n"
+                ALERT="${ALERT}The enclave reported a backup failure.\n\n"
+                ALERT="${ALERT}  Failure time: $LAST_FAILURE ($FAIL_AGE_MIN minutes ago)\n"
+                ALERT="${ALERT}  Exit code: $EXIT_CODE\n"
+                ALERT="${ALERT}  Last success: $LAST_SUCCESS\n"
+              fi
+            fi
+          else
+            echo "No backup health marker found"
+          fi
+
+          # ── Check if latest hourly backup is stale ──
+          LATEST_BACKUP=$(aws s3 ls "s3://$S3_BUCKET/backups/hourly/" 2>/dev/null | sort -k1,2 | tail -1)
+          if [ -n "$LATEST_BACKUP" ]; then
+            BACKUP_DATE=$(echo "$LATEST_BACKUP" | awk '{print $1 " " $2}')
+            BACKUP_KEY=$(echo "$LATEST_BACKUP" | awk '{print $4}')
+            BACKUP_SIZE=$(echo "$LATEST_BACKUP" | awk '{print $3}')
+            BACKUP_EPOCH=$(date -d "$BACKUP_DATE" +%s 2>/dev/null || echo "0")
+            BACKUP_AGE_MIN=$(( (NOW - BACKUP_EPOCH) / 60 ))
+
+            echo "Latest backup: $BACKUP_KEY ($BACKUP_SIZE bytes, $BACKUP_AGE_MIN min ago)"
+
+            if [ "$BACKUP_AGE_MIN" -gt 120 ]; then
+              STALE_MSG="STALE BACKUP ALERT\n\n"
+              STALE_MSG="${STALE_MSG}No successful backup in the last $BACKUP_AGE_MIN minutes (threshold: 120 min).\n\n"
+              STALE_MSG="${STALE_MSG}  Latest backup: $BACKUP_KEY\n"
+              STALE_MSG="${STALE_MSG}  Backup time: $BACKUP_DATE\n"
+              STALE_MSG="${STALE_MSG}  Backup size: $BACKUP_SIZE bytes\n"
+              STALE_MSG="${STALE_MSG}  Age: $BACKUP_AGE_MIN minutes\n"
+              ALERT="${ALERT}${STALE_MSG}"
+            fi
+          else
+            ALERT="${ALERT}NO BACKUPS FOUND\n\nNo hourly backups exist in s3://$S3_BUCKET/backups/hourly/\n"
+          fi
+
+          # ── Send alert if anything is wrong ──
+          if [ -z "$ALERT" ]; then
+            echo "OK: Backups healthy"
+            exit 0
+          fi
+
+          echo -e "ALERT:\n$ALERT"
+
+          SUBJECT="ALERT: Lightfriend backup health check failed"
+          BODY="Lightfriend Backup Health Watchdog\n\n${ALERT}\n"
+          BODY="${BODY}Check the enclave logs and S3 backup bucket.\n"
+          BODY="${BODY}If the enclave disk is full, trigger a disaster-recovery deploy.\n"
+
+          cat > /tmp/email.txt <<EOF
+          From: Lightfriend Watchdog <notifications@lightfriend.ai>
+          To: rasmus@lightfriend.ai
+          Subject: ${SUBJECT}
+          Content-Type: text/plain; charset=utf-8
+
+          $(echo -e "$BODY")
+          EOF
+
+          sed -i 's/^          //' /tmp/email.txt
+
+          curl -s --url "smtps://smtp.resend.com:465" \
+            --mail-from "notifications@lightfriend.ai" \
+            --mail-rcpt "rasmus@lightfriend.ai" \
+            --upload-file /tmp/email.txt \
+            --user "${SMTP_USERNAME}:${SMTP_PASSWORD}" \
+            --ssl-reqd
+
+          echo "Backup alert email sent to rasmus@lightfriend.ai"
+
+          # Fail the workflow so it shows red in GitHub Actions
+          exit 1

--- a/backend/src/agent_core.rs
+++ b/backend/src/agent_core.rs
@@ -122,20 +122,15 @@ When the user asks for a "digest", "summary", "recap", "what's new", "what did I
 5. Never include a sender, subject, or company name the user hasn't seen before WITHOUT it being literally in the tool output. If in doubt, say "nothing new".
 6. Do not describe a "typical" digest or "what a digest would look like". If there's no data, say so.
 
-### CRITICAL - [id=N] citation format (enforced by post-processor):
-Every time you mention a specific message, event, or person that came from a tool result, you MUST cite its `[id=N]` from the tool output on the SAME LINE as the item. This is not optional — a verifier strips any line whose `[id=N]` doesn't match what the tool returned, and the user sees a "(Stripped unverified items — ask to retry)" footer when that happens.
-Format rules:
-- Use EXACTLY the literal syntax `[id=N]` — square brackets, lowercase `id`, equals sign, digits, no spaces. NOT `(id 123)`, `[ID:123]`, `id=123`, or any other variant. Only `[id=123]` is recognized.
-- Put each item on its own line (one item per line) with its `[id=N]` on the SAME line. Don't bundle multiple items into one paragraph — the verifier strips by line, so one bad id would drop a whole paragraph of good items.
-- Copy the `N` exactly as the tool returned it. Don't renumber, round, or invent. If you don't have an id for something, don't mention it.
-- Lines without any `[id=N]` (headers, counts, closing CTAs) pass through untouched — you don't need to cite an id when the line doesn't reference a specific tool result.
-Example good output:
+### Output format — [id=N] references:
+When you mention a specific message, event, or person from a tool result, include its `[id=N]` from the tool output on the same line. This keeps your answers grounded in real data. One item per line.
+- Format: `[id=N]` — square brackets, lowercase `id`, equals sign, digits. Copy the number exactly as the tool returned it.
+- If you don't have an id for something, don't mention it.
+Example:
   `2 msgs today:`
   `1. Alice — quarterly review [id=7821]`
   `2. Bob — sounds good [id=7820]`
   `Reply to dig in.`
-Example BAD output that gets stripped:
-  `1. Alice — quarterly review (id 7821) AND Bob — sounds good [id=7820]` (wrong format on one id + multiple items on one line)
 
 Provide all information immediately; only ask follow-ups when confirming send/create actions. Call all needed tools upfront.
 Never fabricate information. Use tools to fetch latest information before answering.

--- a/backend/src/api/twilio_sms.rs
+++ b/backend/src/api/twilio_sms.rs
@@ -1354,7 +1354,88 @@ pub async fn process_sms(
     // failure path (no verification ran, so history == user_facing).
     let (final_response, history_for_storage) = if !fail {
         let valid_ids = crate::utils::id_verifier::collect_tool_result_ids(&loop_messages);
-        let verified = crate::utils::id_verifier::verify(&final_response, &valid_ids);
+        let mut verified = crate::utils::id_verifier::verify(&final_response, &valid_ids);
+
+        // If the verifier stripped hallucinated content, retry the LLM
+        // with a correction hint. Up to 3 retries. If it still fails,
+        // silently drop the bad lines (no user-visible disclaimer).
+        if verified.dropped_line {
+            for retry in 1..=3 {
+                tracing::info!("Id verifier stripped content, retry {}/3", retry);
+                options.emit_status(ChatStatus::Retrying {
+                    attempt: retry,
+                    max: 3,
+                });
+
+                loop_messages.push(chat_completion::ChatCompletionMessage {
+                    role: chat_completion::MessageRole::assistant,
+                    content: chat_completion::Content::Text(final_response.clone()),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+                loop_messages.push(chat_completion::ChatCompletionMessage {
+                    role: chat_completion::MessageRole::system,
+                    content: chat_completion::Content::Text(
+                        "Your previous response contained fabricated information that was automatically detected and rejected. Rewrite your answer based strictly on what the tools actually returned. Do not make anything up.".to_string()
+                    ),
+                    name: None,
+                    tool_calls: None,
+                    tool_call_id: None,
+                });
+
+                match llm_call_with_retry(
+                    state,
+                    ctx.provider,
+                    &model,
+                    &loop_messages,
+                    &tools,
+                    &reasoning_tx,
+                    &mut options,
+                    MAX_RETRIES,
+                    user.id,
+                )
+                .await
+                {
+                    Ok(r) => {
+                        if let Some(text) = &r.choices[0].message.content {
+                            let retry_verified =
+                                crate::utils::id_verifier::verify(text, &valid_ids);
+                            // Remove the correction messages for next iteration
+                            loop_messages.pop();
+                            loop_messages.pop();
+                            if !retry_verified.dropped_line {
+                                verified = retry_verified;
+                                break;
+                            }
+                            verified = retry_verified;
+                        } else {
+                            loop_messages.pop();
+                            loop_messages.pop();
+                            break;
+                        }
+                    }
+                    Err(_) => {
+                        loop_messages.pop();
+                        loop_messages.pop();
+                        break;
+                    }
+                }
+            }
+
+            // After retries, if still dropping lines, silently strip
+            // without the footer - assume there's no valid content for
+            // those items
+            if verified.dropped_line {
+                tracing::info!("Id verifier still stripping after 3 retries, silently dropping");
+                verified.user_facing = verified
+                    .user_facing
+                    .replace(crate::utils::id_verifier::STRIPPED_FOOTER, "")
+                    .trim_end()
+                    .to_string();
+            }
+        }
+
         (verified.user_facing, verified.history)
     } else {
         (final_response.clone(), final_response)

--- a/backend/src/context.rs
+++ b/backend/src/context.rs
@@ -452,7 +452,7 @@ pub fn convert_history(
                 }
             }
 
-            let context_content = format!("[Previous result: {}]", msg.encrypted_content);
+            let context_content = msg.encrypted_content.clone();
             out.push(ChatCompletionMessage {
                 role: chat_completion::MessageRole::assistant,
                 content: chat_completion::Content::Text(context_content),

--- a/backend/src/tools/ontology.rs
+++ b/backend/src/tools/ontology.rs
@@ -231,7 +231,7 @@ fn query_message(
     // "call me again with a larger limit" pattern to actually work.
     if messages.len() == limit as usize {
         output.push_str(&format!(
-            "\n\nResult hit the limit of {}. If you need to reach further back in time, call this tool again with a larger `limit`.",
+            "\n\nResult hit the limit of {}. There may be older messages not shown.",
             limit
         ));
     }

--- a/enclave/export.sh
+++ b/enclave/export.sh
@@ -501,6 +501,15 @@ fi
 
 echo "Phase E complete."
 
+# ── Cleanup: remove local encrypted file after successful upload ─────────────
+# Without this, each hourly backup leaves a ~33MB file in /data/seed/ inside
+# the enclave. After ~30 hours the enclave's filesystem fills up and future
+# exports fail with "error writing output file" during encryption.
+echo "Cleaning up local encrypted file..."
+rm -f "${ENCRYPTED}" 2>/dev/null || true
+# Also clean any old export artifacts left by previous runs
+find /data/seed -name 'lightfriend-full-backup-*.tar.gz.enc' -mmin +60 -delete 2>/dev/null || true
+
 # ── Write local success status ────────────────────────────────────────────────
 
 write_status "SUCCESS" "${ENCRYPTED_SIZE}" "${USER_COUNT}"

--- a/frontend/Cargo.lock
+++ b/frontend/Cargo.lock
@@ -84,6 +84,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitflags"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
 name = "boolinator"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -207,6 +213,7 @@ dependencies = [
  "gloo-timers",
  "js-sys",
  "log",
+ "pulldown-cmark",
  "regex",
  "serde",
  "serde-wasm-bindgen 0.6.5",
@@ -791,6 +798,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pulldown-cmark"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f86ba2052aebccc42cbbb3ed234b8b13ce76f75c3551a303cb2bcffcff12bb14"
+dependencies = [
+ "bitflags",
+ "memchr",
+ "pulldown-cmark-escape",
+ "unicase",
+]
+
+[[package]]
+name = "pulldown-cmark-escape"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
+
+[[package]]
 name = "quote"
 version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1047,6 +1072,12 @@ checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
 ]
+
+[[package]]
+name = "unicase"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
 name = "unicode-ident"

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -57,5 +57,6 @@ log = "0.4"
 console_log = "1.0"
 serde-wasm-bindgen = "0.6.5"
 chrono-tz = "0.10.2"
+pulldown-cmark = { version = "0.12", default-features = false, features = ["html"] }
 base64 = "0.22"
 regex = "1.10"

--- a/frontend/src/dashboard/chat_box.rs
+++ b/frontend/src/dashboard/chat_box.rs
@@ -8,6 +8,14 @@ use wasm_bindgen_futures::spawn_local;
 use web_sys::HtmlTextAreaElement;
 use yew::prelude::*;
 
+fn render_markdown(text: &str) -> Html {
+    use pulldown_cmark::{Parser, Options, html::push_html};
+    let parser = Parser::new_ext(text, Options::empty());
+    let mut html_output = String::new();
+    push_html(&mut html_output, parser);
+    Html::from_html_unchecked(AttrValue::from(html_output))
+}
+
 // @mention system - available mentions
 const MENTION_OPTIONS: &[(&str, &str, &str)] = &[
     ("tesla", "Tesla Controls", "fa-car"),
@@ -53,6 +61,16 @@ const CHAT_STYLES: &str = r#"
     margin-right: auto;
     border-bottom-left-radius: 4px;
 }
+.chat-msg.markdown p { margin: 0.3em 0; }
+.chat-msg.markdown p:first-child { margin-top: 0; }
+.chat-msg.markdown p:last-child { margin-bottom: 0; }
+.chat-msg.markdown ul, .chat-msg.markdown ol { margin: 0.3em 0; padding-left: 1.3em; }
+.chat-msg.markdown li { margin: 0.15em 0; }
+.chat-msg.markdown strong { color: #fff; }
+.chat-msg.markdown code { background: rgba(255,255,255,0.1); padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.9em; }
+.chat-msg.markdown pre { background: rgba(0,0,0,0.2); padding: 0.5em; border-radius: 4px; overflow-x: auto; margin: 0.3em 0; }
+.chat-msg.markdown pre code { background: none; padding: 0; }
+.chat-msg.markdown h1, .chat-msg.markdown h2, .chat-msg.markdown h3 { margin: 0.4em 0 0.2em; font-size: 1em; color: #fff; }
 .chat-msg.loading {
     opacity: 0.6;
 }
@@ -1172,7 +1190,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                         match ((*chat_user_msg).clone(), (*chat_bot_reply).clone(), *chat_loading) {
                             // Task edit mode: only show bot reply (must come before wildcard)
                             (None, Some(bot_reply), false) => html! {
-                                <div class="chat-msg assistant">{bot_reply}</div>
+                                <div class="chat-msg assistant markdown">{render_markdown(&bot_reply)}</div>
                             },
                             // Loading state in task edit mode (no user message shown)
                             (None, None, true) => html! {
@@ -1191,7 +1209,7 @@ pub fn chat_box(props: &ChatBoxProps) -> Html {
                             (Some(user_msg), Some(bot_reply), _) => html! {
                                 <>
                                     <div class="chat-msg user">{user_msg}</div>
-                                    <div class="chat-msg assistant">{bot_reply}</div>
+                                    <div class="chat-msg assistant markdown">{render_markdown(&bot_reply)}</div>
                                 </>
                             },
                             // Regular chat: user message, no response yet


### PR DESCRIPTION
## Summary
- Fix enclave disk leak: export.sh now deletes encrypted backup files after S3 upload (root cause of deploy failures)
- Add backup health monitoring to watchdog: emails alert on backup failures and stale backups (>2hr)
- Redact presigned URLs from export error logs
- Clean stale export-request.json from host on deploy cleanup and rollback
- Shorten presigned URL lifetime from 1hr to 15min
- Add startup smoke test to CI to catch route panics before merge

## Test plan
- [ ] CI passes
- [ ] DR deploy succeeds with S3 backup
- [ ] After deploy, hourly backups resume (verify in S3 after 1-2 hours)
- [ ] Watchdog runs and reports healthy (check next 30min cycle)