### PR TITLE
Add WhatsApp bridge watchdog monitoring

### DIFF
--- a/.github/workflows/bridge-watchdog.yml
+++ b/.github/workflows/bridge-watchdog.yml
@@ -1,0 +1,164 @@
+name: Bridge Watchdog
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'   # Every 15 minutes
+  workflow_dispatch: {}       # Manual trigger
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  check-bridge-health:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_DEPLOY_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
+      - name: Check bridge health
+        env:
+          WATCHDOG_API_KEY: ${{ secrets.WATCHDOG_API_KEY }}
+          SERVER_URL: ${{ secrets.SERVER_URL }}
+          SMTP_USERNAME: ${{ secrets.SMTP_USERNAME }}
+          SMTP_PASSWORD: ${{ secrets.SMTP_PASSWORD }}
+          S3_BUCKET: lightfriend-prod-backups
+        run: |
+          set -euo pipefail
+
+          # Call the health check endpoint
+          RESPONSE=$(curl -sf --max-time 30 \
+            -H "X-Watchdog-Key: ${WATCHDOG_API_KEY}" \
+            "${SERVER_URL}/api/watchdog/bridge/health" 2>/dev/null || echo "")
+
+          if [ -z "$RESPONSE" ]; then
+            echo "CRITICAL: Backend unreachable or returned error"
+            STATUS="unreachable"
+            TOTAL=0
+            HEALTHY=0
+            UNHEALTHY=0
+          else
+            STATUS=$(echo "$RESPONSE" | jq -r '.overall_status // "unknown"')
+            TOTAL=$(echo "$RESPONSE" | jq -r '.total_bridges // 0')
+            HEALTHY=$(echo "$RESPONSE" | jq -r '.healthy // 0')
+            UNHEALTHY=$(echo "$RESPONSE" | jq -r '.unhealthy // 0')
+
+            # Log only aggregate status (no per-user details in workflow output)
+            echo "Bridge health: ${HEALTHY}/${TOTAL} healthy (status: ${STATUS})"
+          fi
+
+          # Only alert on unhealthy or unreachable
+          if [ "$STATUS" != "unhealthy" ] && [ "$STATUS" != "unreachable" ]; then
+            echo "OK: All bridges healthy"
+            exit 0
+          fi
+
+          echo "ALERT: Bridge status is ${STATUS}"
+
+          # Check cooldown: skip email if we sent one within the last 4 hours
+          MARKER_KEY="watchdog/last-bridge-alert.txt"
+          LAST_ALERT=$(aws s3 cp "s3://${S3_BUCKET}/${MARKER_KEY}" - 2>/dev/null || echo "0")
+          NOW=$(date +%s)
+          COOLDOWN=14400  # 4 hours
+
+          if [ -n "$LAST_ALERT" ] && [ "$LAST_ALERT" -gt 0 ] 2>/dev/null; then
+            ELAPSED=$((NOW - LAST_ALERT))
+            if [ "$ELAPSED" -lt "$COOLDOWN" ]; then
+              echo "Cooldown active: last alert was ${ELAPSED}s ago (threshold: ${COOLDOWN}s). Skipping email."
+              exit 1
+            fi
+          fi
+
+          # Build alert email - include full details only in email (private)
+          if [ "$STATUS" = "unreachable" ]; then
+            DETAILS="The backend health check endpoint is unreachable.\nThis could indicate the server is down."
+          else
+            DETAILS=$(echo "$RESPONSE" | jq -r '
+              .checks_detail[] |
+              select(.status != "healthy") |
+              "User \(.user_id) (\(.bridge_type)): \(.status)\n" +
+              (.checks | to_entries[] | select(.value.status != "pass") |
+              "  \(.key): \(.value.status) - \(.value.detail // "no detail")\n")
+            ' 2>/dev/null | head -50)
+          fi
+
+          SUBJECT="ALERT: WhatsApp bridge ${STATUS} (${UNHEALTHY}/${TOTAL} unhealthy)"
+
+          cat > /tmp/email.txt <<EOF
+          From: Lightfriend Watchdog <notifications@lightfriend.ai>
+          To: rasmus@lightfriend.ai
+          Subject: ${SUBJECT}
+          Content-Type: text/plain; charset=utf-8
+
+          Lightfriend Bridge Watchdog
+
+          Status: ${STATUS}
+          Bridges: ${HEALTHY}/${TOTAL} healthy, ${UNHEALTHY} unhealthy
+
+          Failed checks:
+          $(echo -e "$DETAILS")
+
+          Timestamp: $(date -u '+%Y-%m-%d %H:%M:%S UTC')
+          EOF
+
+          sed -i 's/^          //' /tmp/email.txt
+
+          curl -s --url "smtps://smtp.resend.com:465" \
+            --mail-from "notifications@lightfriend.ai" \
+            --mail-rcpt "rasmus@lightfriend.ai" \
+            --upload-file /tmp/email.txt \
+            --user "${SMTP_USERNAME}:${SMTP_PASSWORD}" \
+            --ssl-reqd
+
+          echo "Alert email sent"
+
+          # Write cooldown marker to S3
+          echo -n "$NOW" | aws s3 cp - "s3://${S3_BUCKET}/${MARKER_KEY}"
+
+          # Fail the workflow so it shows red in GitHub Actions
+          exit 1
+
+  send-test-message:
+    runs-on: ubuntu-latest
+    # Only attempt test-send every 3 hours
+    if: github.event_name == 'schedule'
+    steps:
+      - name: Send test message (rate-limited by backend)
+        env:
+          WATCHDOG_API_KEY: ${{ secrets.WATCHDOG_API_KEY }}
+          SERVER_URL: ${{ secrets.SERVER_URL }}
+        run: |
+          set -euo pipefail
+
+          HOUR=$(date -u +%H)
+          MINUTE=$(date -u +%M)
+
+          # Only run at 3-hour boundaries in the first 15-minute window
+          if [ $(( HOUR % 3 )) -ne 0 ] || [ "$MINUTE" -ge 15 ]; then
+            echo "Skipping test-send: not a 3-hour boundary (hour=${HOUR}, minute=${MINUTE})"
+            exit 0
+          fi
+
+          RESPONSE=$(curl -sf --max-time 60 \
+            -X POST \
+            -H "X-Watchdog-Key: ${WATCHDOG_API_KEY}" \
+            "${SERVER_URL}/api/watchdog/bridge/test-send" 2>/dev/null || echo "")
+
+          if [ -z "$RESPONSE" ]; then
+            echo "WARNING: Test send endpoint unreachable"
+            exit 0
+          fi
+
+          TEST_STATUS=$(echo "$RESPONSE" | jq -r '.status // "unknown"')
+          SKIPPED=$(echo "$RESPONSE" | jq -r '.skipped // false')
+
+          echo "Test send: status=${TEST_STATUS}, skipped=${SKIPPED}"
+
+          if [ "$TEST_STATUS" = "fail" ] && [ "$SKIPPED" = "false" ]; then
+            echo "WARNING: Test message send failed"
+            echo "Detail: $(echo "$RESPONSE" | jq -r '.detail // "unknown"')"
+            # Don't fail workflow - the health check job handles alerting
+          fi

--- a/backend/pg_migrations/00000000000027_create_bridge_watchdog_logs/down.sql
+++ b/backend/pg_migrations/00000000000027_create_bridge_watchdog_logs/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS bridge_watchdog_logs;

--- a/backend/pg_migrations/00000000000027_create_bridge_watchdog_logs/up.sql
+++ b/backend/pg_migrations/00000000000027_create_bridge_watchdog_logs/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE bridge_watchdog_logs (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    bridge_type TEXT NOT NULL,
+    event_type TEXT NOT NULL,
+    message TEXT NOT NULL,
+    metadata TEXT,
+    created_at INTEGER NOT NULL
+);
+CREATE INDEX idx_bwl_user_bridge ON bridge_watchdog_logs (user_id, bridge_type);
+CREATE INDEX idx_bwl_created_at ON bridge_watchdog_logs (created_at);
+CREATE INDEX idx_bwl_event_type ON bridge_watchdog_logs (event_type);

--- a/backend/src/handlers/dashboard_handlers.rs
+++ b/backend/src/handlers/dashboard_handlers.rs
@@ -763,7 +763,7 @@ pub async fn get_activity_feed(
     }
 
     // Sort by timestamp descending, truncate
-    entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    entries.sort_by_key(|e| std::cmp::Reverse(e.timestamp));
     entries.truncate(limit as usize);
 
     Ok(Json(entries))

--- a/backend/src/handlers/watchdog_handlers.rs
+++ b/backend/src/handlers/watchdog_handlers.rs
@@ -1,0 +1,420 @@
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::{IntoResponse, Json};
+use serde_json::json;
+use std::sync::Arc;
+
+use crate::AppState;
+
+/// Validates the X-Watchdog-Key header against the WATCHDOG_API_KEY env var.
+fn check_watchdog_key(headers: &HeaderMap) -> bool {
+    let expected = match std::env::var("WATCHDOG_API_KEY") {
+        Ok(s) if !s.is_empty() => s,
+        _ => return false,
+    };
+    headers
+        .get("X-Watchdog-Key")
+        .and_then(|v| v.to_str().ok())
+        .is_some_and(|v| v == expected)
+}
+
+/// GET /api/watchdog/bridge/health
+///
+/// Comprehensive health check for all users' WhatsApp bridges.
+/// Returns aggregate status + per-user check details.
+pub async fn bridge_health_check(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if !check_watchdog_key(&headers) {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "forbidden"}))).into_response();
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    // Get all users with active bridges
+    let users_with_bridges = match state.user_repository.get_users_with_active_bridges() {
+        Ok(m) => m,
+        Err(e) => {
+            tracing::error!("Watchdog: failed to get active bridges: {}", e);
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({
+                    "overall_status": "unhealthy",
+                    "timestamp": now,
+                    "error": format!("Failed to query bridges: {}", e)
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let mut checks_detail = Vec::new();
+    let mut healthy_count = 0;
+    let mut total_count = 0;
+
+    for (user_id, bridges) in &users_with_bridges {
+        for bridge in bridges {
+            if bridge.bridge_type != "whatsapp" {
+                continue;
+            }
+            total_count += 1;
+
+            let user_checks = run_bridge_checks(&state, *user_id, bridge, now).await;
+            let bridge_status = derive_status(&user_checks);
+
+            if bridge_status == "healthy" {
+                healthy_count += 1;
+            }
+
+            checks_detail.push(json!({
+                "user_id": user_id,
+                "bridge_type": "whatsapp",
+                "status": bridge_status,
+                "checks": user_checks,
+            }));
+        }
+    }
+
+    let overall_status = if total_count == 0 {
+        "no_bridges"
+    } else if healthy_count == total_count {
+        "healthy"
+    } else if healthy_count > 0 {
+        "degraded"
+    } else {
+        "unhealthy"
+    };
+
+    Json(json!({
+        "overall_status": overall_status,
+        "timestamp": now,
+        "total_bridges": total_count,
+        "healthy": healthy_count,
+        "unhealthy": total_count - healthy_count,
+        "checks_detail": checks_detail,
+    }))
+    .into_response()
+}
+
+/// Run all health checks for a single bridge.
+async fn run_bridge_checks(
+    state: &Arc<AppState>,
+    user_id: i32,
+    bridge: &crate::pg_models::PgBridge,
+    now: i64,
+) -> serde_json::Value {
+    // Check 1: Bridge record
+    let bridge_record_check = json!({
+        "status": "pass",
+        "detail": format!("Bridge exists, status={}", bridge.status),
+    });
+
+    // Check 2: Matrix client
+    let (matrix_check, client) =
+        match crate::utils::matrix_auth::get_cached_client(user_id, state).await {
+            Ok(c) => (
+                json!({
+                    "status": "pass",
+                    "detail": "Matrix client available",
+                }),
+                Some(c),
+            ),
+            Err(e) => (
+                json!({
+                    "status": "fail",
+                    "detail": format!("Failed to get Matrix client: {}", e),
+                }),
+                None,
+            ),
+        };
+
+    // Check 3: Room access (only if we have a client)
+    let room_access_check = if let Some(ref client) = client {
+        match crate::utils::bridge::get_service_rooms(client, "whatsapp").await {
+            Ok(rooms) => {
+                let count = rooms.len();
+                if count > 0 {
+                    json!({
+                        "status": "pass",
+                        "room_count": count,
+                        "detail": format!("{} WhatsApp rooms accessible", count),
+                    })
+                } else {
+                    json!({
+                        "status": "warn",
+                        "room_count": 0,
+                        "detail": "No WhatsApp rooms found (bridge may be connected but empty)",
+                    })
+                }
+            }
+            Err(e) => json!({
+                "status": "fail",
+                "room_count": 0,
+                "detail": format!("Failed to fetch rooms: {}", e),
+            }),
+        }
+    } else {
+        json!({
+            "status": "fail",
+            "room_count": 0,
+            "detail": "Skipped - no Matrix client",
+        })
+    };
+
+    // Check 4: Management room messages
+    let management_room_check =
+        if let (Some(ref client), Some(ref room_id)) = (&client, &bridge.room_id) {
+            match crate::utils::bridge::read_management_room_messages(client, room_id, 20).await {
+                Ok(messages) => {
+                    let bot_messages: Vec<_> = messages.iter().filter(|m| m.is_from_bot).collect();
+
+                    // Use is_disconnection_message on the fly to detect problems
+                    let one_hour_ago = now - 3600;
+                    let recent_disconnections = bot_messages
+                        .iter()
+                        .filter(|m| {
+                            m.timestamp >= one_hour_ago
+                                && crate::utils::bridge::is_disconnection_message(&m.body)
+                        })
+                        .count();
+
+                    let last_bot_msg = bot_messages.first();
+                    let last_bot_message_age = last_bot_msg.map(|m| now - m.timestamp);
+
+                    let recent_texts: Vec<&str> = bot_messages
+                        .iter()
+                        .take(5)
+                        .map(|m| m.body.as_str())
+                        .collect();
+
+                    let status = if recent_disconnections > 0 {
+                        "fail"
+                    } else {
+                        "pass"
+                    };
+
+                    json!({
+                        "status": status,
+                        "last_bot_message_age_secs": last_bot_message_age,
+                        "recent_disconnections": recent_disconnections,
+                        "recent_bot_messages": recent_texts,
+                        "detail": if recent_disconnections > 0 {
+                            format!("{} disconnection messages in last hour", recent_disconnections)
+                        } else {
+                            "No disconnection messages in last hour".to_string()
+                        },
+                    })
+                }
+                Err(e) => json!({
+                    "status": "warn",
+                    "detail": format!("Failed to read management room: {}", e),
+                }),
+            }
+        } else {
+            json!({
+                "status": "warn",
+                "detail": if client.is_none() {
+                    "Skipped - no Matrix client"
+                } else {
+                    "No management room ID stored"
+                },
+            })
+        };
+
+    // Check 5: Data freshness
+    let data_freshness_check = {
+        let last_seen_age = bridge
+            .last_seen_online
+            .map(|ts| now - ts as i64)
+            .unwrap_or(i64::MAX);
+
+        let status = if last_seen_age < 7200 {
+            "pass"
+        } else if last_seen_age < 86400 {
+            "warn"
+        } else {
+            "fail"
+        };
+
+        json!({
+            "status": status,
+            "last_seen_online_age_secs": if last_seen_age == i64::MAX { None } else { Some(last_seen_age) },
+            "detail": if last_seen_age == i64::MAX {
+                "No last_seen_online timestamp".to_string()
+            } else {
+                format!("Last seen {} seconds ago", last_seen_age)
+            },
+        })
+    };
+
+    json!({
+        "bridge_record": bridge_record_check,
+        "matrix_client": matrix_check,
+        "room_access": room_access_check,
+        "management_room": management_room_check,
+        "data_freshness": data_freshness_check,
+    })
+}
+
+/// Derive overall status from individual check results.
+fn derive_status(checks: &serde_json::Value) -> &'static str {
+    let check_names = [
+        "bridge_record",
+        "matrix_client",
+        "room_access",
+        "management_room",
+        "data_freshness",
+    ];
+
+    let mut has_fail = false;
+    let mut has_warn = false;
+
+    for name in &check_names {
+        if let Some(status) = checks
+            .get(name)
+            .and_then(|c| c.get("status"))
+            .and_then(|s| s.as_str())
+        {
+            match status {
+                "fail" => has_fail = true,
+                "warn" => has_warn = true,
+                _ => {}
+            }
+        }
+    }
+
+    if has_fail {
+        "unhealthy"
+    } else if has_warn {
+        "degraded"
+    } else {
+        "healthy"
+    }
+}
+
+/// POST /api/watchdog/bridge/test-send
+///
+/// Send a test message to the admin's Note to Self room via WhatsApp bridge.
+/// Rate-limited to once every 2 hours. User 1 only.
+pub async fn bridge_send_test(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+) -> impl IntoResponse {
+    if !check_watchdog_key(&headers) {
+        return (StatusCode::FORBIDDEN, Json(json!({"error": "forbidden"}))).into_response();
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i32;
+
+    let user_id = 1;
+    let bridge_type = "whatsapp";
+
+    // Rate limit: check if last test was within 2 hours
+    let two_hours_ago = now - 7200;
+    if let Ok(recent_logs) =
+        state
+            .user_repository
+            .get_watchdog_logs_since(user_id, bridge_type, two_hours_ago)
+    {
+        let recent_test = recent_logs
+            .iter()
+            .any(|l| l.event_type == "test_send_ok" || l.event_type == "test_send_fail");
+        if recent_test {
+            return Json(json!({
+                "status": "skipped",
+                "skipped": true,
+                "skip_reason": "Last test was within 2 hours",
+            }))
+            .into_response();
+        }
+    }
+
+    // Get the phone number for Note to Self
+    let phone_number = match std::env::var("WATCHDOG_TEST_PHONE") {
+        Ok(p) if !p.is_empty() => p,
+        _ => {
+            return Json(json!({
+                "status": "skipped",
+                "skipped": true,
+                "skip_reason": "WATCHDOG_TEST_PHONE env var not set",
+            }))
+            .into_response();
+        }
+    };
+
+    // Send test message
+    let test_message = format!("Watchdog ping {}", now);
+    let result = crate::utils::bridge::send_bridge_message(
+        bridge_type,
+        &state,
+        user_id,
+        &phone_number,
+        &test_message,
+        None,
+        None,
+    )
+    .await;
+
+    // Compute bridge age for metadata
+    let bridge_age = state
+        .user_repository
+        .get_bridge(user_id, bridge_type)
+        .ok()
+        .flatten()
+        .and_then(|b| b.created_at.map(|c| now - c));
+
+    let metadata = json!({
+        "bridge_age_secs": bridge_age,
+        "phone": phone_number,
+    })
+    .to_string();
+
+    match result {
+        Ok(_) => {
+            let _ = state.user_repository.insert_watchdog_log(
+                crate::pg_models::NewPgBridgeWatchdogLog {
+                    user_id,
+                    bridge_type: bridge_type.to_string(),
+                    event_type: "test_send_ok".to_string(),
+                    message: test_message,
+                    metadata: Some(metadata),
+                    created_at: now,
+                },
+            );
+
+            Json(json!({
+                "status": "pass",
+                "skipped": false,
+                "detail": "Test message sent successfully",
+            }))
+            .into_response()
+        }
+        Err(e) => {
+            let error_msg = format!("Test send failed: {}", e);
+            let _ = state.user_repository.insert_watchdog_log(
+                crate::pg_models::NewPgBridgeWatchdogLog {
+                    user_id,
+                    bridge_type: bridge_type.to_string(),
+                    event_type: "test_send_fail".to_string(),
+                    message: error_msg.clone(),
+                    metadata: Some(metadata),
+                    created_at: now,
+                },
+            );
+
+            Json(json!({
+                "status": "fail",
+                "skipped": false,
+                "detail": error_msg,
+            }))
+            .into_response()
+        }
+    }
+}

--- a/backend/src/jobs/scheduler.rs
+++ b/backend/src/jobs/scheduler.rs
@@ -5,7 +5,7 @@ use chrono::Offset;
 use futures_util::TryStreamExt;
 use std::sync::Arc;
 use tokio_cron_scheduler::{Job, JobScheduler};
-use tracing::{debug, error};
+use tracing::{debug, error, warn};
 
 use crate::handlers::imap_handlers;
 
@@ -248,6 +248,84 @@ async fn cleanup_matrix_client(state: &Arc<AppState>, user_id: i32) {
     if matrix_clients.remove(&user_id).is_some() {
         debug!("Removed Matrix client for user {} during cleanup", user_id);
     }
+}
+
+/// Scan bridge management rooms for all users and log bot messages.
+/// This captures disconnection events, errors, and status messages
+/// for future analysis.
+async fn scan_bridge_management_rooms(
+    state: &Arc<AppState>,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let users_with_bridges = state.user_repository.get_users_with_active_bridges()?;
+
+    for (user_id, bridges) in users_with_bridges {
+        for bridge in bridges {
+            let Some(ref room_id) = bridge.room_id else {
+                continue;
+            };
+
+            let client = match crate::utils::matrix_auth::get_cached_client(user_id, state).await {
+                Ok(c) => c,
+                Err(e) => {
+                    warn!("Watchdog: can't get client for user {}: {}", user_id, e);
+                    continue;
+                }
+            };
+
+            let messages =
+                match crate::utils::bridge::read_management_room_messages(&client, room_id, 10)
+                    .await
+                {
+                    Ok(m) => m,
+                    Err(e) => {
+                        warn!(
+                            "Watchdog: can't read mgmt room for user {} {}: {}",
+                            user_id, bridge.bridge_type, e
+                        );
+                        continue;
+                    }
+                };
+
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i32;
+
+            // Get the last logged timestamp to avoid duplicate logging
+            let last_logged = state
+                .user_repository
+                .get_recent_watchdog_logs(user_id, &bridge.bridge_type, 1)
+                .ok()
+                .and_then(|logs| logs.first().map(|l| l.created_at))
+                .unwrap_or(0);
+
+            // Compute bridge age for metadata
+            let bridge_age = bridge.created_at.map(|c| now - c);
+
+            for msg in messages
+                .iter()
+                .filter(|m| m.is_from_bot && (m.timestamp as i32) > last_logged)
+            {
+                let metadata = serde_json::json!({
+                    "bridge_age_secs": bridge_age,
+                })
+                .to_string();
+
+                let log = crate::pg_models::NewPgBridgeWatchdogLog {
+                    user_id,
+                    bridge_type: bridge.bridge_type.clone(),
+                    event_type: "bot_message".to_string(),
+                    message: msg.body.clone(),
+                    metadata: Some(metadata),
+                    created_at: msg.timestamp as i32,
+                };
+                if let Err(e) = state.user_repository.insert_watchdog_log(log) {
+                    error!("Failed to insert watchdog log: {}", e);
+                }
+            }
+        }
+    }
+    Ok(())
 }
 
 /// Check if any Matrix sync tasks have died and restart them.
@@ -684,6 +762,24 @@ pub async fn start_scheduler(state: Arc<AppState>) {
         .await
         .expect("Failed to add sync health check job to scheduler");
 
+    // Bridge watchdog - runs every 15 minutes to log management room messages
+    let state_clone = Arc::clone(&state);
+    let bridge_watchdog_job = Job::new_async("0 */15 * * * *", move |_, _| {
+        let state = state_clone.clone();
+        Box::pin(async move {
+            debug!("Running bridge watchdog management room scan...");
+            if let Err(e) = scan_bridge_management_rooms(&state).await {
+                error!("Bridge watchdog scan failed: {}", e);
+            }
+        })
+    })
+    .expect("Failed to create bridge watchdog job");
+
+    sched
+        .add(bridge_watchdog_job)
+        .await
+        .expect("Failed to add bridge watchdog job to scheduler");
+
     // Admin alert cleanup - runs daily at 2am UTC to remove alerts older than 30 days
     let state_clone = Arc::clone(&state);
     let alert_cleanup_job = Job::new_async("0 0 2 * * *", move |_, _| {
@@ -731,6 +827,16 @@ pub async fn start_scheduler(state: Arc<AppState>) {
             {
                 Ok(count) => debug!("Cleaned up {} old message status logs", count),
                 Err(e) => error!("Failed to cleanup old message status logs: {}", e),
+            }
+
+            // Clean up old watchdog logs (30 days)
+            match state
+                .user_repository
+                .delete_old_watchdog_logs(message_log_cutoff)
+            {
+                Ok(count) if count > 0 => debug!("Cleaned up {} old watchdog logs", count),
+                Err(e) => error!("Failed to cleanup old watchdog logs: {}", e),
+                _ => {}
             }
 
             // Expire stale "ongoing" call records (no webhook received after 1 hour)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -29,6 +29,7 @@ pub mod handlers {
     pub mod totp_handlers;
     pub mod trust_chain_handlers;
     pub mod twilio_handlers;
+    pub mod watchdog_handlers;
     pub mod webauthn_handlers;
     pub mod whatsapp_auth;
     pub mod whatsapp_handlers;

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -1298,7 +1298,19 @@ async fn main() {
             post(admin_handlers::recover_users_from_external),
         );
 
+    // Watchdog endpoints (secret-authenticated, no JWT)
+    let watchdog_routes = Router::new()
+        .route(
+            "/api/watchdog/bridge/health",
+            get(handlers::watchdog_handlers::bridge_health_check),
+        )
+        .route(
+            "/api/watchdog/bridge/test-send",
+            post(handlers::watchdog_handlers::bridge_send_test),
+        );
+
     let app = Router::new()
+        .merge(watchdog_routes)
         .merge(maintenance_routes)
         .merge(public_routes)
         .merge(admin_routes)

--- a/backend/src/pg_models.rs
+++ b/backend/src/pg_models.rs
@@ -4,10 +4,10 @@
 //! If any code tries to use these with a SQLite connection, it won't compile.
 
 use crate::pg_schema::{
-    admin_alerts, bridge_bandwidth_logs, bridge_disconnection_events, bridges,
-    country_availability, disabled_alert_types, imap_connection, llm_usage_logs, mcp_servers,
-    message_history, message_status_log, processed_emails, refund_info, site_metrics, tesla,
-    totp_backup_codes, totp_secrets, usage_logs, user_info, user_secrets, waitlist,
+    admin_alerts, bridge_bandwidth_logs, bridge_disconnection_events, bridge_watchdog_logs,
+    bridges, country_availability, disabled_alert_types, imap_connection, llm_usage_logs,
+    mcp_servers, message_history, message_status_log, processed_emails, refund_info, site_metrics,
+    tesla, totp_backup_codes, totp_secrets, usage_logs, user_info, user_secrets, waitlist,
     webauthn_challenges, webauthn_credentials, youtube,
 };
 use diesel::prelude::*;
@@ -352,6 +352,32 @@ pub struct NewPgBridgeDisconnectionEvent {
     pub user_id: i32,
     pub bridge_type: String,
     pub detected_at: i32,
+}
+
+// -- bridge_watchdog_logs --
+
+#[derive(Queryable, Selectable, Debug, Clone, Serialize)]
+#[diesel(table_name = bridge_watchdog_logs)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct PgBridgeWatchdogLog {
+    pub id: i32,
+    pub user_id: i32,
+    pub bridge_type: String,
+    pub event_type: String,
+    pub message: String,
+    pub metadata: Option<String>,
+    pub created_at: i32,
+}
+
+#[derive(Insertable)]
+#[diesel(table_name = bridge_watchdog_logs)]
+pub struct NewPgBridgeWatchdogLog {
+    pub user_id: i32,
+    pub bridge_type: String,
+    pub event_type: String,
+    pub message: String,
+    pub metadata: Option<String>,
+    pub created_at: i32,
 }
 
 // -- usage_logs --

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -502,6 +502,18 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    bridge_watchdog_logs (id) {
+        id -> Int4,
+        user_id -> Int4,
+        bridge_type -> Text,
+        event_type -> Text,
+        message -> Text,
+        metadata -> Nullable<Text>,
+        created_at -> Int4,
+    }
+}
+
 diesel::joinable!(ont_person_edits -> ont_persons (person_id));
 diesel::joinable!(ont_channels -> ont_persons (person_id));
 
@@ -544,4 +556,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     ont_rules,
     llm_usage_logs,
     bridge_bandwidth_logs,
+    bridge_watchdog_logs,
 );

--- a/backend/src/repositories/user_repository.rs
+++ b/backend/src/repositories/user_repository.rs
@@ -1673,6 +1673,63 @@ impl UserRepository {
         Ok(())
     }
 
+    // Bridge watchdog log methods
+
+    pub fn insert_watchdog_log(
+        &self,
+        log: crate::pg_models::NewPgBridgeWatchdogLog,
+    ) -> Result<(), DieselError> {
+        use crate::pg_schema::bridge_watchdog_logs;
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+
+        diesel::insert_into(bridge_watchdog_logs::table)
+            .values(&log)
+            .execute(&mut conn)?;
+
+        Ok(())
+    }
+
+    pub fn get_recent_watchdog_logs(
+        &self,
+        user_id_val: i32,
+        bridge_type_val: &str,
+        limit_val: i64,
+    ) -> Result<Vec<crate::pg_models::PgBridgeWatchdogLog>, DieselError> {
+        use crate::pg_schema::bridge_watchdog_logs::dsl::*;
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+
+        bridge_watchdog_logs
+            .filter(user_id.eq(user_id_val))
+            .filter(bridge_type.eq(bridge_type_val))
+            .order(created_at.desc())
+            .limit(limit_val)
+            .load::<crate::pg_models::PgBridgeWatchdogLog>(&mut conn)
+    }
+
+    pub fn get_watchdog_logs_since(
+        &self,
+        user_id_val: i32,
+        bridge_type_val: &str,
+        since_ts: i32,
+    ) -> Result<Vec<crate::pg_models::PgBridgeWatchdogLog>, DieselError> {
+        use crate::pg_schema::bridge_watchdog_logs::dsl::*;
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+
+        bridge_watchdog_logs
+            .filter(user_id.eq(user_id_val))
+            .filter(bridge_type.eq(bridge_type_val))
+            .filter(created_at.ge(since_ts))
+            .order(created_at.desc())
+            .load::<crate::pg_models::PgBridgeWatchdogLog>(&mut conn)
+    }
+
+    pub fn delete_old_watchdog_logs(&self, cutoff_ts: i32) -> Result<usize, DieselError> {
+        use crate::pg_schema::bridge_watchdog_logs::dsl::*;
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+
+        diesel::delete(bridge_watchdog_logs.filter(created_at.lt(cutoff_ts))).execute(&mut conn)
+    }
+
     // Mark an email as processed
     pub fn mark_email_as_processed(
         &self,

--- a/backend/src/utils/bridge.rs
+++ b/backend/src/utils/bridge.rs
@@ -2453,3 +2453,83 @@ pub fn capitalize(s: &str) -> String {
         Some(f) => f.to_uppercase().collect::<String>() + c.as_str(),
     }
 }
+
+// -- Watchdog: management room message reader --
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ManagementRoomMessage {
+    pub sender: String,
+    pub body: String,
+    pub timestamp: i64,
+    pub is_from_bot: bool,
+}
+
+/// Read recent messages from a bridge management room (the room where the bridge
+/// bot sends status/health messages). Uses the room_id stored in PgBridge.room_id.
+pub async fn read_management_room_messages(
+    client: &Arc<MatrixClient>,
+    room_id_str: &str,
+    limit: u64,
+) -> Result<Vec<ManagementRoomMessage>> {
+    use matrix_sdk::ruma::{
+        events::room::message::{MessageType, SyncRoomMessageEvent},
+        events::AnySyncTimelineEvent,
+        OwnedRoomId,
+    };
+
+    let room_id: OwnedRoomId = room_id_str
+        .parse()
+        .map_err(|_| anyhow!("Invalid room ID: {}", room_id_str))?;
+
+    let room = client
+        .get_room(&room_id)
+        .ok_or_else(|| anyhow!("Management room not found: {}", room_id_str))?;
+
+    let mut options = MessagesOptions::backward();
+    options.limit = matrix_sdk::ruma::UInt::new(limit).unwrap();
+
+    let response = room
+        .messages(options)
+        .await
+        .map_err(|e| anyhow!("Failed to fetch management room messages: {}", e))?;
+
+    // Determine which bot user to look for based on room members
+    let bot_localparts = ["whatsappbot", "signalbot", "telegrambot"];
+
+    let mut messages = Vec::new();
+    for msg in response.chunk {
+        let raw_event = msg.raw();
+        if let Ok(event) = raw_event.deserialize() {
+            let sender = event.sender().to_string();
+            let sender_localpart = event.sender().localpart().to_string();
+
+            if let AnySyncTimelineEvent::MessageLike(
+                matrix_sdk::ruma::events::AnySyncMessageLikeEvent::RoomMessage(
+                    SyncRoomMessageEvent::Original(original),
+                ),
+            ) = event
+            {
+                let body = match original.content.msgtype {
+                    MessageType::Text(text) => text.body,
+                    MessageType::Notice(notice) => notice.body,
+                    _ => continue,
+                };
+
+                let timestamp = i64::from(original.origin_server_ts.0) / 1000;
+
+                let is_from_bot = bot_localparts
+                    .iter()
+                    .any(|bot| sender_localpart.as_str() == *bot);
+
+                messages.push(ManagementRoomMessage {
+                    sender,
+                    body,
+                    timestamp,
+                    is_from_bot,
+                });
+            }
+        }
+    }
+
+    Ok(messages)
+}

--- a/backend/src/utils/bridge.rs
+++ b/backend/src/utils/bridge.rs
@@ -2517,9 +2517,7 @@ pub async fn read_management_room_messages(
 
                 let timestamp = i64::from(original.origin_server_ts.0) / 1000;
 
-                let is_from_bot = bot_localparts
-                    .iter()
-                    .any(|bot| sender_localpart.as_str() == *bot);
+                let is_from_bot = bot_localparts.contains(&sender_localpart.as_str());
 
                 messages.push(ManagementRoomMessage {
                     sender,


### PR DESCRIPTION
## Summary
- Proactively detect WhatsApp bridge issues instead of waiting for users to interact and discover failures
- Logs bridge bot management room messages for all users (raw, no classification) to collect disconnect patterns for future analysis
- GitHub Actions workflow polls health endpoint every 15 minutes, alerts via Resend SMTP with 4-hour cooldown via S3 marker

## What this adds

**Backend:**
- New `bridge_watchdog_logs` table (migration 27) stores raw bot messages with bridge age metadata - no classification yet since we need real disconnect data first
- `GET /api/watchdog/bridge/health` runs comprehensive checks per user: bridge record status, Matrix client, room access, management room disconnection signals (via existing `is_disconnection_message`), data freshness
- `POST /api/watchdog/bridge/test-send` sends Note to Self test via admin phone number, rate-limited to once per 2 hours
- Scheduled job scans all users' management rooms every 15 minutes
- Daily cleanup job removes logs older than 30 days

**Auth:** Both endpoints use `X-Watchdog-Key` header (same pattern as `maintenance_handlers::check_secret`)

**Privacy:** Health response contains only integer user_ids, never PII. Workflow logs aggregate status only (`4/5 healthy`); per-user details go in private alert email.

**Deploy config:**
- `WATCHDOG_API_KEY` and `WATCHDOG_TEST_PHONE` already added to `s3://lightfriend-prod-backups/config/.env`
- `WATCHDOG_API_KEY` and `SERVER_URL` added as GitHub Actions secrets

## Test plan
- [ ] Migration applies cleanly in prod (diesel migration 27)
- [ ] `curl -H "X-Watchdog-Key: $KEY" https://lightfriend.ai/api/watchdog/bridge/health` returns structured status
- [ ] Forbidden without key: returns 403
- [ ] Scheduled job logs bot messages to `bridge_watchdog_logs` table (check after 15 min)
- [ ] Test-send succeeds and appears in Note to Self on WhatsApp
- [ ] Test-send rate-limits second call within 2 hours
- [ ] GitHub Actions workflow triggers on schedule, logs only aggregate status
- [ ] Alert email sent on unhealthy, cooldown suppresses repeats within 4 hours