### PR TITLE
Sender autocomplete dedup + telegram proxy port fix

### DIFF
--- a/backend/src/api/matrix_client.rs
+++ b/backend/src/api/matrix_client.rs
@@ -663,7 +663,7 @@ impl RoomInterface for MockRoom {
             .take(limit as usize)
             .cloned()
             .collect();
-        result.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+        result.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
         Ok(result)
     }
 

--- a/backend/src/blog/content.rs
+++ b/backend/src/blog/content.rs
@@ -268,7 +268,7 @@ impl BlogStore {
 
         // Blog posts sorted by date
         let mut sorted: Vec<&BlogPost> = posts.values().collect();
-        sorted.sort_by(|a, b| b.frontmatter.date.cmp(&a.frontmatter.date));
+        sorted.sort_by_cached_key(|b| std::cmp::Reverse(b.frontmatter.date.clone()));
 
         for post in sorted {
             let priority = if post.frontmatter.cluster_hub {

--- a/backend/src/handlers/dashboard_handlers.rs
+++ b/backend/src/handlers/dashboard_handlers.rs
@@ -981,6 +981,11 @@ pub async fn get_senders(
                     msg_count: None,
                     is_group: false,
                 });
+                // Claim the chat:/group: keys too, so bridge DB and bridge-room
+                // searches further down don't add a second row for the same
+                // (name, platform) pair that's already surfaced as a person channel.
+                seen.insert(format!("chat:{}:{}", display.to_lowercase(), ch.platform));
+                seen.insert(format!("group:{}:{}", display.to_lowercase(), ch.platform));
             }
         }
     }

--- a/backend/src/handlers/dashboard_handlers.rs
+++ b/backend/src/handlers/dashboard_handlers.rs
@@ -763,7 +763,7 @@ pub async fn get_activity_feed(
     }
 
     // Sort by timestamp descending, truncate
-    entries.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    entries.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     entries.truncate(limit as usize);
 
     Ok(Json(entries))

--- a/backend/src/handlers/imap_handlers.rs
+++ b/backend/src/handlers/imap_handlers.rs
@@ -1133,7 +1133,7 @@ pub async fn fetch_emails_imap(
     }
 
     // Sort by date descending (newest first)
-    all_previews.sort_by(|a, b| b.date.cmp(&a.date));
+    all_previews.sort_by_key(|b| std::cmp::Reverse(b.date));
 
     // Apply limit across all accounts
     if let Some(lim) = limit {

--- a/backend/src/handlers/youtube.rs
+++ b/backend/src/handlers/youtube.rs
@@ -232,7 +232,7 @@ async fn fetch_subscription_feed_with_token(
     }
 
     // Sort by published date (newest first)
-    all_videos.sort_by(|a, b| b.published_at.cmp(&a.published_at));
+    all_videos.sort_by_cached_key(|b| std::cmp::Reverse(b.published_at.clone()));
 
     // Limit to 20 most recent
     all_videos.truncate(20);

--- a/backend/src/jobs/scheduler.rs
+++ b/backend/src/jobs/scheduler.rs
@@ -542,7 +542,7 @@ pub async fn start_scheduler(state: Arc<AppState>) {
 
                                         if processed_emails.len() > cleanup_threshold {
                                             // Sort by processed_at timestamp (newest first)
-                                            processed_emails.sort_by(|a, b| b.processed_at.cmp(&a.processed_at));
+                                            processed_emails.sort_by_key(|b| std::cmp::Reverse(b.processed_at));
 
                                             // Keep at least fetch_window emails plus some buffer
                                             let keep_count = fetch_window * 2;  // Keep 20 emails (double the fetch window)

--- a/backend/src/repositories/bandwidth_repository.rs
+++ b/backend/src/repositories/bandwidth_repository.rs
@@ -96,7 +96,7 @@ impl BandwidthRepository {
             )
             .collect();
 
-        results.sort_by(|a, b| b.bytes_total.cmp(&a.bytes_total));
+        results.sort_by_key(|b| std::cmp::Reverse(b.bytes_total));
         Ok(results)
     }
 

--- a/backend/src/repositories/ontology_repository.rs
+++ b/backend/src/repositories/ontology_repository.rs
@@ -94,7 +94,7 @@ fn active_hour_range(hour_buckets: &[u32; 24], total: u32) -> Option<(usize, usi
         return None;
     }
     // Sort by count descending, accumulate until 80%
-    indexed.sort_by(|a, b| b.1.cmp(&a.1));
+    indexed.sort_by_key(|b| std::cmp::Reverse(b.1));
     let threshold = (total as f64 * 0.8) as u32;
     let mut acc = 0u32;
     let mut active: Vec<usize> = Vec::new();

--- a/backend/src/utils/bridge.rs
+++ b/backend/src/utils/bridge.rs
@@ -518,7 +518,7 @@ pub async fn fetch_bridge_messages_trait(
     }
 
     // Sort by timestamp (most recent first)
-    all_messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    all_messages.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     Ok(all_messages)
 }
 
@@ -1036,7 +1036,7 @@ pub async fn fetch_bridge_messages(
     }
 
     // Sort by timestamp (most recent first)
-    bridge_messages.sort_by(|a, b| b.timestamp.cmp(&a.timestamp));
+    bridge_messages.sort_by_key(|b| std::cmp::Reverse(b.timestamp));
     tracing::info!("Retrieved {} messages from Postgres", bridge_messages.len());
     Ok(bridge_messages)
 }

--- a/backend/tests/digest_layout_test.rs
+++ b/backend/tests/digest_layout_test.rs
@@ -672,7 +672,7 @@ async fn full_digest_renders_all_sections() {
     );
     println!("message_ids included: {:?}", message_ids);
 
-    // Section ordering: header → Today → Critical → Important → FYI → New → Done → Reply
+    // Section ordering: header → Today → Critical → Important → FYI → New → Done
     let today_pos = digest_text.find("Today:").expect("Today section missing");
     let crit_pos = digest_text
         .find("Critical:")
@@ -683,16 +683,12 @@ async fn full_digest_renders_all_sections() {
     let fyi_pos = digest_text.find("FYI:").expect("FYI section missing");
     let new_pos = digest_text.find("New:").expect("New section missing");
     let done_pos = digest_text.find("Done:").expect("Done section missing");
-    let cta_pos = digest_text
-        .find("Reply to dig in")
-        .expect("CTA footer missing");
 
     assert!(today_pos < crit_pos);
     assert!(crit_pos < imp_pos);
     assert!(imp_pos < fyi_pos);
     assert!(fyi_pos < new_pos);
     assert!(new_pos < done_pos);
-    assert!(done_pos < cta_pos);
 
     // Today's events present (inline format with times)
     assert!(digest_text.contains("Doctor appointment"));

--- a/enclave/entrypoint.sh
+++ b/enclave/entrypoint.sh
@@ -882,17 +882,26 @@ proxy_fields = {
     "username": os.environ.get("TELEGRAM_PROXY_USERNAME", ""),
     "password": os.environ.get("TELEGRAM_PROXY_PASSWORD", ""),
 }
-# Always patch proxy type (to allow disabling proxy on existing configs)
-text = re.sub(r"(?m)^(        type:).*$", rf"\1 {proxy_type}", text, count=1)
+# Patch fields inside the proxy: block only. The old code used re.sub with
+# count=1 across the whole file, which matched telegram.server.port (e.g. 10000)
+# before telegram.proxy.port and replaced the wrong field.
+proxy_block_re = r"(?ms)^    proxy:\n(?:        \S.*\n)+"
 if real_addr and real_port and proxy_type != "disabled":
-    for field, value in proxy_fields.items():
-        if field == "type":
-            continue
-        pattern = rf"(?m)^(        {field}:).*$"
-        replacement = rf"\1 {value}"
-        text = re.sub(pattern, replacement, text, count=1)
-    print(f"  Patched proxy: {proxy_type} 127.0.0.1:1080 (VSOCK bridge to {real_addr}:{real_port})", flush=True)
+    def patch_proxy_block(m):
+        block = m.group(0)
+        for field, value in proxy_fields.items():
+            block = re.sub(rf"(?m)^(        {field}:).*$", rf"\1 {value}", block, count=1)
+        return block
+    text, n = re.subn(proxy_block_re, patch_proxy_block, text, count=1)
+    if n:
+        print(f"  Patched proxy: {proxy_type} 127.0.0.1:1080 (VSOCK bridge to {real_addr}:{real_port})", flush=True)
+    else:
+        print(f"  WARNING: proxy block not found in config, could not patch", flush=True)
 else:
+    # Proxy disabled: only patch the type field, leave address/port/creds alone.
+    def patch_proxy_type_only(m):
+        return re.sub(r"(?m)^(        type:).*$", rf"\1 {proxy_type}", m.group(0), count=1)
+    text = re.subn(proxy_block_re, patch_proxy_type_only, text, count=1)[0]
     print(f"  Proxy: {proxy_type} (direct connection via tap0)", flush=True)
 
 path.write_text(text)


### PR DESCRIPTION
## Summary
- Dedup sender autocomplete: rows from the WhatsApp bridge DB and bridge-room searches no longer appear twice when the same (name, platform) pair is already surfaced as a person channel.
- Merge tg-debug: scope the telegram proxy config patch to the proxy block so telegram.server.port isn't overwritten with 1080. Disabled-proxy path now only patches the type field and leaves address/port/creds alone.
- Drop the digest CTA footer assertion - the Reply to dig in CTA is no longer rendered.

## Test plan
- [x] backend: cargo test passes locally (all suites)
- [ ] prod: watch get_senders logs for a search that previously duplicated Karvis Ville (whatsapp)