### PR TITLE
SMS provider fallback + commitment detection + webhook SMS tokens

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -273,7 +273,11 @@
       "Read(//Users/ahtavarasmus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-imap-0.10.4/src/**)",
       "Read(//Users/ahtavarasmus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-imap-0.10.4/examples/**)",
       "Read(//Users/ahtavarasmus/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/async-imap-0.10.4/**)",
-      "Bash(gh run:*)"
+      "Bash(gh run:*)",
+      "Bash(aws ecs list-clusters:*)",
+      "Bash(disown)",
+      "Bash(brew upgrade *)",
+      "Bash(brew install *)"
     ],
     "deny": [
       "Read(.env)",

--- a/backend/Cargo.toml
+++ b/backend/Cargo.toml
@@ -86,3 +86,8 @@ required-features = ["tuwunel-restore"]
 [dev-dependencies]
 serial_test = "3.0"  # For tests that modify environment variables
 wiremock = "0.6"  # For mock HTTP server tests
+
+[lints.rust]
+# `cfg(kani)` is set by the Kani verifier, not by Cargo. Declare it here
+# so `cargo check` doesn't warn about unknown cfg keys.
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/backend/fuzz/.gitignore
+++ b/backend/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/backend/fuzz/Cargo.toml
+++ b/backend/fuzz/Cargo.toml
@@ -1,0 +1,37 @@
+[package]
+name = "backend-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+ed25519-dalek = "2"
+
+[dependencies.backend]
+path = ".."
+
+# Keep the fuzz crate out of the main workspace so cargo-fuzz can manage it
+# independently (and so nightly-only deps don't leak into normal builds).
+[workspace]
+
+[profile.release]
+debug = 1
+
+[[bin]]
+name = "twilio_signature"
+path = "fuzz_targets/twilio_signature.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "telnyx_signature"
+path = "fuzz_targets/telnyx_signature.rs"
+test = false
+doc = false
+bench = false

--- a/backend/fuzz/README.md
+++ b/backend/fuzz/README.md
@@ -1,0 +1,142 @@
+# Fuzz targets
+
+Property-based, coverage-guided fuzz tests for security-critical pure
+functions in `backend`. Each target asserts invariants that must hold
+for **every** input an attacker can supply.
+
+> **Companion**: bounded-model-checking proofs for the same functions
+> live in `backend/tests/kani_signature_proofs.rs`. See the "Kani" section
+> at the bottom for what those prove and how they complement fuzzing.
+
+Today's targets:
+
+| Target              | Function under test          | Why it matters |
+| ------------------- | ---------------------------- | -------------- |
+| `twilio_signature`  | `verify_twilio_signature`    | Webhook forgery would let an attacker impersonate Twilio (inject SMS, fire status callbacks, manipulate user state). |
+| `telnyx_signature`  | `verify_telnyx_signature`    | Same attack surface for the Telnyx provider. |
+
+## One-time setup
+
+`cargo fuzz` needs nightly Rust and the `cargo-fuzz` subcommand:
+
+```bash
+rustup install nightly
+cargo install cargo-fuzz
+```
+
+## Running
+
+From this directory (`backend/fuzz`):
+
+```bash
+# Run forever (Ctrl-C to stop)
+cargo +nightly fuzz run twilio_signature
+
+# Time-boxed run (60 seconds) - what CI / pre-push should use
+cargo +nightly fuzz run twilio_signature -- -max_total_time=60
+cargo +nightly fuzz run telnyx_signature -- -max_total_time=60
+
+# Reproduce a crash from an artifact
+cargo +nightly fuzz run twilio_signature artifacts/twilio_signature/crash-<hash>
+```
+
+Or via the justfile recipes from the repo root:
+
+```bash
+just fuzz-twilio        # 60-second batch
+just fuzz-telnyx        # 60-second batch
+just fuzz-all           # 60 seconds each, sequentially
+```
+
+## What a finding looks like
+
+If a fuzz run finds an input that violates an invariant, libFuzzer prints
+the crashing input and writes it to `artifacts/<target>/crash-<hash>`.
+Read that file, reproduce locally with `cargo fuzz run <target>
+artifacts/<target>/crash-<hash>`, then write a unit test in
+`backend/tests/` pinning the regression before fixing the bug.
+
+The three invariant categories every target checks:
+
+1. **No panic** - the verifier must return `Err` rather than panic on any
+   malformed input. A panic in middleware is a denial-of-service primitive.
+2. **Round-trip** - a signature we just computed with a given key must
+   verify under that same key. If this fails, legitimate webhooks would
+   be rejected in production.
+3. **Tamper detection** - flipping any byte of the signed payload (or the
+   key) must invalidate the signature. If this ever passes, the underlying
+   crypto is broken (which would be Big News, but worth verifying).
+
+## Adding a new target
+
+1. Make the function under test **pure** (no I/O, no env vars, no
+   `AppState`). Extract a helper if needed - see how `telnyx_utils.rs`
+   exposes `verify_telnyx_signature` separately from the middleware.
+2. Add a new file under `fuzz_targets/` with a `fuzz_target!` macro.
+3. Add a corresponding `[[bin]]` entry to `Cargo.toml`.
+4. Add a justfile recipe at the repo root.
+5. Document the new target in the table above.
+
+Prefer targets that take adversarial bytes from untrusted sources:
+webhook signature verifiers, base64/url/hex decoders, OAuth callback
+parsers, JWT validators, encryption round-trips.
+
+## Kani (bounded model checking)
+
+Where fuzzing is "probabilistic search for counterexamples," Kani is
+"exhaustive symbolic execution that PROVES no counterexample exists
+within a stated input bound." A Kani proof that finishes is a real
+mathematical result, not an absence-of-evidence claim.
+
+Proofs live in `backend/tests/kani_signature_proofs.rs` and are gated
+by `#[cfg(kani)]` so they're invisible to `cargo test` / `cargo check`.
+
+**One-time install** (separate from cargo-fuzz):
+
+```bash
+cargo install --locked kani-verifier
+cargo kani setup           # downloads CBMC + the Kani toolchain
+```
+
+**Run all proofs**:
+
+```bash
+just kani                  # ~minutes; runs every #[kani::proof] in the crate
+```
+
+**Run a single proof** (useful when debugging timeouts):
+
+```bash
+cd backend && cargo kani --tests --harness proof_telnyx_short_public_key_rejected
+```
+
+**What the current proofs cover**:
+
+| Proof | What it proves for ALL bounded inputs |
+| ----- | -------------------------------------- |
+| `proof_telnyx_short_public_key_rejected` | A pubkey shorter than 32 bytes ALWAYS returns Err("public key...") - no panic, no Ok path. |
+| `proof_telnyx_long_public_key_rejected`  | Same for pubkeys longer than 32 bytes. |
+| `proof_telnyx_wrong_signature_length_rejected` | Any signature length other than 64 ALWAYS returns Err. |
+| `proof_twilio_invalid_base64_signature_rejected` | Any signature string containing a non-base64 byte ALWAYS returns Err. |
+| `proof_twilio_empty_params_no_panic` | The verifier never panics on empty params + bounded URL/token. |
+
+**What the current proofs do NOT cover** (and why):
+
+- **HMAC-SHA1 / Ed25519 internals**: CBMC cannot symbolically execute
+  the SHA-1 compression function or Ed25519 scalar multiplication in
+  bounded time. Those primitives are covered by the audited upstream
+  crates (`hmac`, `sha1`, `ed25519-dalek`) and by the fuzz harnesses,
+  not by Kani.
+- **Round-trip and tamper-detection**: same reason - these require
+  symbolically executing the full crypto pipeline twice. The fuzz
+  harnesses in `fuzz_targets/` cover them probabilistically.
+
+**Adding a new Kani proof**:
+
+1. Pick a property about non-crypto control flow (length checks,
+   parsing, state-machine transitions, branch coverage).
+2. Add a `#[kani::proof]` function in
+   `backend/tests/kani_signature_proofs.rs`.
+3. Use `kani::any()` for symbolic inputs, `kani::assume(...)` to bound
+   the input space, and `#[kani::unwind(N)]` to bound any loops.
+4. Run it. If it doesn't finish in ~5 minutes, tighten the bounds.

--- a/backend/fuzz/fuzz_targets/telnyx_signature.rs
+++ b/backend/fuzz/fuzz_targets/telnyx_signature.rs
@@ -1,0 +1,75 @@
+//! Fuzz harness for `verify_telnyx_signature`.
+//!
+//! Telnyx auto-signs every webhook with Ed25519 over `<timestamp>|<body>`.
+//! The middleware strips base64 + length checks before calling the pure
+//! verifier; this harness exercises the verifier directly so it sees
+//! adversarial public keys, signatures, timestamps, and bodies.
+//!
+//! Invariants asserted for ALL inputs:
+//!
+//!   1. NO PANIC: verify_telnyx_signature never panics, even when the
+//!      public key or signature are wrong length, malformed, or all-zero.
+//!
+//!   2. ROUND-TRIP: a signature produced by compute_telnyx_signature with
+//!      a derived signing key must verify against that key's public half.
+//!
+//!   3. TAMPER DETECTION: flipping any single byte of the body must
+//!      invalidate the signature. (Ed25519 is deterministic and collision-
+//!      resistant; if this ever passes, the library is broken.)
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use backend::api::telnyx_utils::{compute_telnyx_signature, verify_telnyx_signature};
+use ed25519_dalek::SigningKey;
+use libfuzzer_sys::fuzz_target;
+
+#[derive(Arbitrary, Debug)]
+struct FuzzInput {
+    seed: [u8; 32],
+    timestamp: String,
+    body: Vec<u8>,
+    attacker_public_key: Vec<u8>,
+    attacker_signature: Vec<u8>,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    // Invariant 1: arbitrary attacker bytes must not panic the verifier.
+    let _ = verify_telnyx_signature(
+        &input.attacker_public_key,
+        &input.attacker_signature,
+        &input.timestamp,
+        &input.body,
+    );
+
+    // Derive a real keypair from the seed and produce a real signature.
+    let signing_key = SigningKey::from_bytes(&input.seed);
+    let public_key = signing_key.verifying_key().to_bytes();
+    let real_sig = compute_telnyx_signature(&signing_key, &input.timestamp, &input.body);
+
+    // Invariant 2: real signatures must verify.
+    assert!(
+        verify_telnyx_signature(&public_key, &real_sig, &input.timestamp, &input.body).is_ok(),
+        "round-trip failed: timestamp={:?} body_len={}",
+        input.timestamp,
+        input.body.len()
+    );
+
+    // Invariant 3: tampering the body must invalidate the signature.
+    if !input.body.is_empty() {
+        let mut tampered_body = input.body.clone();
+        tampered_body[0] ^= 0xff;
+        assert!(
+            verify_telnyx_signature(&public_key, &real_sig, &input.timestamp, &tampered_body)
+                .is_err(),
+            "tampered body still verified (Ed25519 broken?)"
+        );
+    }
+
+    // Invariant 3b: tampering the timestamp must invalidate the signature.
+    let tampered_ts = format!("{}x", input.timestamp);
+    assert!(
+        verify_telnyx_signature(&public_key, &real_sig, &tampered_ts, &input.body).is_err(),
+        "tampered timestamp still verified"
+    );
+});

--- a/backend/fuzz/fuzz_targets/twilio_signature.rs
+++ b/backend/fuzz/fuzz_targets/twilio_signature.rs
@@ -1,0 +1,66 @@
+//! Fuzz harness for `verify_twilio_signature`.
+//!
+//! Twilio signs webhooks with HMAC-SHA1 over `<url> || k1 || v1 || k2 || v2 ...`
+//! where params are sorted lexicographically. A bug in any step (URL handling,
+//! param sorting, base64 decode, constant-time compare) is a webhook forgery
+//! primitive. This harness asserts three invariants for ALL inputs:
+//!
+//!   1. NO PANIC: verify_twilio_signature must never panic. An attacker
+//!      controls every byte of the request, so any panic is a DoS.
+//!
+//!   2. ROUND-TRIP: compute_twilio_signature followed by verify_twilio_signature
+//!      with the same token must succeed. If this ever fails, our own
+//!      legitimate webhooks would start being rejected.
+//!
+//!   3. TAMPER DETECTION: flipping any bit of the auth token (after computing
+//!      a valid signature) must cause verification to fail. If this ever
+//!      succeeds, an attacker who doesn't know the token can still forge.
+
+#![no_main]
+
+use arbitrary::Arbitrary;
+use backend::api::twilio_utils::{compute_twilio_signature, verify_twilio_signature};
+use libfuzzer_sys::fuzz_target;
+use std::collections::BTreeMap;
+
+#[derive(Arbitrary, Debug)]
+struct FuzzInput {
+    url: String,
+    params: Vec<(String, String)>,
+    auth_token: String,
+    attacker_signature_b64: String,
+}
+
+fuzz_target!(|input: FuzzInput| {
+    let params: BTreeMap<String, String> = input.params.into_iter().collect();
+
+    // Invariant 1: verifying an arbitrary attacker-supplied signature
+    // against arbitrary attacker-supplied inputs must not panic.
+    let _ = verify_twilio_signature(
+        &input.url,
+        &params,
+        &input.attacker_signature_b64,
+        &input.auth_token,
+    );
+
+    // Invariant 2: round-trip with a real Twilio-style signature must verify.
+    let real_sig = compute_twilio_signature(&input.url, &params, &input.auth_token);
+    assert!(
+        verify_twilio_signature(&input.url, &params, &real_sig, &input.auth_token).is_ok(),
+        "round-trip failed: url={:?} params={:?} token_len={}",
+        input.url,
+        params,
+        input.auth_token.len()
+    );
+
+    // Invariant 3: flipping the token must invalidate the signature.
+    // We append a byte that can't already be the last byte of the token,
+    // so the tampered token is always distinct from the original.
+    let mut tampered_token = input.auth_token.clone().into_bytes();
+    tampered_token.push(0x00);
+    let tampered_token = String::from_utf8_lossy(&tampered_token).into_owned();
+    assert!(
+        verify_twilio_signature(&input.url, &params, &real_sig, &tampered_token).is_err(),
+        "signature verified under a different auth token (HMAC broken?)"
+    );
+});

--- a/backend/pg_migrations/00000000000035_add_commitment_signal_tables/down.sql
+++ b/backend/pg_migrations/00000000000035_add_commitment_signal_tables/down.sql
@@ -1,0 +1,3 @@
+DROP TABLE IF EXISTS commitment_prompts;
+DROP TABLE IF EXISTS commitment_label_embeddings;
+DROP TABLE IF EXISTS commitment_sender_rules;

--- a/backend/pg_migrations/00000000000035_add_commitment_signal_tables/up.sql
+++ b/backend/pg_migrations/00000000000035_add_commitment_signal_tables/up.sql
@@ -1,0 +1,68 @@
+-- Per-user sender rules driving commitment detection.
+-- rule_type: 'mute' (skip detection entirely) or 'always_track' (auto-create
+-- ont_event without SMS prompt).
+CREATE TABLE IF NOT EXISTS commitment_sender_rules (
+    id SERIAL PRIMARY KEY,
+    user_id INT4 NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    platform TEXT NOT NULL,
+    sender_key TEXT NOT NULL,
+    rule_type TEXT NOT NULL,
+    source TEXT NOT NULL,
+    active BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at INT4 NOT NULL,
+    deactivated_at INT4
+);
+
+CREATE INDEX IF NOT EXISTS idx_commitment_sender_rules_lookup
+    ON commitment_sender_rules (user_id, platform, sender_key, active);
+
+-- Per-user content similarity memory for label-similarity detection.
+-- label_type: 'track' (reply 1 or 2) or 'wrong' (reply 4). 'mute' (3) does
+-- not seed embeddings because it's a sender preference, not a content signal.
+-- embedding stores raw little-endian f32 bytes.
+CREATE TABLE IF NOT EXISTS commitment_label_embeddings (
+    id SERIAL PRIMARY KEY,
+    user_id INT4 NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    label_type TEXT NOT NULL,
+    embedding BYTEA NOT NULL,
+    source_message_id INT8,
+    created_at INT4 NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_commitment_label_embeddings_user_label
+    ON commitment_label_embeddings (user_id, label_type);
+
+-- Live SMS prompts asking the user to label a detected commitment.
+-- user_label: '1' track, '2' always-track, '3' mute, '4' not-a-commitment.
+-- resolved_at is non-null once user replied OR prompt expired without reply.
+-- resulting_event_id is the ont_event created on reply 1 or 2.
+-- due_at / remind_at preserve the detector-extracted schedule so reply
+-- 1 / 2 can re-create the event with the original deadline (otherwise the
+-- SMS-prompt branch silently strips deadline metadata).
+CREATE TABLE IF NOT EXISTS commitment_prompts (
+    id SERIAL PRIMARY KEY,
+    user_id INT4 NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    ont_message_id INT8 NOT NULL,
+    platform TEXT NOT NULL,
+    sender_key TEXT NOT NULL,
+    sender_display_name TEXT NOT NULL,
+    commitment_description TEXT NOT NULL,
+    due_at INT4,
+    remind_at INT4,
+    sent_at INT4 NOT NULL,
+    sms_message_sid TEXT,
+    user_label TEXT,
+    labeled_at INT4,
+    resulting_event_id INT4,
+    resolved_at INT4
+);
+
+CREATE INDEX IF NOT EXISTS idx_commitment_prompts_user_unresolved
+    ON commitment_prompts (user_id, resolved_at);
+
+-- Enforces "at most one unresolved prompt per sender per user" at the
+-- database level, so concurrent message arrivals can't both pass the
+-- find_unresolved_for_sender check and double-spam the user.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_commitment_prompts_unresolved_sender_unique
+    ON commitment_prompts (user_id, platform, sender_key)
+    WHERE resolved_at IS NULL;

--- a/backend/pg_migrations/00000000000036_add_provider_routes/down.sql
+++ b/backend/pg_migrations/00000000000036_add_provider_routes/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS provider_routes;

--- a/backend/pg_migrations/00000000000036_add_provider_routes/up.sql
+++ b/backend/pg_migrations/00000000000036_add_provider_routes/up.sql
@@ -1,0 +1,21 @@
+-- Per-country ordered list of SMS providers for outbound fallback.
+-- The router tries providers in this order and falls through to the
+-- next on send failure. Two-letter ISO codes match utils::country
+-- output. provider_order is a JSON array of channel ids registered
+-- in ChannelRouter, e.g. '["twilio","telnyx","sinch"]'.
+--
+-- Countries with no row inherit the router default ("twilio" only).
+-- Operators can flip a country's primary at runtime via
+-- POST /api/admin/provider-routes without a redeploy.
+CREATE TABLE IF NOT EXISTS provider_routes (
+    country_code TEXT PRIMARY KEY,
+    provider_order TEXT NOT NULL,
+    updated_at INT4 NOT NULL
+);
+
+-- Seed US with the current behavior: Twilio primary, Telnyx fallback.
+-- Sinch is registered too but kept out of the default order until
+-- we've validated end-to-end deliverability through it.
+INSERT INTO provider_routes (country_code, provider_order, updated_at)
+VALUES ('US', '["twilio","telnyx"]', EXTRACT(EPOCH FROM NOW())::INT4)
+ON CONFLICT (country_code) DO NOTHING;

--- a/backend/pg_migrations/00000000000037_add_pending_reply_watches/down.sql
+++ b/backend/pg_migrations/00000000000037_add_pending_reply_watches/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS pending_reply_watches;

--- a/backend/pg_migrations/00000000000037_add_pending_reply_watches/up.sql
+++ b/backend/pg_migrations/00000000000037_add_pending_reply_watches/up.sql
@@ -1,0 +1,30 @@
+-- One-shot watches: when the AI sends a message on the user's behalf with
+-- notify_on_reply = true, we arm a row here. The first matching inbound
+-- message within the TTL forwards a notification to the user and deletes
+-- the row. No matching message within the TTL = silent expiry.
+--
+-- Polymorphic across bridge (Matrix: WhatsApp/Telegram/Signal) and email.
+-- Bridge rows key the match on room_id. Email rows key on
+-- (imap_connection_id, contact_identifier).
+CREATE TABLE IF NOT EXISTS pending_reply_watches (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    platform TEXT NOT NULL,
+    room_id TEXT,
+    imap_connection_id INTEGER,
+    contact_identifier TEXT NOT NULL,
+    contact_display_name TEXT NOT NULL,
+    created_at INT4 NOT NULL,
+    expires_at INT4 NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS pending_reply_watches_bridge_idx
+    ON pending_reply_watches (user_id, room_id)
+    WHERE platform = 'bridge';
+
+CREATE INDEX IF NOT EXISTS pending_reply_watches_email_idx
+    ON pending_reply_watches (user_id, imap_connection_id, contact_identifier)
+    WHERE platform = 'email';
+
+CREATE INDEX IF NOT EXISTS pending_reply_watches_expires_idx
+    ON pending_reply_watches (expires_at);

--- a/backend/pg_migrations/00000000000038_add_webhook_tokens/down.sql
+++ b/backend/pg_migrations/00000000000038_add_webhook_tokens/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_webhook_tokens_user_id;
+DROP TABLE IF EXISTS webhook_tokens;

--- a/backend/pg_migrations/00000000000038_add_webhook_tokens/up.sql
+++ b/backend/pg_migrations/00000000000038_add_webhook_tokens/up.sql
@@ -1,0 +1,26 @@
+-- Per-user webhook tokens for triggering an SMS to the user's own phone.
+-- A leaked token can only target the owning user's phone_number; it cannot
+-- be used as an open SMS relay, which keeps the abuse surface bounded.
+--
+-- token_hash is SHA-256 of the raw bearer string ("lf_<32 hex>"). The raw
+-- token is shown to the user exactly once at creation time; the DB stores
+-- only the hash, so a DB read does not let an attacker forge requests.
+--
+-- daily_cap / daily_sent / daily_reset_at bound cost even if a token leaks:
+-- the cap is enforced via a single atomic UPDATE so two concurrent requests
+-- cannot both slip past the boundary.
+CREATE TABLE IF NOT EXISTS webhook_tokens (
+    id SERIAL PRIMARY KEY,
+    user_id INT4 NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash TEXT NOT NULL UNIQUE,
+    token_prefix TEXT NOT NULL,
+    label TEXT NOT NULL,
+    daily_cap INT4 NOT NULL DEFAULT 50,
+    daily_sent INT4 NOT NULL DEFAULT 0,
+    daily_reset_at INT4 NOT NULL,
+    last_used_at INT4,
+    revoked_at INT4,
+    created_at INT4 NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_tokens_user_id ON webhook_tokens (user_id);

--- a/backend/pg_migrations/00000000000039_add_webhook_idempotency_keys/down.sql
+++ b/backend/pg_migrations/00000000000039_add_webhook_idempotency_keys/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_webhook_idempotency_created_at;
+DROP TABLE IF EXISTS webhook_idempotency_keys;

--- a/backend/pg_migrations/00000000000039_add_webhook_idempotency_keys/up.sql
+++ b/backend/pg_migrations/00000000000039_add_webhook_idempotency_keys/up.sql
@@ -1,0 +1,26 @@
+-- Per-token idempotency record so retried webhook calls don't send
+-- duplicate SMS. Lookup is keyed on (token_id, idempotency_key).
+--
+-- response_sid:
+--   NULL = the original request is still in-flight; concurrent
+--          replays should be rejected with 409 so the client can wait
+--          and retry rather than racing the original.
+--   non-NULL = the original request completed; replays return this
+--              SID without re-billing or re-consuming the daily cap.
+--
+-- Lookup is TTL-gated in code (24h) so reusing a key after a day
+-- starts fresh; rows older than that are inert but kept until a
+-- periodic cleanup removes them. With the default 50/day cap, even a
+-- year of usage tops out around 18k rows per token — small enough to
+-- leave purging to a later cron job.
+CREATE TABLE IF NOT EXISTS webhook_idempotency_keys (
+    id SERIAL PRIMARY KEY,
+    token_id INT4 NOT NULL REFERENCES webhook_tokens(id) ON DELETE CASCADE,
+    idempotency_key TEXT NOT NULL,
+    response_sid TEXT,
+    created_at INT4 NOT NULL,
+    UNIQUE (token_id, idempotency_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_idempotency_created_at
+    ON webhook_idempotency_keys (created_at);

--- a/backend/src/api/telnyx_utils.rs
+++ b/backend/src/api/telnyx_utils.rs
@@ -20,9 +20,67 @@ use axum::{
     response::Response,
 };
 use base64::{engine::general_purpose::STANDARD as BASE64, Engine as _};
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::{Signature, Signer, SigningKey, Verifier, VerifyingKey};
 
 const MAX_BODY_BYTES: usize = 1024 * 1024;
+
+/// Pure function: verify an Ed25519 signature on a Telnyx-style payload.
+///
+/// The signed message is `<timestamp>|<body>` (UTF-8 bytes). `public_key`
+/// must be exactly 32 bytes (raw Ed25519 public key) and `signature` must
+/// be exactly 64 bytes. Returns Ok(()) only if the signature is valid for
+/// the supplied public key and payload.
+///
+/// This function performs no I/O and reads no environment variables. It's
+/// the verification core used by [`validate_telnyx_signature`] and is the
+/// target of the `telnyx_signature` fuzz harness.
+pub fn verify_telnyx_signature(
+    public_key: &[u8],
+    signature: &[u8],
+    timestamp: &str,
+    body: &[u8],
+) -> Result<(), String> {
+    let public_key_arr: [u8; 32] = public_key.try_into().map_err(|_| {
+        format!(
+            "public key wrong length: expected 32, got {}",
+            public_key.len()
+        )
+    })?;
+    let verifying_key = VerifyingKey::from_bytes(&public_key_arr)
+        .map_err(|e| format!("public key parse failed: {}", e))?;
+
+    let signature_arr: [u8; 64] = signature.try_into().map_err(|_| {
+        format!(
+            "signature wrong length: expected 64, got {}",
+            signature.len()
+        )
+    })?;
+    let signature = Signature::from_bytes(&signature_arr);
+
+    let mut signed_message = Vec::with_capacity(timestamp.len() + 1 + body.len());
+    signed_message.extend_from_slice(timestamp.as_bytes());
+    signed_message.push(b'|');
+    signed_message.extend_from_slice(body);
+
+    verifying_key
+        .verify(&signed_message, &signature)
+        .map_err(|e| format!("signature verification failed: {}", e))
+}
+
+/// Pure function: compute the Ed25519 signature for a Telnyx-style payload.
+/// Useful for tests and fuzz harnesses that need to produce known-good
+/// signatures.
+pub fn compute_telnyx_signature(
+    signing_key: &SigningKey,
+    timestamp: &str,
+    body: &[u8],
+) -> [u8; 64] {
+    let mut signed_message = Vec::with_capacity(timestamp.len() + 1 + body.len());
+    signed_message.extend_from_slice(timestamp.as_bytes());
+    signed_message.push(b'|');
+    signed_message.extend_from_slice(body);
+    signing_key.sign(&signed_message).to_bytes()
+}
 
 /// Verify Ed25519 signature on Telnyx webhook requests. Reads the body,
 /// validates `telnyx-signature-ed25519` against `<telnyx-timestamp>|<body>`
@@ -71,38 +129,21 @@ pub async fn validate_telnyx_signature(
         tracing::error!("TELNYX_PUBLIC_KEY is not valid base64: {}", e);
         StatusCode::INTERNAL_SERVER_ERROR
     })?;
-    let public_key_arr: [u8; 32] = public_key_bytes.as_slice().try_into().map_err(|_| {
-        tracing::error!(
-            "TELNYX_PUBLIC_KEY decoded to {} bytes, expected 32",
-            public_key_bytes.len()
-        );
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-    let verifying_key = VerifyingKey::from_bytes(&public_key_arr).map_err(|e| {
-        tracing::error!("TELNYX_PUBLIC_KEY parse failed: {}", e);
-        StatusCode::INTERNAL_SERVER_ERROR
-    })?;
-
     let signature_bytes = BASE64.decode(signature_b64.as_bytes()).map_err(|e| {
         tracing::warn!("Telnyx signature is not valid base64: {}", e);
         StatusCode::UNAUTHORIZED
     })?;
-    let signature_arr: [u8; 64] = signature_bytes.as_slice().try_into().map_err(|_| {
-        tracing::warn!(
-            "Telnyx signature decoded to {} bytes, expected 64",
-            signature_bytes.len()
-        );
-        StatusCode::UNAUTHORIZED
-    })?;
-    let signature = Signature::from_bytes(&signature_arr);
 
-    let mut signed_message = Vec::with_capacity(timestamp.len() + 1 + body_bytes.len());
-    signed_message.extend_from_slice(timestamp.as_bytes());
-    signed_message.push(b'|');
-    signed_message.extend_from_slice(&body_bytes);
-
-    if let Err(e) = verifying_key.verify(&signed_message, &signature) {
-        tracing::warn!("Telnyx signature verification failed: {}", e);
+    if let Err(e) =
+        verify_telnyx_signature(&public_key_bytes, &signature_bytes, &timestamp, &body_bytes)
+    {
+        // Length / parse problems on the env-supplied public key are
+        // a config error (500); everything else is auth failure (401).
+        if e.starts_with("public key") {
+            tracing::error!("Telnyx public key invalid: {}", e);
+            return Err(StatusCode::INTERNAL_SERVER_ERROR);
+        }
+        tracing::warn!("Telnyx signature rejected: {}", e);
         return Err(StatusCode::UNAUTHORIZED);
     }
 

--- a/backend/src/api/twilio_sms.rs
+++ b/backend/src/api/twilio_sms.rs
@@ -688,6 +688,33 @@ pub async fn process_sms(
         payload.from
     );
 
+    // Commitment-prompt reply path: a bare "1"/"2"/"3"/"4" with a pending
+    // prompt outstanding short-circuits the regular agent flow. Anything else
+    // (including those digits when there's no pending prompt) falls through.
+    if let Some(reply) =
+        crate::proactive::commitment_replies::try_handle_reply(state, &user, &payload.body).await
+    {
+        if !options.skip_twilio_send {
+            let state_clone = state.clone();
+            let user_clone = user.clone();
+            let reply_clone = reply.clone();
+            tokio::spawn(async move {
+                if let Err(e) = state_clone
+                    .channel_router
+                    .send_to_user(&user_clone, &reply_clone, None)
+                    .await
+                {
+                    tracing::error!(
+                        "Failed to send commitment-reply confirmation to user {}: {}",
+                        user_clone.id,
+                        e
+                    );
+                }
+            });
+        }
+        return SmsResult::Success { response: reply }.into_response();
+    }
+
     // Handle 'cancel' message specially
     if payload.body.trim().to_lowercase() == "c" {
         match crate::tool_call_utils::utils::cancel_pending_message(state, user.id).await {

--- a/backend/src/channels/router.rs
+++ b/backend/src/channels/router.rs
@@ -7,26 +7,40 @@
 //! - `notify` — proactive outbound. Goes through the user's chosen single
 //!   notification channel (resolved by the caller from `user_channels`).
 //!
-//! The router has no knowledge of which channel is "primary" — it just looks
-//! up by `channel_id`. Routing policy lives in the caller (or in the
-//! `user_channels` table once we add it).
+//! Outbound to a user (`send_to_user`) tries an ordered list of channels and
+//! falls through to the next one on send failure. The order is sourced from
+//! the `provider_routes` table per country, with `preferred_sms_provider` on
+//! `users` overriding the per-country choice as the first attempt. Fallback
+//! attempts after the first prepend a short tag so the user can tell the
+//! message is still legit Lightfriend reaching out on a different carrier.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use crate::channels::traits::{
     ChannelError, ChannelMessageId, IncomingMessage, MediaRef, MessageChannel,
 };
 use crate::models::user_models::User;
 
+/// Tag prepended to fallback-provider sends so the recipient can tell the
+/// SMS is still Lightfriend even though it comes from a different number.
+/// Kept short to preserve as much of the GSM-7 segment budget as possible.
+pub const FALLBACK_PREFIX: &str = "[Lightfriend backup] ";
+
 pub struct ChannelRouter {
     channels: HashMap<&'static str, Arc<dyn MessageChannel>>,
+    /// Per-country ordered provider ids, mirroring the `provider_routes`
+    /// table. Held behind RwLock so the admin endpoint can flip a country's
+    /// primary at runtime without restarting. Keys are ISO-3166-1 alpha-2
+    /// strings (e.g. "US").
+    routes: Arc<RwLock<HashMap<String, Vec<String>>>>,
 }
 
 impl ChannelRouter {
     pub fn new() -> Self {
         Self {
             channels: HashMap::new(),
+            routes: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -38,6 +52,27 @@ impl ChannelRouter {
     /// Look up a channel impl by id.
     pub fn channel(&self, id: &str) -> Option<&Arc<dyn MessageChannel>> {
         self.channels.get(id)
+    }
+
+    /// Replace the in-memory routing order for a country. Called once per
+    /// row at startup from `main.rs` after loading `provider_routes`, and
+    /// again from the admin endpoint when an operator flips the order.
+    /// Pass an empty vec or call `clear_route` to revert to default.
+    pub fn set_route(&self, country_code: &str, provider_order: Vec<String>) {
+        if let Ok(mut routes) = self.routes.write() {
+            routes.insert(country_code.to_uppercase(), provider_order);
+        }
+    }
+
+    pub fn clear_route(&self, country_code: &str) {
+        if let Ok(mut routes) = self.routes.write() {
+            routes.remove(&country_code.to_uppercase());
+        }
+    }
+
+    /// Snapshot of the current in-memory routes — for admin diagnostics.
+    pub fn current_routes(&self) -> HashMap<String, Vec<String>> {
+        self.routes.read().map(|r| r.clone()).unwrap_or_default()
     }
 
     /// Reply through whichever channel the user reached us on.
@@ -72,9 +107,11 @@ impl ChannelRouter {
         chan.send(user, address, body, None).await
     }
 
-    /// Send a message to a user, picking the right channel based on their
-    /// phone number's country and which channels are registered. Address
-    /// is `user.phone_number` (until `user_channels` lands in a future PR).
+    /// Send a message to a user. Tries providers in priority order
+    /// (`pick_channels_for`) and falls through to the next on send failure.
+    /// The first attempt sends the body unchanged; subsequent attempts
+    /// prepend `FALLBACK_PREFIX` so the user can tell that a backup
+    /// carrier is reaching them.
     ///
     /// Provider-agnostic preprocessing happens here — every outbound SMS
     /// goes through the same URL/defang sanitizer, the same empty-body
@@ -84,19 +121,7 @@ impl ChannelRouter {
     /// Message-history logging is intentionally NOT owned by the router:
     /// callers have richer context about what to log (e.g. citation-
     /// preserving `history_for_storage` vs. user-facing `clean_response`)
-    /// and decide for themselves whether and what to write. Doing it here
-    /// would clobber that distinction and double-log.
-    ///
-    /// Routing policy (presence-based, no env reads here — channels register
-    /// only if their env config is complete):
-    /// - US users: prefer `twilio`, fall back to `telnyx` if twilio is not
-    ///   registered. Telnyx stays as the documented backup channel for the
-    ///   degraded-Twilio scenario (see migration 31/32 for history).
-    /// - All other users: `twilio`
-    ///
-    /// Set `TELNYX_API_KEY` / `SINCH_API_TOKEN` (and friends) to register
-    /// those channels; individual users can be pinned via
-    /// `preferred_sms_provider` (admin endpoint).
+    /// and decide for themselves whether and what to write.
     pub async fn send_to_user(
         &self,
         user: &User,
@@ -125,52 +150,140 @@ impl ChannelRouter {
             return Ok(ChannelMessageId("dev_not_sending".to_string()));
         }
 
-        // 4. Dispatch to the chosen channel.
-        let channel_id = self.pick_channel_for(user);
-        let chan = self
-            .channels
-            .get(channel_id)
-            .ok_or_else(|| ChannelError::NotConfigured(channel_id.to_string()))?;
-        chan.send(user, &user.phone_number, &body, media).await
-    }
+        // 4. Walk the provider list, falling through to the next on error.
+        let order = self.pick_channels_for(user);
+        if order.is_empty() {
+            return Err(ChannelError::NotConfigured(
+                "no SMS providers registered".into(),
+            ));
+        }
 
-    /// Decide which channel id handles outbound for this user. Public so
-    /// callers (e.g. tests, admin diagnostics) can introspect the choice.
-    ///
-    /// `user.preferred_sms_provider` is an explicit override and wins
-    /// over country-based routing — but only if the requested channel
-    /// is actually registered. If the operator pinned a user to "sinch"
-    /// then later tore down the Sinch credentials, we silently fall
-    /// back to country-based selection rather than failing the send.
-    pub fn pick_channel_for(&self, user: &User) -> &'static str {
-        if let Some(pref) = user.preferred_sms_provider.as_deref() {
-            let pref_static: Option<&'static str> = match pref {
-                "twilio" => Some("twilio"),
-                "telnyx" => Some("telnyx"),
-                "sinch" => Some("sinch"),
-                _ => None,
+        let total = order.len();
+        let mut last_err: Option<ChannelError> = None;
+        for (idx, channel_id) in order.iter().enumerate() {
+            let chan = match self.channels.get(channel_id) {
+                Some(c) => c,
+                None => continue,
             };
-            if let Some(id) = pref_static {
-                if self.channels.contains_key(id) {
-                    return id;
+
+            let attempt_body = if idx == 0 {
+                body.clone()
+            } else {
+                format!("{}{}", FALLBACK_PREFIX, body)
+            };
+
+            match chan
+                .send(user, &user.phone_number, &attempt_body, media.clone())
+                .await
+            {
+                Ok(id) => {
+                    if idx > 0 {
+                        tracing::warn!(
+                            "SMS delivered via fallback provider '{}' for user {} (attempt {}/{})",
+                            channel_id,
+                            user.id,
+                            idx + 1,
+                            total
+                        );
+                    }
+                    return Ok(id);
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "SMS provider '{}' failed for user {} (attempt {}/{}): {}",
+                        channel_id,
+                        user.id,
+                        idx + 1,
+                        total,
+                        e
+                    );
+                    last_err = Some(e);
                 }
             }
         }
-        let country = crate::utils::country::get_country_code_from_phone(&user.phone_number);
-        if country.as_deref() == Some("US") {
-            if self.channels.contains_key("twilio") {
-                return "twilio";
+
+        Err(last_err.unwrap_or_else(|| ChannelError::SendFailed("all providers exhausted".into())))
+    }
+
+    /// Decide the ordered list of channel ids to try for this user.
+    /// Public so callers (tests, admin diagnostics) can introspect.
+    ///
+    /// Order of precedence:
+    /// 1. `user.preferred_sms_provider` (admin pin) — goes first if the
+    ///    requested channel is registered. We still append the country
+    ///    route after it so a pinned channel that fails can still hand
+    ///    off to the country's fallbacks; the pin no longer disables
+    ///    resilience.
+    /// 2. The country's `provider_routes` row, filtered to registered
+    ///    channels and de-duplicated.
+    /// 3. Default: `["twilio"]` if it's registered, else any one
+    ///    registered channel.
+    pub fn pick_channels_for(&self, user: &User) -> Vec<&'static str> {
+        let mut order: Vec<&'static str> = Vec::with_capacity(3);
+        let push = |v: &mut Vec<&'static str>,
+                    id: &'static str,
+                    channels: &HashMap<&'static str, Arc<dyn MessageChannel>>| {
+            if !v.contains(&id) && channels.contains_key(id) {
+                v.push(id);
             }
-            if self.channels.contains_key("telnyx") {
-                return "telnyx";
+        };
+
+        if let Some(pref) = user.preferred_sms_provider.as_deref() {
+            if let Some(id) = canonical_channel_id(pref) {
+                push(&mut order, id, &self.channels);
             }
         }
-        "twilio"
+
+        let country = crate::utils::country::get_country_code_from_phone(&user.phone_number)
+            .unwrap_or_default()
+            .to_uppercase();
+        if let Ok(routes) = self.routes.read() {
+            if let Some(ids) = routes.get(&country) {
+                for id in ids {
+                    if let Some(static_id) = canonical_channel_id(id) {
+                        push(&mut order, static_id, &self.channels);
+                    }
+                }
+            }
+        }
+
+        if order.is_empty() {
+            push(&mut order, "twilio", &self.channels);
+            if order.is_empty() {
+                if let Some(first) = self.channels.keys().next() {
+                    order.push(*first);
+                }
+            }
+        }
+
+        order
+    }
+
+    /// Legacy single-channel accessor. Returns the first channel from
+    /// `pick_channels_for`. Kept for callers that only want the primary
+    /// (e.g. accountability nudges via `notify`).
+    pub fn pick_channel_for(&self, user: &User) -> &'static str {
+        self.pick_channels_for(user)
+            .into_iter()
+            .next()
+            .unwrap_or("twilio")
     }
 }
 
 impl Default for ChannelRouter {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+/// Map a user-provided channel id string to the static id used in the
+/// registration table. Returns `None` for unknown ids so we don't poison
+/// the order with channels we'll never register.
+fn canonical_channel_id(s: &str) -> Option<&'static str> {
+    match s {
+        "twilio" => Some("twilio"),
+        "telnyx" => Some("telnyx"),
+        "sinch" => Some("sinch"),
+        _ => None,
     }
 }

--- a/backend/src/handlers/admin_handlers.rs
+++ b/backend/src/handlers/admin_handlers.rs
@@ -3349,3 +3349,132 @@ pub async fn telegram_bridge_schema_introspect(
         "verified_against": "mautrix-telegram v0.15.3 source (puppet.py, portal.py, user.py + migrations v01..v18)",
     })))
 }
+
+// ===== Provider routes =====
+//
+// Per-country SMS provider order driving the router's outbound fallback.
+// Operators flip the primary at runtime here without redeploying; changes
+// hit both the DB and the in-memory cache on `state.channel_router`.
+
+#[derive(Serialize)]
+pub struct ProviderRouteResponse {
+    pub country_code: String,
+    pub provider_order: Vec<String>,
+    pub updated_at: i32,
+}
+
+#[derive(Deserialize)]
+pub struct UpsertProviderRouteRequest {
+    pub country_code: String,
+    pub provider_order: Vec<String>,
+}
+
+/// Channel ids the system knows about. Mirrors the canonical list in
+/// `ChannelRouter::canonical_channel_id`. Keep in sync.
+const KNOWN_PROVIDERS: &[&str] = &["twilio", "telnyx", "sinch"];
+
+pub async fn list_provider_routes(
+    State(state): State<Arc<AppState>>,
+) -> Result<Json<Vec<ProviderRouteResponse>>, (StatusCode, Json<serde_json::Value>)> {
+    let rows = state.provider_routes_repository.list_all().map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("Database error: {}", e)})),
+        )
+    })?;
+
+    let resp = rows
+        .into_iter()
+        .map(|r| {
+            let order = serde_json::from_str::<Vec<String>>(&r.provider_order).unwrap_or_default();
+            ProviderRouteResponse {
+                country_code: r.country_code,
+                provider_order: order,
+                updated_at: r.updated_at,
+            }
+        })
+        .collect();
+    Ok(Json(resp))
+}
+
+pub async fn upsert_provider_route(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<UpsertProviderRouteRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let country = req.country_code.trim().to_uppercase();
+    if country.len() != 2 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "country_code must be a 2-letter ISO code"})),
+        ));
+    }
+    if req.provider_order.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "provider_order must contain at least one channel id"})),
+        ));
+    }
+    for id in &req.provider_order {
+        if !KNOWN_PROVIDERS.contains(&id.as_str()) {
+            return Err((
+                StatusCode::BAD_REQUEST,
+                Json(json!({
+                    "error": format!("unknown provider id '{}'; valid ids: {:?}", id, KNOWN_PROVIDERS)
+                })),
+            ));
+        }
+    }
+
+    let order_json = serde_json::to_string(&req.provider_order).map_err(|e| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(json!({"error": format!("serialize: {}", e)})),
+        )
+    })?;
+
+    state
+        .provider_routes_repository
+        .upsert(&country, &order_json)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Database error: {}", e)})),
+            )
+        })?;
+
+    state
+        .channel_router
+        .set_route(&country, req.provider_order.clone());
+
+    tracing::info!(
+        "Provider route upserted: {} -> {:?}",
+        country,
+        req.provider_order
+    );
+
+    Ok(Json(json!({
+        "country_code": country,
+        "provider_order": req.provider_order,
+    })))
+}
+
+pub async fn delete_provider_route(
+    State(state): State<Arc<AppState>>,
+    axum::extract::Path(country_code): axum::extract::Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let country = country_code.trim().to_uppercase();
+    state
+        .provider_routes_repository
+        .delete(&country)
+        .map_err(|e| {
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(json!({"error": format!("Database error: {}", e)})),
+            )
+        })?;
+
+    state.channel_router.clear_route(&country);
+
+    tracing::info!("Provider route deleted: {}", country);
+    Ok(Json(json!({"deleted": country})))
+}

--- a/backend/src/handlers/commitment_handlers.rs
+++ b/backend/src/handlers/commitment_handlers.rs
@@ -1,0 +1,143 @@
+//! Dashboard endpoints for managing the commitment-detection signal state:
+//! the per-user mute / always-track sender rules, and the recent SMS-prompt
+//! history (so users can see what was asked and what they replied).
+
+use std::sync::Arc;
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use serde::Serialize;
+use serde_json::json;
+
+use crate::handlers::auth_middleware::AuthUser;
+use crate::repositories::commitment_repository::{RULE_ALWAYS_TRACK, RULE_MUTE};
+use crate::AppState;
+
+#[derive(Serialize)]
+pub struct SenderRuleView {
+    pub id: i32,
+    pub platform: String,
+    pub sender_key: String,
+    pub rule_type: String,
+    pub source: String,
+    pub created_at: i32,
+}
+
+#[derive(Serialize)]
+pub struct SenderRulesResponse {
+    pub muted: Vec<SenderRuleView>,
+    pub always_track: Vec<SenderRuleView>,
+}
+
+/// GET /api/commitment/sender-rules
+/// Returns the user's active mute and always-track sender rules grouped by
+/// type so the dashboard can render them in two sections.
+pub async fn list_sender_rules(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+) -> Result<Json<SenderRulesResponse>, StatusCode> {
+    let user_id = auth_user.user_id;
+
+    let muted = state
+        .commitment_repository
+        .list_active_rules(user_id, RULE_MUTE)
+        .map_err(|e| {
+            tracing::error!("list_active_rules(mute) user={}: {}", user_id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    let always_track = state
+        .commitment_repository
+        .list_active_rules(user_id, RULE_ALWAYS_TRACK)
+        .map_err(|e| {
+            tracing::error!("list_active_rules(always) user={}: {}", user_id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+
+    let to_view = |r: crate::models::commitment_models::CommitmentSenderRule| SenderRuleView {
+        id: r.id,
+        platform: r.platform,
+        sender_key: r.sender_key,
+        rule_type: r.rule_type,
+        source: r.source,
+        created_at: r.created_at,
+    };
+
+    Ok(Json(SenderRulesResponse {
+        muted: muted.into_iter().map(to_view).collect(),
+        always_track: always_track.into_iter().map(to_view).collect(),
+    }))
+}
+
+/// DELETE /api/commitment/sender-rules/:id
+/// Deactivates a rule. Scoped to the auth_user so users can't delete each
+/// other's rules; an unknown id returns 200 with `removed=0` rather than
+/// 404 because the rule may already be inactive.
+pub async fn deactivate_sender_rule(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path(rule_id): Path<i32>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let user_id = auth_user.user_id;
+    let removed = state
+        .commitment_repository
+        .deactivate_rule(user_id, rule_id)
+        .map_err(|e| {
+            tracing::error!(
+                "deactivate_rule user={} rule_id={}: {}",
+                user_id,
+                rule_id,
+                e
+            );
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(json!({ "removed": removed })))
+}
+
+#[derive(Serialize)]
+pub struct PromptView {
+    pub id: i32,
+    pub platform: String,
+    pub sender_display_name: String,
+    pub commitment_description: String,
+    pub sent_at: i32,
+    pub user_label: Option<String>,
+    pub labeled_at: Option<i32>,
+    pub resulting_event_id: Option<i32>,
+    pub resolved_at: Option<i32>,
+}
+
+/// GET /api/commitment/recent-prompts
+/// Returns the most recent commitment prompts (capped at 50) for the
+/// transparency panel. Lets a user see what we asked them about, what they
+/// answered, and which event was created.
+pub async fn list_recent_prompts(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+) -> Result<Json<Vec<PromptView>>, StatusCode> {
+    let user_id = auth_user.user_id;
+    let rows = state
+        .commitment_repository
+        .list_recent_prompts(user_id, 50)
+        .map_err(|e| {
+            tracing::error!("list_recent_prompts user={}: {}", user_id, e);
+            StatusCode::INTERNAL_SERVER_ERROR
+        })?;
+    Ok(Json(
+        rows.into_iter()
+            .map(|p| PromptView {
+                id: p.id,
+                platform: p.platform,
+                sender_display_name: p.sender_display_name,
+                commitment_description: p.commitment_description,
+                sent_at: p.sent_at,
+                user_label: p.user_label,
+                labeled_at: p.labeled_at,
+                resulting_event_id: p.resulting_event_id,
+                resolved_at: p.resolved_at,
+            })
+            .collect(),
+    ))
+}

--- a/backend/src/handlers/imap_handlers.rs
+++ b/backend/src/handlers/imap_handlers.rs
@@ -377,6 +377,7 @@ pub async fn insert_email_into_ontology(
     user_id: i32,
     preview: &ImapEmailPreview,
     persons: &[crate::models::ontology_models::PersonWithChannels],
+    imap_connection_id: Option<i32>,
 ) -> Result<i64, String> {
     let email_uid = preview.id.clone();
     let room_id = format!("email_{}", email_uid);
@@ -424,6 +425,81 @@ pub async fn insert_email_into_ontology(
         .from_email
         .as_deref()
         .and_then(normalize_email_sender_key);
+
+    // Pending reply watch: SMS the user the first reply we see from a
+    // recipient they explicitly asked to be notified about, then clear
+    // the watch. Only runs when we know which IMAP account this email
+    // came in on (the IDLE path); the legacy cron path passes None and
+    // is intentionally a no-op for watches.
+    if let (Some(conn_id), Some(key)) = (imap_connection_id, sender_key.as_deref()) {
+        match state
+            .pending_reply_watches_repository
+            .find_active_email(user_id, conn_id, key)
+        {
+            Ok(Some(watch)) => {
+                let subject_line = preview.subject.as_deref().unwrap_or("");
+                let body = if subject_line.is_empty() {
+                    format!("Reply from {} (email)", watch.contact_display_name)
+                } else {
+                    format!(
+                        "Reply from {} (email): {}",
+                        watch.contact_display_name, subject_line
+                    )
+                };
+                // Only clear the watch once we've successfully notified the
+                // user. If the SMS fails (e.g. transient Twilio outage) or we
+                // can't load the user record, leave the watch armed so the
+                // next inbound email retries.
+                let mut notified = false;
+                match state.user_core.find_by_id(user_id) {
+                    Ok(Some(user)) => {
+                        match state.channel_router.send_to_user(&user, &body, None).await {
+                            Ok(_) => notified = true,
+                            Err(e) => tracing::warn!(
+                                "REPLY_WATCH SMS failed user={} watch={}, leaving armed for retry: {}",
+                                user_id,
+                                watch.id,
+                                e
+                            ),
+                        }
+                    }
+                    Ok(None) => tracing::warn!(
+                        "REPLY_WATCH user {} not found while firing email watch id={}",
+                        user_id,
+                        watch.id
+                    ),
+                    Err(e) => {
+                        tracing::warn!("REPLY_WATCH user lookup failed user={}: {}", user_id, e)
+                    }
+                }
+                if notified {
+                    if let Err(e) = state.pending_reply_watches_repository.delete(watch.id) {
+                        tracing::warn!(
+                            "REPLY_WATCH failed to delete fired email watch id={}: {}",
+                            watch.id,
+                            e
+                        );
+                    } else {
+                        tracing::info!(
+                            "REPLY_WATCH fired+cleared email watch id={} user={} account={} sender={}",
+                            watch.id,
+                            user_id,
+                            conn_id,
+                            key
+                        );
+                    }
+                }
+            }
+            Ok(None) => {}
+            Err(e) => tracing::warn!(
+                "REPLY_WATCH email lookup failed user={} account={} sender={}: {}",
+                user_id,
+                conn_id,
+                key,
+                e
+            ),
+        }
+    }
     let content = format!(
         "{}\n{}",
         preview.subject.as_deref().unwrap_or(""),
@@ -488,7 +564,7 @@ pub async fn insert_email_into_ontology(
     Ok(created.id)
 }
 
-fn normalize_email_sender_key(email: &str) -> Option<String> {
+pub fn normalize_email_sender_key(email: &str) -> Option<String> {
     let normalized = email.trim().to_lowercase();
     if normalized.is_empty() {
         None
@@ -586,7 +662,15 @@ pub async fn process_new_emails(
         }
 
         let uid_str = preview.id.clone();
-        match insert_email_into_ontology(state, user_id, &preview, &persons).await {
+        match insert_email_into_ontology(
+            state,
+            user_id,
+            &preview,
+            &persons,
+            Some(imap_connection_id),
+        )
+        .await
+        {
             Ok(_) => {
                 new_count += 1;
                 // Only mark as processed AFTER successful ontology insertion.

--- a/backend/src/handlers/webhook_sms_handlers.rs
+++ b/backend/src/handlers/webhook_sms_handlers.rs
@@ -1,0 +1,391 @@
+//! Webhook-triggered SMS to the authenticated user's own phone number.
+//!
+//! Three management endpoints (JWT-authed) let the user mint, list, and
+//! revoke tokens. One public endpoint (`POST /api/webhook/sms`) accepts
+//! `Authorization: Bearer lf_<hex>` and sends a single SMS to the
+//! owner's `phone_number` via the existing channel router.
+//!
+//! Security shape:
+//! - Token format is `lf_` + 32 hex chars (128 bits of entropy from
+//!   the thread CSPRNG). DB stores only the SHA-256 hash; raw is shown
+//!   once.
+//! - The send destination is hardcoded to the owning user's
+//!   `phone_number` — a leaked token cannot become an open SMS relay.
+//! - Cap enforcement is a single atomic UPDATE (see
+//!   `WebhookTokensRepository::claim_send_slot`), so concurrent requests
+//!   cannot both pass the boundary.
+//! - All credit / tier / phone-service-active gating reuses
+//!   `check_user_credits`, so this path has the same abuse posture as
+//!   every other outbound SMS.
+
+use crate::handlers::auth_middleware::AuthUser;
+use crate::models::user_models::NewWebhookToken;
+use crate::repositories::webhook_tokens_repository::ClaimResult;
+use crate::{AppState, UserCoreOps};
+use axum::{
+    extract::{Path, State},
+    http::{HeaderMap, StatusCode},
+    Json,
+};
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+use sha2::{Digest, Sha256};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Twilio SMS bodies max out at 1600 chars (10 concatenated segments).
+/// Reject anything longer at the API boundary so we don't trigger a
+/// provider-side error after spending credit-check work.
+const MAX_BODY_LEN: usize = 1600;
+const DEFAULT_DAILY_CAP: i32 = 50;
+const TOKEN_PREFIX: &str = "lf_";
+const TOKEN_BYTES: usize = 16; // 128 bits, rendered as 32 hex chars
+
+// ============================================================================
+// Management endpoints (JWT-authed, mounted under protected_routes)
+// ============================================================================
+
+#[derive(Deserialize)]
+pub struct CreateTokenRequest {
+    pub label: String,
+    /// Optional daily cap override. Clamped to [1, 500].
+    pub daily_cap: Option<i32>,
+}
+
+#[derive(Serialize)]
+pub struct CreateTokenResponse {
+    pub id: i32,
+    pub label: String,
+    pub token_prefix: String,
+    pub daily_cap: i32,
+    /// Plaintext token. Shown to the user exactly once; the DB stores
+    /// only the SHA-256 hash. Subsequent GETs never expose this field.
+    pub token: String,
+    pub created_at: i32,
+}
+
+#[derive(Serialize)]
+pub struct WebhookTokenSummary {
+    pub id: i32,
+    pub label: String,
+    pub token_prefix: String,
+    pub daily_cap: i32,
+    pub daily_sent: i32,
+    pub daily_reset_at: i32,
+    pub last_used_at: Option<i32>,
+    pub created_at: i32,
+}
+
+pub async fn create_token(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Json(req): Json<CreateTokenRequest>,
+) -> Result<Json<CreateTokenResponse>, (StatusCode, Json<serde_json::Value>)> {
+    let user_id = auth_user.user_id;
+
+    // Gate on tier 2 — same bar as every other outbound path. We check
+    // here rather than relying on `check_user_credits` later so the user
+    // can't create a token they can never use.
+    let user = state.user_core.find_by_id(user_id).map_err(db_err)?;
+    let user = user.ok_or_else(|| not_found("User not found"))?;
+    if user.sub_tier.as_deref() != Some("tier 2") {
+        return Err((
+            StatusCode::FORBIDDEN,
+            Json(json!({"error": "Active subscription required"})),
+        ));
+    }
+
+    let label = req.label.trim();
+    if label.is_empty() || label.len() > 64 {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "label must be 1..=64 chars"})),
+        ));
+    }
+
+    let daily_cap = req.daily_cap.unwrap_or(DEFAULT_DAILY_CAP).clamp(1, 500);
+
+    // Mint token: 16 random bytes (128 bits) → hex → prefix.
+    let raw_token = generate_token();
+    let token_hash = hash_token(&raw_token);
+    let token_prefix = raw_token.chars().take(8).collect::<String>(); // e.g. "lf_abc12"
+
+    let now = now_unix();
+    let row = NewWebhookToken {
+        user_id,
+        token_hash,
+        token_prefix: token_prefix.clone(),
+        label: label.to_string(),
+        daily_cap,
+        daily_sent: 0,
+        daily_reset_at: next_utc_midnight(now),
+        created_at: now,
+    };
+
+    let inserted = state
+        .webhook_tokens_repository
+        .create(&row)
+        .map_err(db_err)?;
+
+    Ok(Json(CreateTokenResponse {
+        id: inserted.id,
+        label: inserted.label,
+        token_prefix: inserted.token_prefix,
+        daily_cap: inserted.daily_cap,
+        token: raw_token,
+        created_at: inserted.created_at,
+    }))
+}
+
+pub async fn list_tokens(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+) -> Result<Json<Vec<WebhookTokenSummary>>, (StatusCode, Json<serde_json::Value>)> {
+    let rows = state
+        .webhook_tokens_repository
+        .list_for_user(auth_user.user_id)
+        .map_err(db_err)?;
+    let out = rows
+        .into_iter()
+        .map(|r| WebhookTokenSummary {
+            id: r.id,
+            label: r.label,
+            token_prefix: r.token_prefix,
+            daily_cap: r.daily_cap,
+            daily_sent: r.daily_sent,
+            daily_reset_at: r.daily_reset_at,
+            last_used_at: r.last_used_at,
+            created_at: r.created_at,
+        })
+        .collect();
+    Ok(Json(out))
+}
+
+pub async fn revoke_token(
+    State(state): State<Arc<AppState>>,
+    auth_user: AuthUser,
+    Path(token_id): Path<i32>,
+) -> Result<StatusCode, (StatusCode, Json<serde_json::Value>)> {
+    let revoked = state
+        .webhook_tokens_repository
+        .revoke(auth_user.user_id, token_id)
+        .map_err(db_err)?;
+    if !revoked {
+        return Err((
+            StatusCode::NOT_FOUND,
+            Json(json!({"error": "token not found"})),
+        ));
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ============================================================================
+// Public webhook endpoint (Bearer-authed, mounted as a standalone route)
+// ============================================================================
+
+#[derive(Deserialize)]
+pub struct WebhookSmsRequest {
+    pub message: String,
+}
+
+#[derive(Serialize)]
+pub struct WebhookSmsResponse {
+    pub status: &'static str,
+    pub sid: String,
+}
+
+/// `POST /api/webhook/sms`
+///
+/// Bearer-authenticated; sends one SMS to the owning user's phone.
+/// Failure modes:
+/// - 401: missing/malformed/unknown/revoked bearer
+/// - 400: empty or oversized message body
+/// - 402: insufficient credits / inactive subscription / phone-service-off
+///        (collapsed into 402 so the client sees a single "fix billing" code)
+/// - 429: daily cap exhausted
+/// - 502: provider failure
+pub async fn webhook_sms(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    Json(req): Json<WebhookSmsRequest>,
+) -> Result<Json<WebhookSmsResponse>, (StatusCode, Json<serde_json::Value>)> {
+    // 1. Extract bearer.
+    let raw = extract_bearer(&headers).ok_or_else(unauthorized)?;
+    if !raw.starts_with(TOKEN_PREFIX) {
+        return Err(unauthorized());
+    }
+
+    // 2. Hash and look up. We do NOT distinguish missing-row from
+    //    revoked-row in the response to keep the 401 path uniform.
+    let token_hash = hash_token(raw);
+    let token_row = state
+        .webhook_tokens_repository
+        .find_by_hash(&token_hash)
+        .map_err(db_err)?
+        .ok_or_else(unauthorized)?;
+    if token_row.revoked_at.is_some() {
+        return Err(unauthorized());
+    }
+
+    // 3. Validate body before doing any send-side work.
+    let body = req.message.trim();
+    if body.is_empty() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "message must not be empty"})),
+        ));
+    }
+    if body.len() > MAX_BODY_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!("message exceeds {} chars", MAX_BODY_LEN),
+            })),
+        ));
+    }
+    let body = body.to_string();
+
+    // 4. Load user. The token row references a real user via FK, but the
+    //    user could be soft-deleted between token mint and now.
+    let user = state
+        .user_core
+        .find_by_id(token_row.user_id)
+        .map_err(db_err)?
+        .ok_or_else(unauthorized)?;
+
+    // 5. Credit / tier / phone-service-active gate. Same call all other
+    //    outbound paths use — keeps abuse posture identical and reuses
+    //    the existing "out of credits" SMS warning behavior.
+    if let Err(msg) = crate::utils::usage::check_user_credits(&state, &user, "noti_msg", None).await
+    {
+        return Err((StatusCode::PAYMENT_REQUIRED, Json(json!({"error": msg}))));
+    }
+
+    // 6. Atomic daily-cap claim. If this succeeds, we've reserved the
+    //    slot and must proceed to send (or absorb the cost on failure
+    //    via incrementing daily_sent — see below).
+    let claim = state
+        .webhook_tokens_repository
+        .claim_send_slot(&token_hash)
+        .map_err(db_err)?;
+    let token = match claim {
+        ClaimResult::Ok { token } => token,
+        ClaimResult::Revoked => return Err(unauthorized()),
+        ClaimResult::OverCap {
+            daily_cap,
+            daily_sent,
+        } => {
+            return Err((
+                StatusCode::TOO_MANY_REQUESTS,
+                Json(json!({
+                    "error": "daily cap reached",
+                    "daily_cap": daily_cap,
+                    "daily_sent": daily_sent,
+                })),
+            ));
+        }
+    };
+
+    // 7. Send. The slot is already consumed; we count attempts, not
+    //    successes, so a provider failure still burns one of the daily
+    //    quota. That keeps the cap from being a free retry loop on
+    //    provider outages.
+    match state.channel_router.send_to_user(&user, &body, None).await {
+        Ok(sid) => {
+            let sid = sid.into_inner();
+            // Best-effort usage log; SMS cost itself is deducted from
+            // credits later via the provider status callback.
+            if let Err(e) = state.user_repository.log_usage(
+                crate::repositories::user_repository::LogUsageParams {
+                    user_id: user.id,
+                    sid: Some(sid.clone()),
+                    activity_type: "webhook_sms".to_string(),
+                    credits: None,
+                    time_consumed: None,
+                    success: Some(true),
+                    reason: Some(format!("token_id={}", token.id)),
+                    status: Some("sent".to_string()),
+                    recharge_threshold_timestamp: None,
+                    zero_credits_timestamp: None,
+                },
+            ) {
+                tracing::error!("Failed to log webhook_sms usage: {}", e);
+            }
+            Ok(Json(WebhookSmsResponse {
+                status: "sent",
+                sid,
+            }))
+        }
+        Err(e) => {
+            tracing::error!(
+                "webhook_sms send failed for user {} token {}: {}",
+                user.id,
+                token.id,
+                e
+            );
+            Err((
+                StatusCode::BAD_GATEWAY,
+                Json(json!({"error": "send failed"})),
+            ))
+        }
+    }
+}
+
+// ============================================================================
+// Internal helpers
+// ============================================================================
+
+fn extract_bearer(headers: &HeaderMap) -> Option<&str> {
+    let raw = headers
+        .get(axum::http::header::AUTHORIZATION)?
+        .to_str()
+        .ok()?;
+    raw.strip_prefix("Bearer ")
+        .or_else(|| raw.strip_prefix("bearer "))
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+}
+
+fn generate_token() -> String {
+    let mut bytes = [0u8; TOKEN_BYTES];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    format!("{}{}", TOKEN_PREFIX, hex::encode(bytes))
+}
+
+fn hash_token(raw: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(raw.as_bytes());
+    hex::encode(hasher.finalize())
+}
+
+fn now_unix() -> i32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i32
+}
+
+fn next_utc_midnight(now: i32) -> i32 {
+    let day = 86_400;
+    ((now / day) + 1) * day
+}
+
+fn unauthorized() -> (StatusCode, Json<serde_json::Value>) {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(json!({"error": "invalid or revoked token"})),
+    )
+}
+
+fn db_err(e: diesel::result::Error) -> (StatusCode, Json<serde_json::Value>) {
+    tracing::error!("webhook_sms db error: {}", e);
+    (
+        StatusCode::INTERNAL_SERVER_ERROR,
+        Json(json!({"error": "internal error"})),
+    )
+}
+
+fn not_found(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
+    (StatusCode::NOT_FOUND, Json(json!({"error": msg})))
+}

--- a/backend/src/handlers/webhook_sms_handlers.rs
+++ b/backend/src/handlers/webhook_sms_handlers.rs
@@ -20,7 +20,7 @@
 
 use crate::handlers::auth_middleware::AuthUser;
 use crate::models::user_models::NewWebhookToken;
-use crate::repositories::webhook_tokens_repository::ClaimResult;
+use crate::repositories::webhook_tokens_repository::{ClaimResult, IdempotencyResult};
 use crate::{AppState, UserCoreOps};
 use axum::{
     extract::{Path, State},
@@ -35,12 +35,24 @@ use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Twilio SMS bodies max out at 1600 chars (10 concatenated segments).
-/// Reject anything longer at the API boundary so we don't trigger a
-/// provider-side error after spending credit-check work.
-const MAX_BODY_LEN: usize = 1600;
+/// We reserve room for two prefixes the body picks up downstream:
+///
+/// - The `[label] ` provenance prefix added here (≤67 chars: label cap
+///   is 64 + brackets + space).
+/// - The `[Lightfriend backup] ` prefix prepended by the channel router
+///   on fallback (21 chars).
+///
+/// 1600 - 67 - 21 = 1512; cap at 1500 to leave a tiny slack and keep the
+/// boundary number easy to remember.
+const MAX_BODY_LEN: usize = 1500;
 const DEFAULT_DAILY_CAP: i32 = 50;
 const TOKEN_PREFIX: &str = "lf_";
 const TOKEN_BYTES: usize = 16; // 128 bits, rendered as 32 hex chars
+/// Header name used by the public webhook endpoint to dedupe retried
+/// requests. Stripe-style: client sends `Idempotency-Key: <opaque>`
+/// and we replay the cached response for any second hit within 24h.
+const IDEMPOTENCY_HEADER: &str = "Idempotency-Key";
+const MAX_IDEMPOTENCY_KEY_LEN: usize = 64;
 
 // ============================================================================
 // Management endpoints (JWT-authed, mounted under protected_routes)
@@ -198,11 +210,15 @@ pub struct WebhookSmsResponse {
 /// `POST /api/webhook/sms`
 ///
 /// Bearer-authenticated; sends one SMS to the owning user's phone.
+/// Supports `Idempotency-Key` header so retried requests don't duplicate
+/// the SMS.
+///
 /// Failure modes:
 /// - 401: missing/malformed/unknown/revoked bearer
-/// - 400: empty or oversized message body
+/// - 400: empty/oversized body, or malformed Idempotency-Key
 /// - 402: insufficient credits / inactive subscription / phone-service-off
-///        (collapsed into 402 so the client sees a single "fix billing" code)
+///   (collapsed into 402 so the client sees a single "fix billing" code)
+/// - 409: a prior request with this Idempotency-Key is still in flight
 /// - 429: daily cap exhausted
 /// - 502: provider failure
 pub async fn webhook_sms(
@@ -246,36 +262,77 @@ pub async fn webhook_sms(
     }
     let body = body.to_string();
 
-    // 4. Load user. The token row references a real user via FK, but the
+    // 4. Idempotency-Key handling (optional). Resolved here, BEFORE the
+    //    credit check and cap claim, so a replay short-circuits without
+    //    burning the daily quota or the credit-warning side effects in
+    //    `check_user_credits`.
+    let idempotency_key = extract_idempotency_key(&headers)?.unwrap_or_default();
+    let idempotency_row_id: Option<i32> = if !idempotency_key.is_empty() {
+        let res = state
+            .webhook_tokens_repository
+            .reserve_idempotency_key(token_row.id, &idempotency_key)
+            .map_err(db_err)?;
+        match res {
+            IdempotencyResult::Replayed { sid } => {
+                return Ok(Json(WebhookSmsResponse {
+                    status: "sent",
+                    sid,
+                }));
+            }
+            IdempotencyResult::InFlight => {
+                return Err((
+                    StatusCode::CONFLICT,
+                    Json(json!({"error": "idempotency key in flight"})),
+                ));
+            }
+            IdempotencyResult::Fresh { id } => Some(id),
+        }
+    } else {
+        None
+    };
+
+    // 5. Load user. The token row references a real user via FK, but the
     //    user could be soft-deleted between token mint and now.
-    let user = state
+    let user = match state
         .user_core
         .find_by_id(token_row.user_id)
         .map_err(db_err)?
-        .ok_or_else(unauthorized)?;
+    {
+        Some(u) => u,
+        None => {
+            release_idempotency(&state, idempotency_row_id);
+            return Err(unauthorized());
+        }
+    };
 
-    // 5. Credit / tier / phone-service-active gate. Same call all other
+    // 6. Credit / tier / phone-service-active gate. Same call all other
     //    outbound paths use — keeps abuse posture identical and reuses
     //    the existing "out of credits" SMS warning behavior.
     if let Err(msg) = crate::utils::usage::check_user_credits(&state, &user, "noti_msg", None).await
     {
+        release_idempotency(&state, idempotency_row_id);
         return Err((StatusCode::PAYMENT_REQUIRED, Json(json!({"error": msg}))));
     }
 
-    // 6. Atomic daily-cap claim. If this succeeds, we've reserved the
-    //    slot and must proceed to send (or absorb the cost on failure
-    //    via incrementing daily_sent — see below).
-    let claim = state
-        .webhook_tokens_repository
-        .claim_send_slot(&token_hash)
-        .map_err(db_err)?;
+    // 7. Atomic daily-cap claim.
+    let claim = match state.webhook_tokens_repository.claim_send_slot(&token_hash) {
+        Ok(c) => c,
+        Err(e) => {
+            release_idempotency(&state, idempotency_row_id);
+            return Err(db_err(e));
+        }
+    };
     let token = match claim {
         ClaimResult::Ok { token } => token,
-        ClaimResult::Revoked => return Err(unauthorized()),
+        ClaimResult::Revoked => {
+            release_idempotency(&state, idempotency_row_id);
+            return Err(unauthorized());
+        }
         ClaimResult::OverCap {
             daily_cap,
             daily_sent,
         } => {
+            release_idempotency(&state, idempotency_row_id);
             return Err((
                 StatusCode::TOO_MANY_REQUESTS,
                 Json(json!({
@@ -287,15 +344,33 @@ pub async fn webhook_sms(
         }
     };
 
-    // 7. Send. The slot is already consumed; we count attempts, not
+    // 8. Prepend provenance so a leaked token cannot impersonate the AI
+    //    assistant. The label is user-set and bounded to 64 chars at
+    //    creation; we additionally sanitize for control characters so a
+    //    malicious label can't fake a multi-message handoff.
+    let safe_label = sanitize_label(&token.label);
+    let outbound = format!("[{}] {}", safe_label, body);
+
+    // 9. Send. The slot is already consumed; we count attempts, not
     //    successes, so a provider failure still burns one of the daily
     //    quota. That keeps the cap from being a free retry loop on
-    //    provider outages.
-    match state.channel_router.send_to_user(&user, &body, None).await {
+    //    provider outages. Idempotency rows ARE released on failure so
+    //    the client can retry with the same key.
+    match state
+        .channel_router
+        .send_to_user(&user, &outbound, None)
+        .await
+    {
         Ok(sid) => {
             let sid = sid.into_inner();
-            // Best-effort usage log; SMS cost itself is deducted from
-            // credits later via the provider status callback.
+            if let Some(id) = idempotency_row_id {
+                if let Err(e) = state
+                    .webhook_tokens_repository
+                    .complete_idempotency(id, &sid)
+                {
+                    tracing::error!("Failed to complete idempotency row {}: {}", id, e);
+                }
+            }
             if let Err(e) = state.user_repository.log_usage(
                 crate::repositories::user_repository::LogUsageParams {
                     user_id: user.id,
@@ -324,6 +399,7 @@ pub async fn webhook_sms(
                 token.id,
                 e
             );
+            release_idempotency(&state, idempotency_row_id);
             Err((
                 StatusCode::BAD_GATEWAY,
                 Json(json!({"error": "send failed"})),
@@ -345,6 +421,67 @@ fn extract_bearer(headers: &HeaderMap) -> Option<&str> {
         .or_else(|| raw.strip_prefix("bearer "))
         .map(str::trim)
         .filter(|s| !s.is_empty())
+}
+
+/// Pull and validate an optional `Idempotency-Key` header.
+///
+/// - Missing header → Ok(None) (idempotency disabled for this request)
+/// - Present but malformed → Err 400
+///
+/// Accepts ASCII printable chars only, length 1..=64. That covers UUIDs,
+/// ULIDs, and human-typed keys without giving the client room to smuggle
+/// nulls or control characters into a downstream log line.
+fn extract_idempotency_key(
+    headers: &HeaderMap,
+) -> Result<Option<String>, (StatusCode, Json<serde_json::Value>)> {
+    let Some(raw) = headers.get(IDEMPOTENCY_HEADER) else {
+        return Ok(None);
+    };
+    let s = raw.to_str().map_err(|_| {
+        (
+            StatusCode::BAD_REQUEST,
+            Json(json!({"error": "Idempotency-Key contains non-ASCII bytes"})),
+        )
+    })?;
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        // Header explicitly set to empty/whitespace — treat as absent.
+        return Ok(None);
+    }
+    if trimmed.len() > MAX_IDEMPOTENCY_KEY_LEN {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": format!(
+                    "Idempotency-Key exceeds {} chars",
+                    MAX_IDEMPOTENCY_KEY_LEN
+                ),
+            })),
+        ));
+    }
+    if !trimmed
+        .chars()
+        .all(|c| c.is_ascii_graphic() || c == ' ' || c == '-' || c == '_')
+    {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(json!({
+                "error": "Idempotency-Key contains invalid characters",
+            })),
+        ));
+    }
+    Ok(Some(trimmed.to_string()))
+}
+
+/// Best-effort cleanup of an in-flight idempotency row when the request
+/// fails before completing. Errors are logged but not propagated — the
+/// row will naturally expire after 24h and treat the next retry as fresh.
+fn release_idempotency(state: &Arc<AppState>, row_id: Option<i32>) {
+    if let Some(id) = row_id {
+        if let Err(e) = state.webhook_tokens_repository.clear_idempotency(id) {
+            tracing::error!("Failed to clear in-flight idempotency row {}: {}", id, e);
+        }
+    }
 }
 
 fn generate_token() -> String {
@@ -388,4 +525,20 @@ fn db_err(e: diesel::result::Error) -> (StatusCode, Json<serde_json::Value>) {
 
 fn not_found(msg: &str) -> (StatusCode, Json<serde_json::Value>) {
     (StatusCode::NOT_FOUND, Json(json!({"error": msg})))
+}
+
+/// Strip control characters from the label so it can't break out of the
+/// `[label]` prefix on display. Already length-bounded at creation; we
+/// only need to defuse newlines and other formatting tricks.
+fn sanitize_label(label: &str) -> String {
+    let cleaned: String = label
+        .chars()
+        .filter(|c| !c.is_control() && *c != '[' && *c != ']')
+        .collect();
+    let cleaned = cleaned.trim();
+    if cleaned.is_empty() {
+        "webhook".to_string()
+    } else {
+        cleaned.to_string()
+    }
 }

--- a/backend/src/jobs/scheduler.rs
+++ b/backend/src/jobs/scheduler.rs
@@ -606,6 +606,7 @@ pub async fn start_scheduler(state: Arc<AppState>) {
                                             user.id,
                                             email,
                                             &persons,
+                                            None,
                                         )
                                         .await
                                         {

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -122,6 +122,7 @@ pub mod repositories {
     pub mod mock_signup_repository;
     pub mod mock_twilio_status_repository;
     pub mod ontology_repository;
+    pub mod provider_routes_repository;
     pub mod signup_repository;
     pub mod signup_repository_impl;
     pub mod telegram_bridge_repository;
@@ -175,6 +176,7 @@ pub use repositories::bandwidth_repository::BandwidthRepository;
 pub use repositories::llm_usage_repository::LlmUsageRepository;
 pub use repositories::metrics_repository::MetricsRepository;
 pub use repositories::ontology_repository::OntologyRepository;
+pub use repositories::provider_routes_repository::ProviderRoutesRepository;
 pub use repositories::telegram_bridge_repository::{TelegramBridgeRepository, TelegramContact};
 pub use repositories::totp_repository::TotpRepository;
 pub use repositories::user_core::{UserCore, UserCoreOps};
@@ -280,6 +282,7 @@ pub struct AppState {
     pub webauthn_repository: Arc<WebauthnRepository>,
     pub admin_alert_repository: Arc<AdminAlertRepository>,
     pub metrics_repository: Arc<MetricsRepository>,
+    pub provider_routes_repository: Arc<ProviderRoutesRepository>,
     pub pending_totp_logins: DashMap<String, (i32, i64)>, // (totp_token, (user_id, expiry_timestamp))
     pub pending_password_resets: DashMap<String, (i32, i64)>, // (reset_token, (user_id, expiry_timestamp))
     pub session_to_token: DashMap<String, String>, // stripe_session_id -> magic_token (temporary, for redirect flow)

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -8,6 +8,7 @@ pub mod handlers {
     pub mod auth_middleware;
     pub mod billing_handlers;
     pub mod bridge_auth_common;
+    pub mod commitment_handlers;
     pub mod dashboard_handlers;
     pub mod health_handlers;
     pub mod imap_auth;
@@ -51,6 +52,8 @@ pub mod utils {
     pub mod bridge_responses;
     pub mod country;
     pub mod email;
+    pub mod embedding_service;
+    pub mod embedding_similarity;
     pub mod encryption;
     pub mod id_verifier;
     pub mod imap_idle;
@@ -66,6 +69,7 @@ pub mod utils {
     pub mod webauthn_config;
 }
 pub mod proactive {
+    pub mod commitment_replies;
     pub mod rules;
     pub mod signal_extraction;
     pub mod system_behaviors;
@@ -109,6 +113,7 @@ pub mod tools {
     pub mod youtube;
 }
 pub mod models {
+    pub mod commitment_models;
     pub mod mcp_models;
     pub mod ontology_models;
     pub mod user_models;
@@ -116,6 +121,7 @@ pub mod models {
 pub mod repositories {
     pub mod admin_alert_repository;
     pub mod bandwidth_repository;
+    pub mod commitment_repository;
     pub mod llm_usage_repository;
     pub mod mcp_repository;
     pub mod metrics_repository;
@@ -173,6 +179,7 @@ pub use api::matrix_client::{
 pub use api::twilio_client::RealTwilioClient;
 pub use repositories::admin_alert_repository::AdminAlertRepository;
 pub use repositories::bandwidth_repository::BandwidthRepository;
+pub use repositories::commitment_repository::CommitmentRepository;
 pub use repositories::llm_usage_repository::LlmUsageRepository;
 pub use repositories::metrics_repository::MetricsRepository;
 pub use repositories::ontology_repository::OntologyRepository;
@@ -293,6 +300,7 @@ pub struct AppState {
     pub llm_usage_repository: Arc<LlmUsageRepository>,
     pub bandwidth_repository: Arc<BandwidthRepository>,
     pub ontology_repository: Arc<OntologyRepository>,
+    pub commitment_repository: Arc<CommitmentRepository>,
     /// Optional: read-only access to mautrix-whatsapp's PostgreSQL database.
     /// None when WHATSAPP_BRIDGE_DATABASE_URL is unset (e.g. dev environments).
     pub whatsapp_bridge_repository: Option<Arc<WhatsAppBridgeRepository>>,

--- a/backend/src/lib.rs
+++ b/backend/src/lib.rs
@@ -34,6 +34,7 @@ pub mod handlers {
     pub mod trust_chain_handlers;
     pub mod twilio_handlers;
     pub mod webauthn_handlers;
+    pub mod webhook_sms_handlers;
     pub mod whatsapp_auth;
     pub mod whatsapp_handlers;
     pub mod youtube;
@@ -128,6 +129,7 @@ pub mod repositories {
     pub mod mock_signup_repository;
     pub mod mock_twilio_status_repository;
     pub mod ontology_repository;
+    pub mod pending_reply_watches_repository;
     pub mod provider_routes_repository;
     pub mod signup_repository;
     pub mod signup_repository_impl;
@@ -139,6 +141,7 @@ pub mod repositories {
     pub mod user_repository;
     pub mod user_subscriptions;
     pub mod webauthn_repository;
+    pub mod webhook_tokens_repository;
     pub mod whatsapp_bridge_repository;
 }
 pub mod services {
@@ -183,12 +186,14 @@ pub use repositories::commitment_repository::CommitmentRepository;
 pub use repositories::llm_usage_repository::LlmUsageRepository;
 pub use repositories::metrics_repository::MetricsRepository;
 pub use repositories::ontology_repository::OntologyRepository;
+pub use repositories::pending_reply_watches_repository::PendingReplyWatchesRepository;
 pub use repositories::provider_routes_repository::ProviderRoutesRepository;
 pub use repositories::telegram_bridge_repository::{TelegramBridgeRepository, TelegramContact};
 pub use repositories::totp_repository::TotpRepository;
 pub use repositories::user_core::{UserCore, UserCoreOps};
 pub use repositories::user_repository::UserRepository;
 pub use repositories::webauthn_repository::WebauthnRepository;
+pub use repositories::webhook_tokens_repository::WebhookTokensRepository;
 pub use repositories::whatsapp_bridge_repository::{WhatsAppBridgeRepository, WhatsAppContact};
 pub use services::twilio_message_service::TwilioMessageService;
 
@@ -290,6 +295,8 @@ pub struct AppState {
     pub admin_alert_repository: Arc<AdminAlertRepository>,
     pub metrics_repository: Arc<MetricsRepository>,
     pub provider_routes_repository: Arc<ProviderRoutesRepository>,
+    pub pending_reply_watches_repository: Arc<PendingReplyWatchesRepository>,
+    pub webhook_tokens_repository: Arc<WebhookTokensRepository>,
     pub pending_totp_logins: DashMap<String, (i32, i64)>, // (totp_token, (user_id, expiry_timestamp))
     pub pending_password_resets: DashMap<String, (i32, i64)>, // (reset_token, (user_id, expiry_timestamp))
     pub session_to_token: DashMap<String, String>, // stripe_session_id -> magic_token (temporary, for redirect flow)

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -325,6 +325,10 @@ async fn main() {
     let metrics_repository = Arc::new(backend::MetricsRepository::new(pg_pool.clone()));
     let provider_routes_repository =
         Arc::new(backend::ProviderRoutesRepository::new(pg_pool.clone()));
+    let pending_reply_watches_repository =
+        Arc::new(backend::PendingReplyWatchesRepository::new(pg_pool.clone()));
+    let webhook_tokens_repository =
+        Arc::new(backend::WebhookTokensRepository::new(pg_pool.clone()));
     let llm_usage_repository = Arc::new(LlmUsageRepository::new(pg_pool.clone()));
     let bandwidth_repository = Arc::new(backend::BandwidthRepository::new(pg_pool.clone()));
     let ontology_repository = Arc::new(backend::OntologyRepository::new(pg_pool.clone()));
@@ -559,6 +563,8 @@ async fn main() {
         admin_alert_repository,
         metrics_repository,
         provider_routes_repository,
+        pending_reply_watches_repository,
+        webhook_tokens_repository,
         pending_totp_logins: DashMap::new(),
         pending_password_resets: DashMap::new(),
         session_to_token: DashMap::new(),
@@ -647,6 +653,14 @@ async fn main() {
     let textbee_routes = Router::new().route(
         "/api/sms/textbee-server",
         post(twilio_sms::handle_textbee_sms),
+    );
+
+    // Public webhook endpoint: auth is the per-token bearer, not a JWT
+    // cookie, so this route group lives outside `protected_routes`. The
+    // handler does the bearer lookup, cap check, and credit gate itself.
+    let webhook_sms_routes = Router::new().route(
+        "/api/webhook/sms",
+        post(handlers::webhook_sms_handlers::webhook_sms),
     );
     // Voice pipeline: TwiML endpoint validated by Twilio signature
     let voice_twiml_routes = Router::new()
@@ -1473,6 +1487,15 @@ async fn main() {
             "/api/mcp/test",
             post(handlers::mcp_handlers::test_url_connection),
         )
+        .route(
+            "/api/me/webhook-tokens",
+            get(handlers::webhook_sms_handlers::list_tokens)
+                .post(handlers::webhook_sms_handlers::create_token),
+        )
+        .route(
+            "/api/me/webhook-tokens/{token_id}",
+            delete(handlers::webhook_sms_handlers::revoke_token),
+        )
         .route_layer(middleware::from_fn(handlers::auth_middleware::require_auth));
     // Internal endpoints (secret-authenticated, no JWT)
     let maintenance_routes = Router::new()
@@ -1516,6 +1539,7 @@ async fn main() {
         .merge(sinch_routes)
         .merge(telnyx_routes)
         .merge(voice_routes)
+        .merge(webhook_sms_routes)
         .nest_service("/uploads", ServeDir::new("uploads"))
         .route("/blog/md/{slug}", get(blog::handlers::blog_post_md_handler))
         .route("/blog/{slug}", get(blog::handlers::blog_post_handler))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -323,6 +323,8 @@ async fn main() {
     let webauthn_repository = Arc::new(WebauthnRepository::new(pg_pool.clone()));
     let admin_alert_repository = Arc::new(AdminAlertRepository::new(pg_pool.clone()));
     let metrics_repository = Arc::new(backend::MetricsRepository::new(pg_pool.clone()));
+    let provider_routes_repository =
+        Arc::new(backend::ProviderRoutesRepository::new(pg_pool.clone()));
     let llm_usage_repository = Arc::new(LlmUsageRepository::new(pg_pool.clone()));
     let bandwidth_repository = Arc::new(backend::BandwidthRepository::new(pg_pool.clone()));
     let ontology_repository = Arc::new(backend::OntologyRepository::new(pg_pool.clone()));
@@ -488,6 +490,41 @@ async fn main() {
     {
         tracing::info!("Telnyx inbound + status webhooks enabled (TELNYX_PUBLIC_KEY set)");
     }
+
+    // Load per-country provider order into the router's in-memory cache.
+    // Rows without valid JSON are skipped with a warning rather than failing
+    // boot - operators get a fallback to the hardcoded default.
+    match provider_routes_repository.list_all() {
+        Ok(rows) => {
+            for row in rows {
+                match serde_json::from_str::<Vec<String>>(&row.provider_order) {
+                    Ok(order) => {
+                        tracing::info!(
+                            "Loaded provider route: {} -> {:?}",
+                            row.country_code,
+                            order
+                        );
+                        router.set_route(&row.country_code, order);
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "Skipping provider_routes row for {} (invalid JSON: {}): {}",
+                            row.country_code,
+                            e,
+                            row.provider_order
+                        );
+                    }
+                }
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                "Failed to load provider_routes; falling back to router default: {}",
+                e
+            );
+        }
+    }
+
     let channel_router = Arc::new(router);
 
     let state = Arc::new(AppState {
@@ -520,6 +557,7 @@ async fn main() {
         webauthn_repository,
         admin_alert_repository,
         metrics_repository,
+        provider_routes_repository,
         pending_totp_logins: DashMap::new(),
         pending_password_resets: DashMap::new(),
         session_to_token: DashMap::new(),
@@ -891,6 +929,14 @@ async fn main() {
         .route(
             "/api/admin/telegram-bridge-schema-introspect",
             get(admin_handlers::telegram_bridge_schema_introspect),
+        )
+        .route(
+            "/api/admin/provider-routes",
+            get(admin_handlers::list_provider_routes).post(admin_handlers::upsert_provider_route),
+        )
+        .route(
+            "/api/admin/provider-routes/{country_code}",
+            delete(admin_handlers::delete_provider_route),
         )
         .route_layer(middleware::from_fn_with_state(
             state.clone(),

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -658,10 +658,17 @@ async fn main() {
     // Public webhook endpoint: auth is the per-token bearer, not a JWT
     // cookie, so this route group lives outside `protected_routes`. The
     // handler does the bearer lookup, cap check, and credit gate itself.
-    let webhook_sms_routes = Router::new().route(
-        "/api/webhook/sms",
-        post(handlers::webhook_sms_handlers::webhook_sms),
-    );
+    //
+    // 4 KiB body limit: comfortable headroom for a max-length 1500-byte
+    // message + idempotency key + JSON framing, while rejecting junk
+    // traffic before serde does any work. The global 10 MiB limit would
+    // let an unauthenticated attacker burn a lot of CPU per request.
+    let webhook_sms_routes = Router::new()
+        .route(
+            "/api/webhook/sms",
+            post(handlers::webhook_sms_handlers::webhook_sms),
+        )
+        .layer(DefaultBodyLimit::max(4096));
     // Voice pipeline: TwiML endpoint validated by Twilio signature
     let voice_twiml_routes = Router::new()
         .route("/api/voice/incoming", post(voice_pipeline::voice_incoming))

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -28,10 +28,10 @@ use backend::{
 };
 use handlers::{
     admin_handlers, attestation_handlers, auth_handlers, billing_handlers, bridge_auth_common,
-    dashboard_handlers, imap_auth, imap_handlers, person_handlers, profile_handlers, rule_handlers,
-    self_host_handlers, signal_auth, signal_handlers, stripe_handlers, telegram_auth,
-    telegram_handlers, tesla_auth, trust_chain_handlers, twilio_handlers, whatsapp_auth,
-    whatsapp_handlers, youtube, youtube_auth,
+    commitment_handlers, dashboard_handlers, imap_auth, imap_handlers, person_handlers,
+    profile_handlers, rule_handlers, self_host_handlers, signal_auth, signal_handlers,
+    stripe_handlers, telegram_auth, telegram_handlers, tesla_auth, trust_chain_handlers,
+    twilio_handlers, whatsapp_auth, whatsapp_handlers, youtube, youtube_auth,
 };
 
 async fn health_check() -> &'static str {
@@ -328,6 +328,7 @@ async fn main() {
     let llm_usage_repository = Arc::new(LlmUsageRepository::new(pg_pool.clone()));
     let bandwidth_repository = Arc::new(backend::BandwidthRepository::new(pg_pool.clone()));
     let ontology_repository = Arc::new(backend::OntologyRepository::new(pg_pool.clone()));
+    let commitment_repository = Arc::new(backend::CommitmentRepository::new(pg_pool.clone()));
 
     // Optional read-only pool for the mautrix-whatsapp bridge database. Only
     // configured when WHATSAPP_BRIDGE_DATABASE_URL is set (typically inside
@@ -566,6 +567,7 @@ async fn main() {
         llm_usage_repository,
         bandwidth_repository,
         ontology_repository,
+        commitment_repository,
         whatsapp_bridge_repository,
         telegram_bridge_repository,
         ontology_registry: backend::ontology::registry::OntologyRegistry::build(),
@@ -1431,6 +1433,19 @@ async fn main() {
         .route(
             "/api/rules/{id}/status",
             patch(rule_handlers::update_rule_status),
+        )
+        // Commitment detection dashboard
+        .route(
+            "/api/commitment/sender-rules",
+            get(commitment_handlers::list_sender_rules),
+        )
+        .route(
+            "/api/commitment/sender-rules/{id}",
+            delete(commitment_handlers::deactivate_sender_rule),
+        )
+        .route(
+            "/api/commitment/recent-prompts",
+            get(commitment_handlers::list_recent_prompts),
         )
         // MCP Server routes (custom tool integrations)
         .route(

--- a/backend/src/models/commitment_models.rs
+++ b/backend/src/models/commitment_models.rs
@@ -1,0 +1,94 @@
+use crate::pg_schema::{commitment_label_embeddings, commitment_prompts, commitment_sender_rules};
+use diesel::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// -- commitment_sender_rules --
+
+#[derive(Queryable, Selectable, Debug, Clone, Serialize, Deserialize)]
+#[diesel(table_name = commitment_sender_rules)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct CommitmentSenderRule {
+    pub id: i32,
+    pub user_id: i32,
+    pub platform: String,
+    pub sender_key: String,
+    pub rule_type: String,
+    pub source: String,
+    pub active: bool,
+    pub created_at: i32,
+    pub deactivated_at: Option<i32>,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = commitment_sender_rules)]
+pub struct NewCommitmentSenderRule {
+    pub user_id: i32,
+    pub platform: String,
+    pub sender_key: String,
+    pub rule_type: String,
+    pub source: String,
+    pub active: bool,
+    pub created_at: i32,
+}
+
+// -- commitment_label_embeddings --
+
+#[derive(Queryable, Selectable, Debug, Clone)]
+#[diesel(table_name = commitment_label_embeddings)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct CommitmentLabelEmbedding {
+    pub id: i32,
+    pub user_id: i32,
+    pub label_type: String,
+    pub embedding: Vec<u8>,
+    pub source_message_id: Option<i64>,
+    pub created_at: i32,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = commitment_label_embeddings)]
+pub struct NewCommitmentLabelEmbedding {
+    pub user_id: i32,
+    pub label_type: String,
+    pub embedding: Vec<u8>,
+    pub source_message_id: Option<i64>,
+    pub created_at: i32,
+}
+
+// -- commitment_prompts --
+
+#[derive(Queryable, Selectable, Debug, Clone, Serialize, Deserialize)]
+#[diesel(table_name = commitment_prompts)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct CommitmentPrompt {
+    pub id: i32,
+    pub user_id: i32,
+    pub ont_message_id: i64,
+    pub platform: String,
+    pub sender_key: String,
+    pub sender_display_name: String,
+    pub commitment_description: String,
+    pub due_at: Option<i32>,
+    pub remind_at: Option<i32>,
+    pub sent_at: i32,
+    pub sms_message_sid: Option<String>,
+    pub user_label: Option<String>,
+    pub labeled_at: Option<i32>,
+    pub resulting_event_id: Option<i32>,
+    pub resolved_at: Option<i32>,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = commitment_prompts)]
+pub struct NewCommitmentPrompt {
+    pub user_id: i32,
+    pub ont_message_id: i64,
+    pub platform: String,
+    pub sender_key: String,
+    pub sender_display_name: String,
+    pub commitment_description: String,
+    pub due_at: Option<i32>,
+    pub remind_at: Option<i32>,
+    pub sent_at: i32,
+    pub sms_message_sid: Option<String>,
+}

--- a/backend/src/models/user_models.rs
+++ b/backend/src/models/user_models.rs
@@ -1,9 +1,9 @@
 use crate::pg_schema::{
-    admin_alerts, country_availability, disabled_alert_types, message_status_log, site_metrics,
-    user_settings, users, waitlist,
+    admin_alerts, country_availability, disabled_alert_types, message_status_log, provider_routes,
+    site_metrics, user_settings, users, waitlist,
 };
 use diesel::prelude::*;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[derive(Queryable, Selectable, Insertable, Clone)]
 #[diesel(table_name = users)]
@@ -221,6 +221,19 @@ pub struct DisabledAlertType {
 pub struct NewDisabledAlertType {
     pub alert_type: String,
     pub disabled_at: i32,
+}
+
+// Provider Routes: per-country ordered list of SMS providers driving
+// outbound fallback. `provider_order` stores a JSON array of channel
+// ids (e.g. `["twilio","telnyx","sinch"]`). The router treats absent
+// rows as the default ("twilio" only).
+#[derive(Queryable, Selectable, Insertable, AsChangeset, Clone, Debug, Serialize, Deserialize)]
+#[diesel(table_name = provider_routes)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ProviderRoute {
+    pub country_code: String,
+    pub provider_order: String,
+    pub updated_at: i32,
 }
 
 // Site Metrics models for tracking site-wide statistics

--- a/backend/src/models/user_models.rs
+++ b/backend/src/models/user_models.rs
@@ -1,7 +1,7 @@
 use crate::pg_schema::{
     admin_alerts, country_availability, disabled_alert_types, message_status_log,
     pending_reply_watches, provider_routes, site_metrics, user_settings, users, waitlist,
-    webhook_tokens,
+    webhook_idempotency_keys, webhook_tokens,
 };
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -281,6 +281,27 @@ pub struct NewWebhookToken {
     pub daily_cap: i32,
     pub daily_sent: i32,
     pub daily_reset_at: i32,
+    pub created_at: i32,
+}
+
+#[derive(Queryable, Selectable, Clone, Debug)]
+#[diesel(table_name = webhook_idempotency_keys)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct WebhookIdempotencyKey {
+    pub id: i32,
+    pub token_id: i32,
+    pub idempotency_key: String,
+    pub response_sid: Option<String>,
+    pub created_at: i32,
+}
+
+#[derive(Insertable, Clone, Debug)]
+#[diesel(table_name = webhook_idempotency_keys)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewWebhookIdempotencyKey {
+    pub token_id: i32,
+    pub idempotency_key: String,
+    pub response_sid: Option<String>,
     pub created_at: i32,
 }
 

--- a/backend/src/models/user_models.rs
+++ b/backend/src/models/user_models.rs
@@ -1,6 +1,7 @@
 use crate::pg_schema::{
-    admin_alerts, country_availability, disabled_alert_types, message_status_log, provider_routes,
-    site_metrics, user_settings, users, waitlist,
+    admin_alerts, country_availability, disabled_alert_types, message_status_log,
+    pending_reply_watches, provider_routes, site_metrics, user_settings, users, waitlist,
+    webhook_tokens,
 };
 use diesel::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -234,6 +235,67 @@ pub struct ProviderRoute {
     pub country_code: String,
     pub provider_order: String,
     pub updated_at: i32,
+}
+
+#[derive(Queryable, Selectable, Clone, Debug)]
+#[diesel(table_name = pending_reply_watches)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct PendingReplyWatch {
+    pub id: i32,
+    pub user_id: i32,
+    pub platform: String,
+    pub room_id: Option<String>,
+    pub imap_connection_id: Option<i32>,
+    pub contact_identifier: String,
+    pub contact_display_name: String,
+    pub created_at: i32,
+    pub expires_at: i32,
+}
+
+#[derive(Queryable, Selectable, Clone, Debug, Serialize)]
+#[diesel(table_name = webhook_tokens)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct WebhookToken {
+    pub id: i32,
+    pub user_id: i32,
+    #[serde(skip_serializing)]
+    pub token_hash: String,
+    pub token_prefix: String,
+    pub label: String,
+    pub daily_cap: i32,
+    pub daily_sent: i32,
+    pub daily_reset_at: i32,
+    pub last_used_at: Option<i32>,
+    pub revoked_at: Option<i32>,
+    pub created_at: i32,
+}
+
+#[derive(Insertable, Clone, Debug)]
+#[diesel(table_name = webhook_tokens)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewWebhookToken {
+    pub user_id: i32,
+    pub token_hash: String,
+    pub token_prefix: String,
+    pub label: String,
+    pub daily_cap: i32,
+    pub daily_sent: i32,
+    pub daily_reset_at: i32,
+    pub created_at: i32,
+}
+
+#[derive(Insertable, Clone, Debug)]
+#[diesel(table_name = pending_reply_watches)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct NewPendingReplyWatch {
+    pub user_id: i32,
+    pub platform: String,
+    pub room_id: Option<String>,
+    pub imap_connection_id: Option<i32>,
+    pub contact_identifier: String,
+    pub contact_display_name: String,
+    pub created_at: i32,
+    pub expires_at: i32,
 }
 
 // Site Metrics models for tracking site-wide statistics

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -356,6 +356,14 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    provider_routes (country_code) {
+        country_code -> Text,
+        provider_order -> Text,
+        updated_at -> Int4,
+    }
+}
+
 // Ontology v1: Person + Channel tables
 
 diesel::table! {
@@ -551,4 +559,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     ont_rules,
     llm_usage_logs,
     bridge_bandwidth_logs,
+    provider_routes,
 );

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -364,6 +364,20 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    pending_reply_watches (id) {
+        id -> Int4,
+        user_id -> Int4,
+        platform -> Text,
+        room_id -> Nullable<Text>,
+        imap_connection_id -> Nullable<Int4>,
+        contact_identifier -> Text,
+        contact_display_name -> Text,
+        created_at -> Int4,
+        expires_at -> Int4,
+    }
+}
+
 // Ontology v1: Person + Channel tables
 
 diesel::table! {
@@ -564,11 +578,28 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    webhook_tokens (id) {
+        id -> Int4,
+        user_id -> Int4,
+        token_hash -> Text,
+        token_prefix -> Text,
+        label -> Text,
+        daily_cap -> Int4,
+        daily_sent -> Int4,
+        daily_reset_at -> Int4,
+        last_used_at -> Nullable<Int4>,
+        revoked_at -> Nullable<Int4>,
+        created_at -> Int4,
+    }
+}
+
 diesel::joinable!(ont_person_edits -> ont_persons (person_id));
 diesel::joinable!(ont_channels -> ont_persons (person_id));
 
 diesel::joinable!(refund_info -> users (user_id));
 diesel::joinable!(user_settings -> users (user_id));
+diesel::joinable!(webhook_tokens -> users (user_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     user_secrets,
@@ -610,4 +641,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     commitment_label_embeddings,
     commitment_prompts,
     provider_routes,
+    pending_reply_watches,
+    webhook_tokens,
 );

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -517,6 +517,53 @@ diesel::table! {
     }
 }
 
+// Commitment detection signal tables (migration 35)
+
+diesel::table! {
+    commitment_sender_rules (id) {
+        id -> Int4,
+        user_id -> Int4,
+        platform -> Text,
+        sender_key -> Text,
+        rule_type -> Text,
+        source -> Text,
+        active -> Bool,
+        created_at -> Int4,
+        deactivated_at -> Nullable<Int4>,
+    }
+}
+
+diesel::table! {
+    commitment_label_embeddings (id) {
+        id -> Int4,
+        user_id -> Int4,
+        label_type -> Text,
+        embedding -> Bytea,
+        source_message_id -> Nullable<Int8>,
+        created_at -> Int4,
+    }
+}
+
+diesel::table! {
+    commitment_prompts (id) {
+        id -> Int4,
+        user_id -> Int4,
+        ont_message_id -> Int8,
+        platform -> Text,
+        sender_key -> Text,
+        sender_display_name -> Text,
+        commitment_description -> Text,
+        due_at -> Nullable<Int4>,
+        remind_at -> Nullable<Int4>,
+        sent_at -> Int4,
+        sms_message_sid -> Nullable<Text>,
+        user_label -> Nullable<Text>,
+        labeled_at -> Nullable<Int4>,
+        resulting_event_id -> Nullable<Int4>,
+        resolved_at -> Nullable<Int4>,
+    }
+}
+
 diesel::joinable!(ont_person_edits -> ont_persons (person_id));
 diesel::joinable!(ont_channels -> ont_persons (person_id));
 
@@ -559,5 +606,8 @@ diesel::allow_tables_to_appear_in_same_query!(
     ont_rules,
     llm_usage_logs,
     bridge_bandwidth_logs,
+    commitment_sender_rules,
+    commitment_label_embeddings,
+    commitment_prompts,
     provider_routes,
 );

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -594,12 +594,23 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    webhook_idempotency_keys (id) {
+        id -> Int4,
+        token_id -> Int4,
+        idempotency_key -> Text,
+        response_sid -> Nullable<Text>,
+        created_at -> Int4,
+    }
+}
+
 diesel::joinable!(ont_person_edits -> ont_persons (person_id));
 diesel::joinable!(ont_channels -> ont_persons (person_id));
 
 diesel::joinable!(refund_info -> users (user_id));
 diesel::joinable!(user_settings -> users (user_id));
 diesel::joinable!(webhook_tokens -> users (user_id));
+diesel::joinable!(webhook_idempotency_keys -> webhook_tokens (token_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     user_secrets,
@@ -643,4 +654,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     provider_routes,
     pending_reply_watches,
     webhook_tokens,
+    webhook_idempotency_keys,
 );

--- a/backend/src/proactive/commitment_replies.rs
+++ b/backend/src/proactive/commitment_replies.rs
@@ -1,0 +1,389 @@
+//! Incoming SMS handler for commitment-prompt replies (1/2/3/4).
+//!
+//! When `run_commitment_detection` sends an SMS prompt, it writes a row to
+//! `commitment_prompts`. This module parses the user's numeric reply and
+//! applies the corresponding action: create a tracked event (1, 2), upsert a
+//! sender rule (2, 3), or just record the negative label (4). Returns
+//! `Some(confirmation)` when a reply was handled so the caller can short-
+//! circuit the regular agent processing path.
+//!
+//! 1 and 2 also seed a `track` content embedding (for cross-sender rescue of
+//! future missed commitments). 4 seeds a `wrong` embedding (for suppressing
+//! near-duplicate false positives). 3 only sets a sender rule - it's a
+//! sender preference, not a content signal.
+
+use std::sync::Arc;
+
+use tracing::{info, warn};
+
+use crate::models::commitment_models::{NewCommitmentLabelEmbedding, NewCommitmentSenderRule};
+use crate::models::ontology_models::NewOntEvent;
+use crate::models::user_models::User;
+use crate::repositories::commitment_repository::{
+    LABEL_TRACK, LABEL_WRONG, REPLY_ALWAYS, REPLY_MUTE, REPLY_TRACK, REPLY_WRONG,
+    RULE_ALWAYS_TRACK, RULE_MUTE, RULE_SOURCE_SMS,
+};
+use crate::utils::{embedding_service, embedding_similarity};
+use crate::AppState;
+
+/// Inspect an incoming SMS body. If it's a valid commitment-prompt reply
+/// (1/2/3/4) AND the user has an unresolved prompt, apply the action and
+/// return a confirmation message. Returns `None` if the body isn't a
+/// commitment reply or there's no pending prompt - caller should fall back
+/// to regular SMS processing.
+pub async fn try_handle_reply(state: &Arc<AppState>, user: &User, body: &str) -> Option<String> {
+    let reply = parse_reply(body)?;
+
+    let prompt = match state
+        .commitment_repository
+        .find_latest_unresolved_for_user(user.id)
+    {
+        Ok(Some(p)) => p,
+        Ok(None) => {
+            info!(
+                "commitment_reply user={} got '{}' but no pending prompt - ignoring as agent input",
+                user.id, body
+            );
+            return None;
+        }
+        Err(e) => {
+            warn!(
+                "commitment_reply user={} pending lookup failed: {}",
+                user.id, e
+            );
+            return None;
+        }
+    };
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i32;
+
+    let confirmation = match reply {
+        REPLY_TRACK => apply_track(state, &prompt, now).await,
+        REPLY_ALWAYS => apply_always(state, &prompt, now).await,
+        REPLY_MUTE => apply_mute(state, &prompt),
+        REPLY_WRONG => apply_wrong(state, &prompt).await,
+        _ => unreachable!(),
+    };
+
+    Some(confirmation)
+}
+
+/// Strict parser: leading whitespace tolerated, but the body must be exactly
+/// "1", "2", "3", or "4" otherwise we don't treat it as a commitment reply.
+/// This keeps general SMS chat ("1 thing I noticed today...") from being
+/// hijacked as a numeric label.
+fn parse_reply(body: &str) -> Option<&'static str> {
+    match body.trim() {
+        "1" => Some(REPLY_TRACK),
+        "2" => Some(REPLY_ALWAYS),
+        "3" => Some(REPLY_MUTE),
+        "4" => Some(REPLY_WRONG),
+        _ => None,
+    }
+}
+
+/// Conservative fallback when the user replied within the TTL window but
+/// the prompt was already resolved (duplicate Twilio webhook, racing
+/// retry). The user still gets an acknowledgement instead of the bare SMS
+/// reply silently leaking into the regular agent flow.
+const ALREADY_PROCESSED: &str = "Already handled that prompt.";
+
+/// Try to atomically claim the prompt for the given reply label. Returns
+/// `true` when the caller is the first to resolve it - only then should
+/// side effects run. `false` means a duplicate (Twilio retry, racing
+/// reply) and the caller must return the already-handled message without
+/// touching events / rules / embeddings.
+fn claim_or_log_duplicate(
+    state: &Arc<AppState>,
+    prompt: &crate::models::commitment_models::CommitmentPrompt,
+    reply: &str,
+) -> bool {
+    match state.commitment_repository.claim_prompt(prompt.id, reply) {
+        Ok(1) => true,
+        Ok(_) => {
+            info!(
+                "commitment_reply user={} reply={} duplicate (prompt {} already resolved)",
+                prompt.user_id, reply, prompt.id
+            );
+            false
+        }
+        Err(e) => {
+            warn!(
+                "commitment_reply user={} reply={} claim_prompt failed: {}",
+                prompt.user_id, reply, e
+            );
+            // Conservative: treat DB error as "do not double-apply".
+            false
+        }
+    }
+}
+
+async fn apply_track(
+    state: &Arc<AppState>,
+    prompt: &crate::models::commitment_models::CommitmentPrompt,
+    now: i32,
+) -> String {
+    if !claim_or_log_duplicate(state, prompt, REPLY_TRACK) {
+        return ALREADY_PROCESSED.to_string();
+    }
+
+    let new_event = NewOntEvent {
+        user_id: prompt.user_id,
+        description: prompt.commitment_description.clone(),
+        remind_at: prompt.remind_at,
+        due_at: prompt.due_at,
+        status: "active".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+
+    match state.ontology_repository.create_event(&new_event) {
+        Ok(created) => {
+            let _ = state.ontology_repository.create_link(
+                prompt.user_id,
+                "Event",
+                created.id,
+                "Message",
+                prompt.ont_message_id as i32,
+                "source_message",
+                None,
+            );
+            if let Err(e) = state
+                .commitment_repository
+                .set_prompt_event_id(prompt.id, created.id)
+            {
+                warn!(
+                    "commitment_reply set_prompt_event_id failed prompt={}: {}",
+                    prompt.id, e
+                );
+            }
+            seed_label_embedding(state, prompt, LABEL_TRACK, now).await;
+            info!(
+                "commitment_reply user={} reply=1 created event={} from prompt={}",
+                prompt.user_id, created.id, prompt.id
+            );
+            format!("Tracking: {}", prompt.commitment_description)
+        }
+        Err(e) => {
+            warn!(
+                "commitment_reply user={} reply=1 create_event failed: {}",
+                prompt.user_id, e
+            );
+            "Sorry, couldn't track that right now. Try again later.".to_string()
+        }
+    }
+}
+
+async fn apply_always(
+    state: &Arc<AppState>,
+    prompt: &crate::models::commitment_models::CommitmentPrompt,
+    now: i32,
+) -> String {
+    if !claim_or_log_duplicate(state, prompt, REPLY_ALWAYS) {
+        return ALREADY_PROCESSED.to_string();
+    }
+
+    let new_event = NewOntEvent {
+        user_id: prompt.user_id,
+        description: prompt.commitment_description.clone(),
+        remind_at: prompt.remind_at,
+        due_at: prompt.due_at,
+        status: "active".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+
+    let created_id = match state.ontology_repository.create_event(&new_event) {
+        Ok(created) => {
+            let _ = state.ontology_repository.create_link(
+                prompt.user_id,
+                "Event",
+                created.id,
+                "Message",
+                prompt.ont_message_id as i32,
+                "source_message",
+                None,
+            );
+            Some(created.id)
+        }
+        Err(e) => {
+            warn!(
+                "commitment_reply user={} reply=2 create_event failed: {}",
+                prompt.user_id, e
+            );
+            None
+        }
+    };
+
+    if let Some(eid) = created_id {
+        if let Err(e) = state
+            .commitment_repository
+            .set_prompt_event_id(prompt.id, eid)
+        {
+            warn!(
+                "commitment_reply set_prompt_event_id failed prompt={}: {}",
+                prompt.id, e
+            );
+        }
+    }
+
+    // Upsert the always-track sender rule even if event create failed - the
+    // user's preference signal is still valid for future detections.
+    let rule = NewCommitmentSenderRule {
+        user_id: prompt.user_id,
+        platform: prompt.platform.clone(),
+        sender_key: prompt.sender_key.clone(),
+        rule_type: RULE_ALWAYS_TRACK.to_string(),
+        source: RULE_SOURCE_SMS.to_string(),
+        active: true,
+        created_at: now,
+    };
+    if let Err(e) = state.commitment_repository.deactivate_existing_rules(
+        prompt.user_id,
+        &prompt.platform,
+        &prompt.sender_key,
+    ) {
+        warn!(
+            "commitment_reply user={} reply=2 deactivate_existing_rules failed: {}",
+            prompt.user_id, e
+        );
+    }
+    if let Err(e) = state.commitment_repository.create_sender_rule(&rule) {
+        warn!(
+            "commitment_reply user={} reply=2 create_sender_rule failed: {}",
+            prompt.user_id, e
+        );
+    }
+
+    seed_label_embedding(state, prompt, LABEL_TRACK, now).await;
+
+    info!(
+        "commitment_reply user={} reply=2 created event={:?} always_track_sender={} prompt={}",
+        prompt.user_id, created_id, prompt.sender_key, prompt.id
+    );
+
+    format!(
+        "Tracking: {} - will auto-track future from {}",
+        prompt.commitment_description, prompt.sender_display_name
+    )
+}
+
+fn apply_mute(
+    state: &Arc<AppState>,
+    prompt: &crate::models::commitment_models::CommitmentPrompt,
+) -> String {
+    if !claim_or_log_duplicate(state, prompt, REPLY_MUTE) {
+        return ALREADY_PROCESSED.to_string();
+    }
+
+    if let Err(e) = state.commitment_repository.upsert_sender_rule(
+        prompt.user_id,
+        &prompt.platform,
+        &prompt.sender_key,
+        RULE_MUTE,
+        RULE_SOURCE_SMS,
+    ) {
+        warn!(
+            "commitment_reply user={} reply=3 upsert_sender_rule failed: {}",
+            prompt.user_id, e
+        );
+    }
+
+    info!(
+        "commitment_reply user={} reply=3 muted sender={} prompt={}",
+        prompt.user_id, prompt.sender_key, prompt.id
+    );
+
+    format!(
+        "Muted {}. No more commitment prompts from them.",
+        prompt.sender_display_name
+    )
+}
+
+async fn apply_wrong(
+    state: &Arc<AppState>,
+    prompt: &crate::models::commitment_models::CommitmentPrompt,
+) -> String {
+    if !claim_or_log_duplicate(state, prompt, REPLY_WRONG) {
+        return ALREADY_PROCESSED.to_string();
+    }
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i32;
+    seed_label_embedding(state, prompt, LABEL_WRONG, now).await;
+
+    info!(
+        "commitment_reply user={} reply=4 wrong prompt={}",
+        prompt.user_id, prompt.id
+    );
+
+    "Got it - won't treat this as a commitment.".to_string()
+}
+
+/// Fetch the original message content and store an embedding tagged with
+/// `label_type`. Best-effort: any failure (no message, embedding service
+/// disabled or errored) is logged and swallowed - the user-visible action
+/// has already succeeded.
+async fn seed_label_embedding(
+    state: &Arc<AppState>,
+    prompt: &crate::models::commitment_models::CommitmentPrompt,
+    label_type: &str,
+    now: i32,
+) {
+    let messages = match state
+        .ontology_repository
+        .get_messages_by_ids(&[prompt.ont_message_id])
+    {
+        Ok(m) => m,
+        Err(e) => {
+            warn!(
+                "seed_label_embedding user={} get_messages failed: {}",
+                prompt.user_id, e
+            );
+            return;
+        }
+    };
+    let msg = match messages.into_iter().next() {
+        Some(m) => m,
+        None => {
+            warn!(
+                "seed_label_embedding user={} ont_message {} not found",
+                prompt.user_id, prompt.ont_message_id
+            );
+            return;
+        }
+    };
+
+    let embedding =
+        match embedding_service::generate_embedding(&state.ai_config, &msg.content).await {
+            Ok(Some(v)) => v,
+            Ok(None) => return, // feature disabled - silent no-op
+            Err(e) => {
+                warn!(
+                    "seed_label_embedding user={} embedding failed: {}",
+                    prompt.user_id, e
+                );
+                return;
+            }
+        };
+
+    let row = NewCommitmentLabelEmbedding {
+        user_id: prompt.user_id,
+        label_type: label_type.to_string(),
+        embedding: embedding_similarity::pack_embedding(&embedding),
+        source_message_id: Some(prompt.ont_message_id),
+        created_at: now,
+    };
+
+    if let Err(e) = state.commitment_repository.store_label_embedding(&row) {
+        warn!(
+            "seed_label_embedding user={} store failed: {}",
+            prompt.user_id, e
+        );
+    }
+}

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -1454,48 +1454,19 @@ pub async fn run_commitment_detection(
                         })
                     }
                 } else {
-                    let new_event = crate::models::ontology_models::NewOntEvent {
+                    handle_new_commitment(
+                        state,
                         user_id,
-                        description: description.clone(),
-                        remind_at,
+                        entity_snapshot,
+                        sender_name,
+                        platform,
+                        message_id,
+                        &description,
                         due_at,
-                        status: "active".to_string(),
-                        created_at: now,
-                        updated_at: now,
-                    };
-                    match state.ontology_repository.create_event(&new_event) {
-                        Ok(created) => {
-                            if let Some(mid) = message_id {
-                                let _ = state.ontology_repository.create_link(
-                                    user_id,
-                                    "Event",
-                                    created.id,
-                                    "Message",
-                                    mid as i32,
-                                    "source_message",
-                                    None,
-                                );
-                            }
-                            info!(
-                                "Auto-created event {} for user {}: {}",
-                                created.id, user_id, created.description
-                            );
-                            serde_json::json!({
-                                "action": "created",
-                                "event_id": created.id,
-                                "status": "active",
-                                "due_at": due_at,
-                            })
-                        }
-                        Err(e) => {
-                            tracing::warn!("Failed to create event for user {}: {}", user_id, e);
-                            serde_json::json!({
-                                "action": "error",
-                                "reason": "create_event_failed",
-                                "error": e.to_string(),
-                            })
-                        }
-                    }
+                        remind_at,
+                        now,
+                    )
+                    .await
                 };
             }
         }
@@ -1504,6 +1475,402 @@ pub async fn run_commitment_detection(
 
     persist_envelope(extraction_json, routing);
     Ok(())
+}
+
+/// Branch for a freshly-detected new commitment (no `existing_match_id`).
+/// Order of precedence: mute rule skip → always_track rule auto-create →
+/// pending-prompt dedup skip → SMS prompt (no event yet) → fall back to
+/// auto-create on any failure or missing sender_key. Returns the routing
+/// JSON describing what happened, for the activity-feed envelope.
+async fn handle_new_commitment(
+    state: &Arc<AppState>,
+    user_id: i32,
+    entity_snapshot: &serde_json::Value,
+    sender_name: &str,
+    platform: &str,
+    message_id: Option<i64>,
+    description: &str,
+    due_at: Option<i32>,
+    remind_at: Option<i32>,
+    now: i32,
+) -> serde_json::Value {
+    let sender_key_opt = entity_snapshot.get("sender_key").and_then(|v| v.as_str());
+
+    if let Some(sender_key) = sender_key_opt {
+        match state
+            .commitment_repository
+            .lookup_sender_rule(user_id, platform, sender_key)
+        {
+            Ok(Some(rule))
+                if rule.rule_type == crate::repositories::commitment_repository::RULE_MUTE =>
+            {
+                info!(
+                    "commitment_detection user={} skip sender_muted sender={} rule={}",
+                    user_id, sender_key, rule.id
+                );
+                return serde_json::json!({
+                    "action": "skipped",
+                    "reason": "sender_muted",
+                    "rule_id": rule.id,
+                });
+            }
+            Ok(Some(rule))
+                if rule.rule_type
+                    == crate::repositories::commitment_repository::RULE_ALWAYS_TRACK =>
+            {
+                info!(
+                    "commitment_detection user={} auto-tracking via always_track sender={} rule={}",
+                    user_id, sender_key, rule.id
+                );
+                // Fall through to auto-create below.
+            }
+            _ => {
+                // No rule. Dedupe vs an existing unresolved prompt from this
+                // same sender so a rapid-fire sender can't burst-spam the user.
+                match state
+                    .commitment_repository
+                    .find_unresolved_for_sender(user_id, platform, sender_key)
+                {
+                    Ok(Some(existing)) => {
+                        info!(
+                            "commitment_detection user={} skip duplicate_pending prompt_id={}",
+                            user_id, existing.id
+                        );
+                        return serde_json::json!({
+                            "action": "skipped",
+                            "reason": "duplicate_pending_prompt",
+                            "existing_prompt_id": existing.id,
+                        });
+                    }
+                    Ok(None) => {
+                        // Embedding similarity memory: opportunistically rescue
+                        // (auto-track if very similar to a past 1/2 reply) or
+                        // suppress (skip if very similar to a past 4 reply).
+                        // Track-similarity check runs FIRST so a message that
+                        // clears both thresholds gets rescued, not suppressed -
+                        // this matches the asymmetric-cost principle (false
+                        // negatives hurt more than an extra auto-create).
+                        // Best-effort - if embeddings are disabled or fail,
+                        // the SMS prompt path runs as normal.
+                        let mut skip_sms_prompt = false;
+                        if let Some(content) =
+                            entity_snapshot.get("content").and_then(|v| v.as_str())
+                        {
+                            if !content.trim().is_empty() {
+                                match crate::utils::embedding_service::generate_embedding(
+                                    &state.ai_config,
+                                    content,
+                                )
+                                .await
+                                {
+                                    Ok(Some(emb)) => {
+                                        let track_sim = max_user_label_similarity(
+                                            state,
+                                            user_id,
+                                            crate::repositories::commitment_repository::LABEL_TRACK,
+                                            &emb,
+                                        );
+                                        if track_sim >= TRACK_AUTOTRACK_THRESHOLD {
+                                            info!(
+                                                "commitment_detection user={} auto-track via track_similar sim={:.3}",
+                                                user_id, track_sim
+                                            );
+                                            skip_sms_prompt = true;
+                                        } else {
+                                            let wrong_sim = max_user_label_similarity(
+                                                state,
+                                                user_id,
+                                                crate::repositories::commitment_repository::LABEL_WRONG,
+                                                &emb,
+                                            );
+                                            if wrong_sim >= WRONG_SUPPRESS_THRESHOLD {
+                                                info!(
+                                                    "commitment_detection user={} skip similar_to_past_wrong sim={:.3}",
+                                                    user_id, wrong_sim
+                                                );
+                                                return serde_json::json!({
+                                                    "action": "skipped",
+                                                    "reason": "similar_to_past_wrong",
+                                                    "similarity": wrong_sim,
+                                                });
+                                            }
+                                        }
+                                    }
+                                    Ok(None) => {}
+                                    Err(e) => {
+                                        tracing::warn!(
+                                            "commitment_detection user={} embedding_failed: {}",
+                                            user_id,
+                                            e
+                                        );
+                                    }
+                                }
+                            }
+                        }
+
+                        if !skip_sms_prompt {
+                            match try_send_commitment_prompt(
+                                state,
+                                user_id,
+                                message_id,
+                                platform,
+                                sender_key,
+                                sender_name,
+                                description,
+                                due_at,
+                                remind_at,
+                            )
+                            .await
+                            {
+                                Ok(PromptSendOutcome::Sent { prompt_id }) => {
+                                    info!(
+                                        "commitment_detection user={} sms_prompt_sent prompt_id={}",
+                                        user_id, prompt_id
+                                    );
+                                    return serde_json::json!({
+                                        "action": "sms_prompt_sent",
+                                        "prompt_id": prompt_id,
+                                    });
+                                }
+                                Ok(PromptSendOutcome::RaceLost) => {
+                                    info!(
+                                        "commitment_detection user={} skip prompt_race_lost - another worker already sent",
+                                        user_id
+                                    );
+                                    return serde_json::json!({
+                                        "action": "skipped",
+                                        "reason": "prompt_race_lost",
+                                    });
+                                }
+                                Err(e) => {
+                                    tracing::warn!(
+                                        "commitment_detection user={} sms_prompt_failed: {} - falling back to auto-create",
+                                        user_id, e
+                                    );
+                                    // Fall through to auto-create.
+                                }
+                            }
+                        }
+                        // If skip_sms_prompt set, fall through to outer
+                        // auto-create with `similar_to_past_track` rationale
+                        // (the log line above captures the similarity score).
+                    }
+                    Err(e) => {
+                        tracing::warn!(
+                            "commitment_detection user={} pending_lookup_failed: {} - falling back to auto-create",
+                            user_id, e
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    // Fall-through: auto-create the event. Reached when always_track rule
+    // matched, sender_key was unavailable, SMS dispatch failed, or rule
+    // lookups errored.
+    let new_event = crate::models::ontology_models::NewOntEvent {
+        user_id,
+        description: description.to_string(),
+        remind_at,
+        due_at,
+        status: "active".to_string(),
+        created_at: now,
+        updated_at: now,
+    };
+    match state.ontology_repository.create_event(&new_event) {
+        Ok(created) => {
+            if let Some(mid) = message_id {
+                let _ = state.ontology_repository.create_link(
+                    user_id,
+                    "Event",
+                    created.id,
+                    "Message",
+                    mid as i32,
+                    "source_message",
+                    None,
+                );
+            }
+            info!(
+                "Auto-created event {} for user {}: {}",
+                created.id, user_id, created.description
+            );
+            serde_json::json!({
+                "action": "created",
+                "event_id": created.id,
+                "status": "active",
+                "due_at": due_at,
+            })
+        }
+        Err(e) => {
+            tracing::warn!("Failed to create event for user {}: {}", user_id, e);
+            serde_json::json!({
+                "action": "error",
+                "reason": "create_event_failed",
+                "error": e.to_string(),
+            })
+        }
+    }
+}
+
+/// Outcome of attempting to send a commitment SMS prompt.
+enum PromptSendOutcome {
+    /// New prompt persisted and SMS dispatched. `prompt_id` is the new row id.
+    Sent { prompt_id: i32 },
+    /// Another concurrent worker already has an unresolved prompt for this
+    /// (user, platform, sender_key) - unique partial index rejected our
+    /// insert. We did NOT send a duplicate SMS.
+    RaceLost,
+}
+
+/// Insert the `commitment_prompts` row FIRST, then send the SMS, then
+/// backfill the channel SID. Inserting before sending is what makes the
+/// unique partial index actually prevent duplicate prompts under concurrent
+/// detection: if two workers see no existing prompt and race, exactly one
+/// wins the insert and only that one sends an SMS.
+///
+/// If SMS dispatch fails after the row was inserted, the prompt is marked
+/// resolved-with-no-label so it doesn't haunt the user's pending list.
+async fn try_send_commitment_prompt(
+    state: &Arc<AppState>,
+    user_id: i32,
+    message_id: Option<i64>,
+    platform: &str,
+    sender_key: &str,
+    sender_name: &str,
+    description: &str,
+    due_at: Option<i32>,
+    remind_at: Option<i32>,
+) -> Result<PromptSendOutcome, String> {
+    let mid = message_id.ok_or_else(|| "no message_id available".to_string())?;
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs() as i32;
+
+    let new_prompt = crate::models::commitment_models::NewCommitmentPrompt {
+        user_id,
+        ont_message_id: mid,
+        platform: platform.to_string(),
+        sender_key: sender_key.to_string(),
+        sender_display_name: sender_name.to_string(),
+        commitment_description: description.to_string(),
+        due_at,
+        remind_at,
+        sent_at: now,
+        sms_message_sid: None,
+    };
+
+    let prompt = match state
+        .commitment_repository
+        .create_prompt(&new_prompt)
+        .map_err(|e| format!("create_prompt: {}", e))?
+    {
+        Some(p) => p,
+        None => return Ok(PromptSendOutcome::RaceLost),
+    };
+
+    let body = format!(
+        "Commitment? \"{}\" (from {}). Reply: 1=track, 2=always, 3=mute, 4=not commitment",
+        truncate_chars(description, 100),
+        truncate_chars(sender_name, 40)
+    );
+
+    let user = state
+        .user_core
+        .find_by_id(user_id)
+        .map_err(|e| format!("find_by_id failed: {}", e))?
+        .ok_or_else(|| "user not found".to_string())?;
+
+    match state.channel_router.send_to_user(&user, &body, None).await {
+        Ok(channel_id) => {
+            if let Err(e) = state
+                .commitment_repository
+                .set_prompt_sms_sid(prompt.id, &channel_id.0)
+            {
+                tracing::warn!(
+                    "commitment_prompt user={} prompt={} set_sms_sid failed: {}",
+                    user_id,
+                    prompt.id,
+                    e
+                );
+            }
+            Ok(PromptSendOutcome::Sent {
+                prompt_id: prompt.id,
+            })
+        }
+        Err(e) => {
+            // SMS failed but a row exists. Mark resolved so the unique
+            // partial index releases the (user, platform, sender_key) slot
+            // and so the pending list doesn't show this orphan to the user.
+            if let Err(e2) = state.commitment_repository.expire_prompt(prompt.id) {
+                tracing::warn!(
+                    "commitment_prompt user={} prompt={} expire_after_send_fail failed: {}",
+                    user_id,
+                    prompt.id,
+                    e2
+                );
+            }
+            Err(format!("channel send failed: {}", e))
+        }
+    }
+}
+
+/// Char-bounded truncation that adds an ellipsis when content overflows.
+/// Operates on chars not bytes so we don't slice mid-codepoint.
+fn truncate_chars(s: &str, max: usize) -> String {
+    if s.chars().count() <= max {
+        return s.to_string();
+    }
+    let mut out: String = s.chars().take(max.saturating_sub(1)).collect();
+    out.push('…');
+    out
+}
+
+/// Cosine similarity at or above this threshold against the user's "wrong"
+/// embedding store suppresses the SMS prompt entirely. Tuned to "very
+/// similar to a past 4-reply" - asymmetric vs the track threshold because
+/// false negatives (missing a real commitment) cost more than the noise of
+/// an extra SMS prompt.
+const WRONG_SUPPRESS_THRESHOLD: f32 = 0.90;
+
+/// Cosine similarity at or above this threshold against the user's "track"
+/// embedding store causes auto-create even without an explicit always_track
+/// sender rule. Lower bar than WRONG_SUPPRESS_THRESHOLD because the
+/// downside of an unwanted auto-create is recoverable (user resolves the
+/// event) while a missed commitment is not.
+const TRACK_AUTOTRACK_THRESHOLD: f32 = 0.85;
+
+/// Brute-force max cosine similarity between `query` and the user's stored
+/// embeddings of the given label type. Returns 0.0 on lookup failure or
+/// when there are no stored embeddings yet.
+fn max_user_label_similarity(
+    state: &Arc<AppState>,
+    user_id: i32,
+    label_type: &str,
+    query: &[f32],
+) -> f32 {
+    let rows = match state
+        .commitment_repository
+        .list_embeddings(user_id, label_type)
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::warn!(
+                "commitment_detection user={} list_embeddings({}) failed: {}",
+                user_id,
+                label_type,
+                e
+            );
+            return 0.0;
+        }
+    };
+    let candidates: Vec<Vec<f32>> = rows
+        .into_iter()
+        .filter_map(|r| crate::utils::embedding_similarity::unpack_embedding(&r.embedding))
+        .collect();
+    crate::utils::embedding_similarity::max_similarity(query, &candidates)
 }
 
 /// Check if the user's outgoing message indicates a tracked event is already done.

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -1522,6 +1522,7 @@ pub async fn run_commitment_detection(
 /// pending-prompt dedup skip → SMS prompt (no event yet) → fall back to
 /// auto-create on any failure or missing sender_key. Returns the routing
 /// JSON describing what happened, for the activity-feed envelope.
+#[allow(clippy::too_many_arguments)]
 async fn handle_new_commitment(
     state: &Arc<AppState>,
     user_id: i32,
@@ -1771,6 +1772,7 @@ enum PromptSendOutcome {
 ///
 /// If SMS dispatch fails after the row was inserted, the prompt is marked
 /// resolved-with-no-label so it doesn't haunt the user's pending list.
+#[allow(clippy::too_many_arguments)]
 async fn try_send_commitment_prompt(
     state: &Arc<AppState>,
     user_id: i32,

--- a/backend/src/proactive/system_behaviors.rs
+++ b/backend/src/proactive/system_behaviors.rs
@@ -927,7 +927,13 @@ pub async fn run_commitment_detection(
     } else {
         let items: Vec<String> = scored
             .iter()
-            .map(|(_, e)| format!("[id={}] {}", e.id, e.description))
+            .map(|(_, e)| {
+                let deadline = e
+                    .due_at
+                    .map(|d| format!(" deadline={}", fmt_ts(d)))
+                    .unwrap_or_default();
+                format!("[id={}]{} {}", e.id, deadline, e.description)
+            })
             .collect();
         format!("Existing tracked items:\n{}", items.join("\n"))
     };
@@ -961,9 +967,10 @@ pub async fn run_commitment_detection(
         1. If the latest message contains no concrete actionable obligation, return has_commitment=false and STOP. Leave description empty.\n\
         2. If it DOES, you MUST fill ALL of: commitment_type, description, who, confidence. description must be a short imperative phrase (\"Buy hat from seller\", \"Pay invoice\", \"Send project files\") - never empty when has_commitment=true.\n\
         3. who is strictly \"sender\" or \"user\". \"sender\" means the message sender. \"user\" means the user this assistant works for. Never free-form.\n\
-        4. deadline must be RFC 3339 in the timezone shown above, or null.\n\
+        4. deadline must be RFC 3339 in the timezone shown above, or null. ONLY set a deadline when the message explicitly states or unambiguously implies one for THIS obligation. Bare time mentions (\"at 20:00\", \"in the evening\") without a date are NOT deadlines - leave deadline null. When updating an existing tracked item that already has a deadline shown above, leave deadline null UNLESS the message explicitly reschedules it.\n\
         5. existing_match_id is the integer id from the \"Existing tracked items\" list above, or null if this is a new obligation.\n\
-        6. Works in any language. Conditional commitments (\"if X then I'll buy Friday\") still count.\n\
+        6. commitment_type=deadline_update is ONLY for messages that explicitly reschedule an existing tracked item (\"moved to Friday\", \"pushed to next week\", \"actually let's do it tomorrow\"). Casual time references in conversation are NOT deadline updates.\n\
+        7. Works in any language. Conditional commitments (\"if X then I'll buy Friday\") still count.\n\
         \n\
         Bias: when in doubt about description specificity, write a best-guess imperative phrase rather than leaving it empty.",
         now_formatted, tz_label, sender_name, events_context
@@ -1344,13 +1351,34 @@ pub async fn run_commitment_detection(
                         } else {
                             Some(format!("Update: {}", description))
                         };
+                        // Safety: if the LLM's new deadline pulls a still-future
+                        // user-set deadline meaningfully forward, ignore the
+                        // timing change and just append context. Prevents an
+                        // ambient time mention ("at 20:00") from firing a
+                        // reminder days before the real event.
+                        const PULL_FORWARD_GUARD_SECS: i32 = 6 * 3600;
+                        let (safe_remind, safe_due) = match (old_event.as_ref(), due_at) {
+                            (Some(old), Some(new_due)) => {
+                                let old_due = old.due_at.unwrap_or(0);
+                                if old_due > now && new_due + PULL_FORWARD_GUARD_SECS < old_due {
+                                    tracing::info!(
+                                        "deadline_update guard: ignoring earlier inferred deadline event={} old_due={} new_due={}",
+                                        event_id, old_due, new_due
+                                    );
+                                    (None, None)
+                                } else {
+                                    (remind_at, due_at)
+                                }
+                            }
+                            _ => (remind_at, due_at),
+                        };
                         match state.ontology_repository.update_event(
                             user_id,
                             event_id,
                             update_desc.as_deref(),
                             None,
-                            remind_at,
-                            due_at,
+                            safe_remind,
+                            safe_due,
                         ) {
                             Ok(_) => {
                                 if let Some(mid) = message_id {
@@ -1366,7 +1394,7 @@ pub async fn run_commitment_detection(
                                 }
                                 if let Some(old) = old_event {
                                     let old_due = old.due_at.unwrap_or(0);
-                                    if let Some(new_due) = due_at {
+                                    if let Some(new_due) = safe_due {
                                         if old_due != new_due && old_due != 0 {
                                             let change_msg = format!(
                                                 "Tracked item updated: \"{}\"\nDeadline changed based on new message from {}.",
@@ -1383,11 +1411,19 @@ pub async fn run_commitment_detection(
                                         }
                                     }
                                 }
-                                serde_json::json!({
-                                    "action": "deadline_updated",
-                                    "event_id": event_id,
-                                    "new_due_at": due_at,
-                                })
+                                if safe_due.is_none() && due_at.is_some() {
+                                    serde_json::json!({
+                                        "action": "deadline_update_guarded",
+                                        "event_id": event_id,
+                                        "rejected_due_at": due_at,
+                                    })
+                                } else {
+                                    serde_json::json!({
+                                        "action": "deadline_updated",
+                                        "event_id": event_id,
+                                        "new_due_at": safe_due,
+                                    })
+                                }
                             }
                             Err(e) => {
                                 tracing::warn!("Failed to update event {}: {}", event_id, e);
@@ -1410,7 +1446,11 @@ pub async fn run_commitment_detection(
                 };
             }
             _ => {
-                // commitment_to_user or commitment_by_user
+                // commitment_to_user or commitment_by_user.
+                // For UPDATES to an existing event, never touch remind_at/due_at -
+                // the user's original deadline stands. Only deadline_update may
+                // reschedule. This prevents ambient time mentions ("at 20:00") in
+                // chatter from rewriting a far-future user-set deadline.
                 routing = if let Some(event_id) = existing_match_id {
                     if valid_ids.contains(&event_id) {
                         match state.ontology_repository.update_event(
@@ -1418,8 +1458,8 @@ pub async fn run_commitment_detection(
                             event_id,
                             Some(&format!("Update: {}", description)),
                             None,
-                            remind_at,
-                            due_at,
+                            None,
+                            None,
                         ) {
                             Ok(_) => {
                                 if let Some(mid) = message_id {

--- a/backend/src/repositories/commitment_repository.rs
+++ b/backend/src/repositories/commitment_repository.rs
@@ -1,0 +1,338 @@
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+
+use crate::models::commitment_models::{
+    CommitmentLabelEmbedding, CommitmentPrompt, CommitmentSenderRule, NewCommitmentLabelEmbedding,
+    NewCommitmentPrompt, NewCommitmentSenderRule,
+};
+use crate::pg_schema::{commitment_label_embeddings, commitment_prompts, commitment_sender_rules};
+use crate::PgDbPool;
+
+pub const RULE_MUTE: &str = "mute";
+pub const RULE_ALWAYS_TRACK: &str = "always_track";
+
+pub const LABEL_TRACK: &str = "track";
+pub const LABEL_WRONG: &str = "wrong";
+
+pub const RULE_SOURCE_SMS: &str = "sms_reply";
+pub const RULE_SOURCE_DASHBOARD: &str = "dashboard";
+
+/// User-visible SMS reply values mapped to the 2x2 signal grid.
+/// 1 = track this message, 2 = always track from this sender,
+/// 3 = mute sender, 4 = not a commitment.
+pub const REPLY_TRACK: &str = "1";
+pub const REPLY_ALWAYS: &str = "2";
+pub const REPLY_MUTE: &str = "3";
+pub const REPLY_WRONG: &str = "4";
+
+/// A bare `1/2/3/4` SMS reply older than this is no longer eligible to match
+/// an unresolved prompt - the user might have meant something else entirely
+/// hours later. Forces them to act on prompts while context is fresh and
+/// prevents accidental hijacking of a stale prompt by an unrelated reply.
+pub const REPLY_MATCH_WINDOW_SECS: i32 = 60 * 60;
+
+pub struct CommitmentRepository {
+    pub pool: PgDbPool,
+}
+
+impl CommitmentRepository {
+    pub fn new(pool: PgDbPool) -> Self {
+        Self { pool }
+    }
+
+    fn now() -> i32 {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i32
+    }
+
+    // -------------------------------------------------------------------------
+    // Sender rules
+    // -------------------------------------------------------------------------
+
+    /// Look up the active sender rule for a given (user, platform, sender_key).
+    /// Returns None when no active rule exists. If multiple rules exist (e.g.,
+    /// mute and always_track for the same sender, which shouldn't normally
+    /// happen but is possible across history), the most recent wins.
+    pub fn lookup_sender_rule(
+        &self,
+        user_id: i32,
+        platform: &str,
+        sender_key: &str,
+    ) -> Result<Option<CommitmentSenderRule>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        commitment_sender_rules::table
+            .filter(commitment_sender_rules::user_id.eq(user_id))
+            .filter(commitment_sender_rules::platform.eq(platform))
+            .filter(commitment_sender_rules::sender_key.eq(sender_key))
+            .filter(commitment_sender_rules::active.eq(true))
+            .order(commitment_sender_rules::created_at.desc())
+            .first::<CommitmentSenderRule>(&mut conn)
+            .optional()
+    }
+
+    /// Insert a new active sender rule. Caller should typically deactivate any
+    /// pre-existing rule for the same (user, platform, sender_key) first so
+    /// lookups are unambiguous.
+    pub fn create_sender_rule(
+        &self,
+        rule: &NewCommitmentSenderRule,
+    ) -> Result<CommitmentSenderRule, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::insert_into(commitment_sender_rules::table)
+            .values(rule)
+            .get_result(&mut conn)
+    }
+
+    /// Deactivate any active rules for a (user, platform, sender_key). Used
+    /// before creating a new rule so the old one doesn't shadow the new one.
+    pub fn deactivate_existing_rules(
+        &self,
+        user_id: i32,
+        platform: &str,
+        sender_key: &str,
+    ) -> Result<usize, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = Self::now();
+        diesel::update(
+            commitment_sender_rules::table
+                .filter(commitment_sender_rules::user_id.eq(user_id))
+                .filter(commitment_sender_rules::platform.eq(platform))
+                .filter(commitment_sender_rules::sender_key.eq(sender_key))
+                .filter(commitment_sender_rules::active.eq(true)),
+        )
+        .set((
+            commitment_sender_rules::active.eq(false),
+            commitment_sender_rules::deactivated_at.eq(Some(now)),
+        ))
+        .execute(&mut conn)
+    }
+
+    /// Upsert a sender rule: deactivate any existing active rules for that
+    /// (user, platform, sender_key), then insert the new one. Returns the new
+    /// rule row.
+    pub fn upsert_sender_rule(
+        &self,
+        user_id: i32,
+        platform: &str,
+        sender_key: &str,
+        rule_type: &str,
+        source: &str,
+    ) -> Result<CommitmentSenderRule, DieselError> {
+        self.deactivate_existing_rules(user_id, platform, sender_key)?;
+        let rule = NewCommitmentSenderRule {
+            user_id,
+            platform: platform.to_string(),
+            sender_key: sender_key.to_string(),
+            rule_type: rule_type.to_string(),
+            source: source.to_string(),
+            active: true,
+            created_at: Self::now(),
+        };
+        self.create_sender_rule(&rule)
+    }
+
+    /// List a user's active rules of a given type (e.g. all muted senders).
+    pub fn list_active_rules(
+        &self,
+        user_id: i32,
+        rule_type: &str,
+    ) -> Result<Vec<CommitmentSenderRule>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        commitment_sender_rules::table
+            .filter(commitment_sender_rules::user_id.eq(user_id))
+            .filter(commitment_sender_rules::rule_type.eq(rule_type))
+            .filter(commitment_sender_rules::active.eq(true))
+            .order(commitment_sender_rules::created_at.desc())
+            .load(&mut conn)
+    }
+
+    /// Deactivate a specific rule (e.g. user removes it from the dashboard).
+    pub fn deactivate_rule(&self, user_id: i32, rule_id: i32) -> Result<usize, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = Self::now();
+        diesel::update(
+            commitment_sender_rules::table
+                .filter(commitment_sender_rules::id.eq(rule_id))
+                .filter(commitment_sender_rules::user_id.eq(user_id))
+                .filter(commitment_sender_rules::active.eq(true)),
+        )
+        .set((
+            commitment_sender_rules::active.eq(false),
+            commitment_sender_rules::deactivated_at.eq(Some(now)),
+        ))
+        .execute(&mut conn)
+    }
+
+    // -------------------------------------------------------------------------
+    // SMS prompts (live + history)
+    // -------------------------------------------------------------------------
+
+    /// Insert a new prompt row. Returns `Ok(None)` when the unique partial
+    /// index on (user_id, platform, sender_key) WHERE resolved_at IS NULL
+    /// already covers an active prompt - the race lost. Callers should treat
+    /// that as "another worker already sent the SMS" and skip both the
+    /// outbound and the local row.
+    pub fn create_prompt(
+        &self,
+        prompt: &NewCommitmentPrompt,
+    ) -> Result<Option<CommitmentPrompt>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        match diesel::insert_into(commitment_prompts::table)
+            .values(prompt)
+            .get_result::<CommitmentPrompt>(&mut conn)
+        {
+            Ok(p) => Ok(Some(p)),
+            Err(DieselError::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            )) => Ok(None),
+            Err(e) => Err(e),
+        }
+    }
+
+    /// Most recently-sent unresolved prompt for a user *within the reply
+    /// window*. Anything older than `REPLY_MATCH_WINDOW_SECS` is excluded so
+    /// a bare `1/2/3/4` reply can't accidentally fire on a forgotten prompt
+    /// from yesterday.
+    pub fn find_latest_unresolved_for_user(
+        &self,
+        user_id: i32,
+    ) -> Result<Option<CommitmentPrompt>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let cutoff = Self::now() - REPLY_MATCH_WINDOW_SECS;
+        commitment_prompts::table
+            .filter(commitment_prompts::user_id.eq(user_id))
+            .filter(commitment_prompts::resolved_at.is_null())
+            .filter(commitment_prompts::sent_at.ge(cutoff))
+            .order(commitment_prompts::sent_at.desc())
+            .first::<CommitmentPrompt>(&mut conn)
+            .optional()
+    }
+
+    /// Live prompt for a (user, platform, sender_key) - used to dedup further
+    /// detections from the same sender while the first prompt is unresolved.
+    pub fn find_unresolved_for_sender(
+        &self,
+        user_id: i32,
+        platform: &str,
+        sender_key: &str,
+    ) -> Result<Option<CommitmentPrompt>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        commitment_prompts::table
+            .filter(commitment_prompts::user_id.eq(user_id))
+            .filter(commitment_prompts::platform.eq(platform))
+            .filter(commitment_prompts::sender_key.eq(sender_key))
+            .filter(commitment_prompts::resolved_at.is_null())
+            .order(commitment_prompts::sent_at.desc())
+            .first::<CommitmentPrompt>(&mut conn)
+            .optional()
+    }
+
+    /// Atomically claim a prompt for resolution. Updates only when the
+    /// prompt is still unresolved - duplicate Twilio retries or concurrent
+    /// replies see `Ok(0)` and the caller must skip side effects to avoid
+    /// double-creating events / sender rules.
+    ///
+    /// Does NOT set resulting_event_id - that's a separate update once the
+    /// event has actually been created. This keeps the claim atomic without
+    /// needing a wrapping transaction.
+    pub fn claim_prompt(&self, prompt_id: i32, user_label: &str) -> Result<usize, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = Self::now();
+        diesel::update(
+            commitment_prompts::table
+                .filter(commitment_prompts::id.eq(prompt_id))
+                .filter(commitment_prompts::resolved_at.is_null()),
+        )
+        .set((
+            commitment_prompts::user_label.eq(Some(user_label.to_string())),
+            commitment_prompts::labeled_at.eq(Some(now)),
+            commitment_prompts::resolved_at.eq(Some(now)),
+        ))
+        .execute(&mut conn)
+    }
+
+    /// Attach the resulting ont_event id after a successful track / always
+    /// action. Separate from claim_prompt because the event id isn't known
+    /// until the event is actually created.
+    pub fn set_prompt_event_id(
+        &self,
+        prompt_id: i32,
+        resulting_event_id: i32,
+    ) -> Result<usize, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::update(commitment_prompts::table.filter(commitment_prompts::id.eq(prompt_id)))
+            .set(commitment_prompts::resulting_event_id.eq(Some(resulting_event_id)))
+            .execute(&mut conn)
+    }
+
+    /// Backfill the channel SID on a freshly-created prompt row. The row is
+    /// inserted before the outbound send so the unique partial index can
+    /// reject racing duplicates, then the SID is patched in after the send
+    /// returns. Best-effort: a failure here doesn't break the prompt flow.
+    pub fn set_prompt_sms_sid(
+        &self,
+        prompt_id: i32,
+        sms_message_sid: &str,
+    ) -> Result<usize, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::update(commitment_prompts::table.filter(commitment_prompts::id.eq(prompt_id)))
+            .set(commitment_prompts::sms_message_sid.eq(Some(sms_message_sid.to_string())))
+            .execute(&mut conn)
+    }
+
+    /// Mark a prompt resolved without a user reply (e.g. expired by TTL job).
+    pub fn expire_prompt(&self, prompt_id: i32) -> Result<usize, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = Self::now();
+        diesel::update(commitment_prompts::table.filter(commitment_prompts::id.eq(prompt_id)))
+            .set(commitment_prompts::resolved_at.eq(Some(now)))
+            .execute(&mut conn)
+    }
+
+    pub fn list_recent_prompts(
+        &self,
+        user_id: i32,
+        limit: i64,
+    ) -> Result<Vec<CommitmentPrompt>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        commitment_prompts::table
+            .filter(commitment_prompts::user_id.eq(user_id))
+            .order(commitment_prompts::sent_at.desc())
+            .limit(limit)
+            .load(&mut conn)
+    }
+
+    // -------------------------------------------------------------------------
+    // Label embeddings (similarity memory)
+    // -------------------------------------------------------------------------
+
+    pub fn store_label_embedding(
+        &self,
+        embedding: &NewCommitmentLabelEmbedding,
+    ) -> Result<CommitmentLabelEmbedding, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::insert_into(commitment_label_embeddings::table)
+            .values(embedding)
+            .get_result(&mut conn)
+    }
+
+    /// All embeddings for a user filtered by label type ('track' or 'wrong').
+    /// Returned in created_at desc order so callers can easily take the N most
+    /// recent. Brute-force cosine similarity is fine for the per-user scale
+    /// (hundreds of vectors at most).
+    pub fn list_embeddings(
+        &self,
+        user_id: i32,
+        label_type: &str,
+    ) -> Result<Vec<CommitmentLabelEmbedding>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        commitment_label_embeddings::table
+            .filter(commitment_label_embeddings::user_id.eq(user_id))
+            .filter(commitment_label_embeddings::label_type.eq(label_type))
+            .order(commitment_label_embeddings::created_at.desc())
+            .load(&mut conn)
+    }
+}

--- a/backend/src/repositories/pending_reply_watches_repository.rs
+++ b/backend/src/repositories/pending_reply_watches_repository.rs
@@ -1,0 +1,145 @@
+//! One-shot reply watches. The AI tools `send_chat_message`,
+//! `send_email`, and `respond_to_email` arm a row here when the user
+//! asked to be told about the reply. The inbound message handlers
+//! (`handle_bridge_message`, `insert_email_into_ontology`) look up
+//! matching rows and notify+delete on first match.
+
+use crate::{
+    models::user_models::{NewPendingReplyWatch, PendingReplyWatch},
+    pg_schema::pending_reply_watches,
+    PgDbPool,
+};
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub const PLATFORM_BRIDGE: &str = "bridge";
+pub const PLATFORM_EMAIL: &str = "email";
+
+/// 24 hours.
+pub const DEFAULT_TTL_SECONDS: i64 = 24 * 60 * 60;
+
+pub struct PendingReplyWatchesRepository {
+    pool: PgDbPool,
+}
+
+impl PendingReplyWatchesRepository {
+    pub fn new(pool: PgDbPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn create(&self, watch: NewPendingReplyWatch) -> Result<PendingReplyWatch, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::insert_into(pending_reply_watches::table)
+            .values(&watch)
+            .get_result::<PendingReplyWatch>(&mut conn)
+    }
+
+    /// Arm a bridge watch. `display_name` is what we'll use to label
+    /// the inbound notification SMS ("Reply from John: ...").
+    pub fn arm_bridge(
+        &self,
+        user_id: i32,
+        room_id: &str,
+        contact_identifier: &str,
+        display_name: &str,
+    ) -> Result<PendingReplyWatch, DieselError> {
+        let now = now_epoch();
+        self.create(NewPendingReplyWatch {
+            user_id,
+            platform: PLATFORM_BRIDGE.to_string(),
+            room_id: Some(room_id.to_string()),
+            imap_connection_id: None,
+            contact_identifier: contact_identifier.to_string(),
+            contact_display_name: display_name.to_string(),
+            created_at: now,
+            expires_at: now + DEFAULT_TTL_SECONDS as i32,
+        })
+    }
+
+    /// Arm an email watch. `contact_identifier` should be the normalized
+    /// recipient email (matches the `sender_key` produced by IMAP ingest).
+    pub fn arm_email(
+        &self,
+        user_id: i32,
+        imap_connection_id: i32,
+        contact_identifier: &str,
+        display_name: &str,
+    ) -> Result<PendingReplyWatch, DieselError> {
+        let now = now_epoch();
+        self.create(NewPendingReplyWatch {
+            user_id,
+            platform: PLATFORM_EMAIL.to_string(),
+            room_id: None,
+            imap_connection_id: Some(imap_connection_id),
+            contact_identifier: contact_identifier.to_string(),
+            contact_display_name: display_name.to_string(),
+            created_at: now,
+            expires_at: now + DEFAULT_TTL_SECONDS as i32,
+        })
+    }
+
+    /// Find an active (non-expired) bridge watch for this (user, room).
+    pub fn find_active_bridge(
+        &self,
+        user_id: i32,
+        room_id: &str,
+    ) -> Result<Option<PendingReplyWatch>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = now_epoch();
+        pending_reply_watches::table
+            .filter(pending_reply_watches::platform.eq(PLATFORM_BRIDGE))
+            .filter(pending_reply_watches::user_id.eq(user_id))
+            .filter(pending_reply_watches::room_id.eq(room_id))
+            .filter(pending_reply_watches::expires_at.gt(now))
+            .select(PendingReplyWatch::as_select())
+            .first::<PendingReplyWatch>(&mut conn)
+            .optional()
+    }
+
+    /// Find an active email watch for (user, account, sender). `sender_key`
+    /// is the already-normalized sender email produced by IMAP ingest.
+    pub fn find_active_email(
+        &self,
+        user_id: i32,
+        imap_connection_id: i32,
+        sender_key: &str,
+    ) -> Result<Option<PendingReplyWatch>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = now_epoch();
+        pending_reply_watches::table
+            .filter(pending_reply_watches::platform.eq(PLATFORM_EMAIL))
+            .filter(pending_reply_watches::user_id.eq(user_id))
+            .filter(pending_reply_watches::imap_connection_id.eq(imap_connection_id))
+            .filter(pending_reply_watches::contact_identifier.eq(sender_key))
+            .filter(pending_reply_watches::expires_at.gt(now))
+            .select(PendingReplyWatch::as_select())
+            .first::<PendingReplyWatch>(&mut conn)
+            .optional()
+    }
+
+    pub fn delete(&self, id: i32) -> Result<(), DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::delete(pending_reply_watches::table.filter(pending_reply_watches::id.eq(id)))
+            .execute(&mut conn)?;
+        Ok(())
+    }
+
+    /// Best-effort cleanup of expired rows. Safe to call on any cadence;
+    /// queries already filter by `expires_at > now`.
+    pub fn delete_expired(&self) -> Result<usize, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = now_epoch();
+        diesel::delete(
+            pending_reply_watches::table.filter(pending_reply_watches::expires_at.le(now)),
+        )
+        .execute(&mut conn)
+    }
+}
+
+fn now_epoch() -> i32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i32
+}

--- a/backend/src/repositories/provider_routes_repository.rs
+++ b/backend/src/repositories/provider_routes_repository.rs
@@ -1,0 +1,62 @@
+//! Persistence for per-country SMS provider order. Drives outbound
+//! fallback in `ChannelRouter`: countries with a row use the stored
+//! `provider_order` (JSON array of channel ids), countries without a
+//! row inherit the router default.
+
+use crate::{models::user_models::ProviderRoute, pg_schema::provider_routes, PgDbPool};
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct ProviderRoutesRepository {
+    pool: PgDbPool,
+}
+
+impl ProviderRoutesRepository {
+    pub fn new(pool: PgDbPool) -> Self {
+        Self { pool }
+    }
+
+    pub fn list_all(&self) -> Result<Vec<ProviderRoute>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        provider_routes::table
+            .order(provider_routes::country_code.asc())
+            .select(ProviderRoute::as_select())
+            .load::<ProviderRoute>(&mut conn)
+    }
+
+    /// Insert or update the order for a country. `provider_order_json` must be
+    /// a JSON array of channel id strings — the caller is responsible for
+    /// validating that the ids are registered channels.
+    pub fn upsert(&self, country_code: &str, provider_order_json: &str) -> Result<(), DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i32;
+        let row = ProviderRoute {
+            country_code: country_code.to_string(),
+            provider_order: provider_order_json.to_string(),
+            updated_at: now,
+        };
+        diesel::insert_into(provider_routes::table)
+            .values(&row)
+            .on_conflict(provider_routes::country_code)
+            .do_update()
+            .set((
+                provider_routes::provider_order.eq(&row.provider_order),
+                provider_routes::updated_at.eq(row.updated_at),
+            ))
+            .execute(&mut conn)?;
+        Ok(())
+    }
+
+    pub fn delete(&self, country_code: &str) -> Result<(), DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::delete(
+            provider_routes::table.filter(provider_routes::country_code.eq(country_code)),
+        )
+        .execute(&mut conn)?;
+        Ok(())
+    }
+}

--- a/backend/src/repositories/webhook_tokens_repository.rs
+++ b/backend/src/repositories/webhook_tokens_repository.rs
@@ -1,0 +1,182 @@
+//! Storage for per-user webhook tokens. Each row is keyed by `token_hash`
+//! (SHA-256 hex of the raw bearer string) so a DB read leaks neither the
+//! plaintext token nor anything an attacker could replay.
+//!
+//! The send path goes through `claim_send_slot`, which combines daily-cap
+//! window reset and per-request increment in a single atomic UPDATE.
+//! Two concurrent requests therefore cannot both pass the cap check.
+
+use crate::{
+    models::user_models::{NewWebhookToken, WebhookToken},
+    pg_schema::webhook_tokens,
+    PgDbPool,
+};
+use diesel::prelude::*;
+use diesel::result::Error as DieselError;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+pub struct WebhookTokensRepository {
+    pool: PgDbPool,
+}
+
+/// Outcome of attempting to reserve one send slot for a token.
+#[derive(Debug)]
+pub enum ClaimResult {
+    /// Slot reserved; caller may send.
+    Ok { token: WebhookToken },
+    /// Token has been revoked.
+    Revoked,
+    /// Token is valid but the daily cap is exhausted.
+    OverCap { daily_cap: i32, daily_sent: i32 },
+}
+
+impl WebhookTokensRepository {
+    pub fn new(pool: PgDbPool) -> Self {
+        Self { pool }
+    }
+
+    /// Insert a new token row. Caller supplies the SHA-256 hash and the
+    /// short prefix; the raw token never reaches this layer.
+    pub fn create(&self, row: &NewWebhookToken) -> Result<WebhookToken, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::insert_into(webhook_tokens::table)
+            .values(row)
+            .get_result::<WebhookToken>(&mut conn)
+    }
+
+    /// List active (non-revoked) tokens for the dashboard UI, newest first.
+    pub fn list_for_user(&self, user_id: i32) -> Result<Vec<WebhookToken>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        webhook_tokens::table
+            .filter(webhook_tokens::user_id.eq(user_id))
+            .filter(webhook_tokens::revoked_at.is_null())
+            .order(webhook_tokens::created_at.desc())
+            .select(WebhookToken::as_select())
+            .load::<WebhookToken>(&mut conn)
+    }
+
+    /// Mark a token as revoked. Idempotent; rows already revoked are left
+    /// untouched. Returns whether the row exists and belongs to this user.
+    pub fn revoke(&self, user_id: i32, token_id: i32) -> Result<bool, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = now_unix();
+        let affected = diesel::update(
+            webhook_tokens::table
+                .filter(webhook_tokens::id.eq(token_id))
+                .filter(webhook_tokens::user_id.eq(user_id))
+                .filter(webhook_tokens::revoked_at.is_null()),
+        )
+        .set(webhook_tokens::revoked_at.eq(now))
+        .execute(&mut conn)?;
+        Ok(affected > 0)
+    }
+
+    /// Find a token row by its SHA-256 hash. Returns None when no row
+    /// matches; callers must not distinguish "no such hash" from
+    /// "revoked" in responses to keep the bearer 401 path uniform.
+    pub fn find_by_hash(&self, token_hash: &str) -> Result<Option<WebhookToken>, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        webhook_tokens::table
+            .filter(webhook_tokens::token_hash.eq(token_hash))
+            .select(WebhookToken::as_select())
+            .first::<WebhookToken>(&mut conn)
+            .optional()
+    }
+
+    /// Atomically reserve one send slot. Resets the daily window when the
+    /// stored `daily_reset_at` is in the past, then increments `daily_sent`
+    /// only if it would stay strictly less than `daily_cap`. Either the
+    /// row is updated and the new state returned, or the cap was hit and
+    /// `OverCap` is returned without sending.
+    ///
+    /// Race-safety: the eligibility predicate and the increment live in a
+    /// single UPDATE, so two callers cannot both pass.
+    pub fn claim_send_slot(&self, token_hash: &str) -> Result<ClaimResult, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = now_unix();
+
+        // 1. Reset the daily window if it has expired. Always touches
+        //    last_used_at would be a write on every poll, so we only
+        //    reset rows whose window is actually stale.
+        let next_reset = next_utc_midnight(now);
+        diesel::update(
+            webhook_tokens::table
+                .filter(webhook_tokens::token_hash.eq(token_hash))
+                .filter(webhook_tokens::daily_reset_at.le(now)),
+        )
+        .set((
+            webhook_tokens::daily_sent.eq(0),
+            webhook_tokens::daily_reset_at.eq(next_reset),
+        ))
+        .execute(&mut conn)?;
+
+        // 2. Re-read to decide the response shape. We already know the
+        //    row exists by hash (handler looked it up first), but we
+        //    re-read here so revoked/cap state is fresh.
+        let row = match webhook_tokens::table
+            .filter(webhook_tokens::token_hash.eq(token_hash))
+            .select(WebhookToken::as_select())
+            .first::<WebhookToken>(&mut conn)
+            .optional()?
+        {
+            Some(r) => r,
+            None => return Ok(ClaimResult::Revoked), // treat missing as 401-equivalent
+        };
+
+        if row.revoked_at.is_some() {
+            return Ok(ClaimResult::Revoked);
+        }
+
+        // 3. Atomic claim: increment only when there's headroom.
+        let affected = diesel::update(
+            webhook_tokens::table
+                .filter(webhook_tokens::id.eq(row.id))
+                .filter(webhook_tokens::revoked_at.is_null())
+                .filter(webhook_tokens::daily_sent.lt(webhook_tokens::daily_cap)),
+        )
+        .set((
+            webhook_tokens::daily_sent.eq(webhook_tokens::daily_sent + 1),
+            webhook_tokens::last_used_at.eq(now),
+        ))
+        .execute(&mut conn)?;
+
+        if affected == 0 {
+            // A concurrent revoke between step 2 and step 3 would also
+            // produce affected==0; re-read to distinguish revoked from
+            // cap-exhausted so the API returns the right status code.
+            let fresh = webhook_tokens::table
+                .filter(webhook_tokens::id.eq(row.id))
+                .select(WebhookToken::as_select())
+                .first::<WebhookToken>(&mut conn)?;
+            if fresh.revoked_at.is_some() {
+                return Ok(ClaimResult::Revoked);
+            }
+            return Ok(ClaimResult::OverCap {
+                daily_cap: fresh.daily_cap,
+                daily_sent: fresh.daily_sent,
+            });
+        }
+
+        // 4. Return the updated row.
+        let updated = webhook_tokens::table
+            .filter(webhook_tokens::id.eq(row.id))
+            .select(WebhookToken::as_select())
+            .first::<WebhookToken>(&mut conn)?;
+        Ok(ClaimResult::Ok { token: updated })
+    }
+}
+
+fn now_unix() -> i32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i32
+}
+
+/// Next UTC midnight after `now`. Used as the daily-cap reset boundary so
+/// users see predictable "X requests remaining today" semantics regardless
+/// of when their first request of the day arrived.
+fn next_utc_midnight(now: i32) -> i32 {
+    let day = 86_400;
+    ((now / day) + 1) * day
+}

--- a/backend/src/repositories/webhook_tokens_repository.rs
+++ b/backend/src/repositories/webhook_tokens_repository.rs
@@ -7,13 +7,19 @@
 //! Two concurrent requests therefore cannot both pass the cap check.
 
 use crate::{
-    models::user_models::{NewWebhookToken, WebhookToken},
-    pg_schema::webhook_tokens,
+    models::user_models::{NewWebhookIdempotencyKey, NewWebhookToken, WebhookToken},
+    pg_schema::{webhook_idempotency_keys, webhook_tokens},
     PgDbPool,
 };
 use diesel::prelude::*;
-use diesel::result::Error as DieselError;
+use diesel::result::{DatabaseErrorKind, Error as DieselError};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Idempotency keys older than this are treated as if they don't exist.
+/// 24h matches the Stripe convention; long enough that legitimate retries
+/// always hit, short enough that an attacker reusing a key the next day
+/// can't replay a stale response.
+const IDEMPOTENCY_TTL_SECS: i32 = 86_400;
 
 pub struct WebhookTokensRepository {
     pool: PgDbPool,
@@ -28,6 +34,22 @@ pub enum ClaimResult {
     Revoked,
     /// Token is valid but the daily cap is exhausted.
     OverCap { daily_cap: i32, daily_sent: i32 },
+}
+
+/// Outcome of looking up / reserving an idempotency key.
+#[derive(Debug)]
+pub enum IdempotencyResult {
+    /// First time we've seen this (token_id, key). Caller should
+    /// proceed with the send and then call `complete_idempotency` with
+    /// the resulting SID so future replays can be answered.
+    Fresh { id: i32 },
+    /// We've seen this key before and the prior request completed.
+    /// Caller should return the cached SID without re-billing or
+    /// re-consuming the daily cap.
+    Replayed { sid: String },
+    /// A prior request with the same key is still in flight. Reject
+    /// with 409 so the client backs off.
+    InFlight,
 }
 
 impl WebhookTokensRepository {
@@ -55,12 +77,30 @@ impl WebhookTokensRepository {
             .load::<WebhookToken>(&mut conn)
     }
 
-    /// Mark a token as revoked. Idempotent; rows already revoked are left
-    /// untouched. Returns whether the row exists and belongs to this user.
+    /// Mark a token as revoked. Truly idempotent: a second revoke of an
+    /// already-revoked token still returns `Ok(true)` so client retries
+    /// (double-click, network retry) don't surface as 404. The original
+    /// `revoked_at` timestamp is preserved — we only stamp `now` when the
+    /// row is transitioning from active to revoked.
+    ///
+    /// Returns `Ok(true)` if the row exists and belongs to this user
+    /// (regardless of whether this call was the one that flipped it),
+    /// `Ok(false)` only when the row is truly not the caller's.
     pub fn revoke(&self, user_id: i32, token_id: i32) -> Result<bool, DieselError> {
         let mut conn = self.pool.get().expect("Failed to get DB connection");
         let now = now_unix();
-        let affected = diesel::update(
+        // First: confirm the row belongs to this user. If not → 404.
+        let owned: i64 = webhook_tokens::table
+            .filter(webhook_tokens::id.eq(token_id))
+            .filter(webhook_tokens::user_id.eq(user_id))
+            .count()
+            .get_result(&mut conn)?;
+        if owned == 0 {
+            return Ok(false);
+        }
+        // Then: only stamp `revoked_at` if currently NULL. The second
+        // revoke matches 0 rows but still returns success above.
+        diesel::update(
             webhook_tokens::table
                 .filter(webhook_tokens::id.eq(token_id))
                 .filter(webhook_tokens::user_id.eq(user_id))
@@ -68,7 +108,7 @@ impl WebhookTokensRepository {
         )
         .set(webhook_tokens::revoked_at.eq(now))
         .execute(&mut conn)?;
-        Ok(affected > 0)
+        Ok(true)
     }
 
     /// Find a token row by its SHA-256 hash. Returns None when no row
@@ -83,86 +123,194 @@ impl WebhookTokensRepository {
             .optional()
     }
 
-    /// Atomically reserve one send slot. Resets the daily window when the
-    /// stored `daily_reset_at` is in the past, then increments `daily_sent`
-    /// only if it would stay strictly less than `daily_cap`. Either the
-    /// row is updated and the new state returned, or the cap was hit and
-    /// `OverCap` is returned without sending.
+    /// Atomically reserve one send slot. Resets the daily window when
+    /// the stored `daily_reset_at` is in the past, then increments
+    /// `daily_sent` only if it would stay strictly less than `daily_cap`.
+    /// Either the row is updated and the new state returned, or the cap
+    /// was hit and `OverCap` is returned without sending.
     ///
-    /// Race-safety: the eligibility predicate and the increment live in a
-    /// single UPDATE, so two callers cannot both pass.
+    /// Race-safety: the whole reset + read + claim sequence runs inside
+    /// a single database transaction, so concurrent callers serialize
+    /// at the row level. The claim itself is a single UPDATE with the
+    /// `daily_sent < daily_cap` predicate baked into the WHERE clause,
+    /// so even without transaction isolation the cap could not be
+    /// exceeded; the transaction is what guarantees the *response* we
+    /// return reflects the same row state we acted on (no torn read
+    /// where the post-claim re-read happens to land in a later window).
     pub fn claim_send_slot(&self, token_hash: &str) -> Result<ClaimResult, DieselError> {
         let mut conn = self.pool.get().expect("Failed to get DB connection");
         let now = now_unix();
-
-        // 1. Reset the daily window if it has expired. Always touches
-        //    last_used_at would be a write on every poll, so we only
-        //    reset rows whose window is actually stale.
         let next_reset = next_utc_midnight(now);
-        diesel::update(
-            webhook_tokens::table
-                .filter(webhook_tokens::token_hash.eq(token_hash))
-                .filter(webhook_tokens::daily_reset_at.le(now)),
-        )
-        .set((
-            webhook_tokens::daily_sent.eq(0),
-            webhook_tokens::daily_reset_at.eq(next_reset),
-        ))
-        .execute(&mut conn)?;
+        let token_hash = token_hash.to_string();
 
-        // 2. Re-read to decide the response shape. We already know the
-        //    row exists by hash (handler looked it up first), but we
-        //    re-read here so revoked/cap state is fresh.
-        let row = match webhook_tokens::table
-            .filter(webhook_tokens::token_hash.eq(token_hash))
-            .select(WebhookToken::as_select())
-            .first::<WebhookToken>(&mut conn)
-            .optional()?
-        {
-            Some(r) => r,
-            None => return Ok(ClaimResult::Revoked), // treat missing as 401-equivalent
-        };
+        conn.transaction::<ClaimResult, DieselError, _>(|conn| {
+            // 1. Reset the daily window if it has expired. The predicate
+            //    `daily_reset_at <= now` means rows still inside their
+            //    current window are no-ops; we don't burn a write per
+            //    request.
+            diesel::update(
+                webhook_tokens::table
+                    .filter(webhook_tokens::token_hash.eq(&token_hash))
+                    .filter(webhook_tokens::daily_reset_at.le(now)),
+            )
+            .set((
+                webhook_tokens::daily_sent.eq(0),
+                webhook_tokens::daily_reset_at.eq(next_reset),
+            ))
+            .execute(conn)?;
 
-        if row.revoked_at.is_some() {
-            return Ok(ClaimResult::Revoked);
-        }
-
-        // 3. Atomic claim: increment only when there's headroom.
-        let affected = diesel::update(
-            webhook_tokens::table
-                .filter(webhook_tokens::id.eq(row.id))
-                .filter(webhook_tokens::revoked_at.is_null())
-                .filter(webhook_tokens::daily_sent.lt(webhook_tokens::daily_cap)),
-        )
-        .set((
-            webhook_tokens::daily_sent.eq(webhook_tokens::daily_sent + 1),
-            webhook_tokens::last_used_at.eq(now),
-        ))
-        .execute(&mut conn)?;
-
-        if affected == 0 {
-            // A concurrent revoke between step 2 and step 3 would also
-            // produce affected==0; re-read to distinguish revoked from
-            // cap-exhausted so the API returns the right status code.
-            let fresh = webhook_tokens::table
-                .filter(webhook_tokens::id.eq(row.id))
+            // 2. Re-read inside the same transaction so we see our own
+            //    write from step 1, and so revoked/cap state is fresh.
+            let row = match webhook_tokens::table
+                .filter(webhook_tokens::token_hash.eq(&token_hash))
                 .select(WebhookToken::as_select())
-                .first::<WebhookToken>(&mut conn)?;
-            if fresh.revoked_at.is_some() {
+                .first::<WebhookToken>(conn)
+                .optional()?
+            {
+                Some(r) => r,
+                None => return Ok(ClaimResult::Revoked),
+            };
+            if row.revoked_at.is_some() {
                 return Ok(ClaimResult::Revoked);
             }
-            return Ok(ClaimResult::OverCap {
-                daily_cap: fresh.daily_cap,
-                daily_sent: fresh.daily_sent,
-            });
-        }
 
-        // 4. Return the updated row.
-        let updated = webhook_tokens::table
-            .filter(webhook_tokens::id.eq(row.id))
-            .select(WebhookToken::as_select())
-            .first::<WebhookToken>(&mut conn)?;
-        Ok(ClaimResult::Ok { token: updated })
+            // 3. Atomic claim: predicate-guarded increment.
+            let affected = diesel::update(
+                webhook_tokens::table
+                    .filter(webhook_tokens::id.eq(row.id))
+                    .filter(webhook_tokens::revoked_at.is_null())
+                    .filter(webhook_tokens::daily_sent.lt(webhook_tokens::daily_cap)),
+            )
+            .set((
+                webhook_tokens::daily_sent.eq(webhook_tokens::daily_sent + 1),
+                webhook_tokens::last_used_at.eq(now),
+            ))
+            .execute(conn)?;
+
+            if affected == 0 {
+                // A concurrent revoke between step 2 and step 3 would
+                // also produce affected==0 even inside this transaction
+                // (transactions in PG use read-committed by default and
+                // another committed revoke is visible to subsequent
+                // statements). Re-read to distinguish revoked from cap.
+                let fresh = webhook_tokens::table
+                    .filter(webhook_tokens::id.eq(row.id))
+                    .select(WebhookToken::as_select())
+                    .first::<WebhookToken>(conn)?;
+                if fresh.revoked_at.is_some() {
+                    return Ok(ClaimResult::Revoked);
+                }
+                return Ok(ClaimResult::OverCap {
+                    daily_cap: fresh.daily_cap,
+                    daily_sent: fresh.daily_sent,
+                });
+            }
+
+            // 4. Return the updated row.
+            let updated = webhook_tokens::table
+                .filter(webhook_tokens::id.eq(row.id))
+                .select(WebhookToken::as_select())
+                .first::<WebhookToken>(conn)?;
+            Ok(ClaimResult::Ok { token: updated })
+        })
+    }
+
+    /// Look up an idempotency key, reserving a fresh row if the key
+    /// is unseen. The whole sequence runs in a transaction so concurrent
+    /// requests with the same (token_id, key) cannot both reserve.
+    ///
+    /// Behavior:
+    /// - Existing row, within TTL, completed (sid set)  → `Replayed { sid }`
+    /// - Existing row, within TTL, in-flight (sid NULL) → `InFlight`
+    /// - Existing row but expired (older than TTL)      → treat as fresh:
+    ///   delete the stale row, insert a new one. This keeps key reuse
+    ///   well-defined after the TTL elapses.
+    /// - No row                                          → `Fresh { id }`
+    pub fn reserve_idempotency_key(
+        &self,
+        token_id: i32,
+        key: &str,
+    ) -> Result<IdempotencyResult, DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        let now = now_unix();
+        let key = key.to_string();
+
+        conn.transaction::<IdempotencyResult, DieselError, _>(|conn| {
+            // Look up existing row.
+            let existing = webhook_idempotency_keys::table
+                .filter(webhook_idempotency_keys::token_id.eq(token_id))
+                .filter(webhook_idempotency_keys::idempotency_key.eq(&key))
+                .select((
+                    webhook_idempotency_keys::id,
+                    webhook_idempotency_keys::response_sid,
+                    webhook_idempotency_keys::created_at,
+                ))
+                .first::<(i32, Option<String>, i32)>(conn)
+                .optional()?;
+
+            if let Some((row_id, response_sid, created_at)) = existing {
+                if now - created_at <= IDEMPOTENCY_TTL_SECS {
+                    return Ok(match response_sid {
+                        Some(sid) => IdempotencyResult::Replayed { sid },
+                        None => IdempotencyResult::InFlight,
+                    });
+                }
+                // Stale: drop it and fall through to insert a fresh row.
+                diesel::delete(
+                    webhook_idempotency_keys::table.filter(webhook_idempotency_keys::id.eq(row_id)),
+                )
+                .execute(conn)?;
+            }
+
+            // Insert a fresh row with response_sid = NULL (in-flight).
+            // The UNIQUE (token_id, idempotency_key) constraint defends
+            // against a concurrent insert that beat us between the SELECT
+            // and the INSERT — translated to InFlight below.
+            let new_row = NewWebhookIdempotencyKey {
+                token_id,
+                idempotency_key: key.clone(),
+                response_sid: None,
+                created_at: now,
+            };
+            match diesel::insert_into(webhook_idempotency_keys::table)
+                .values(&new_row)
+                .returning(webhook_idempotency_keys::id)
+                .get_result::<i32>(conn)
+            {
+                Ok(id) => Ok(IdempotencyResult::Fresh { id }),
+                Err(DieselError::DatabaseError(DatabaseErrorKind::UniqueViolation, _)) => {
+                    // Lost the race; another request just reserved.
+                    // Whatever they're doing, we treat as in-flight.
+                    Ok(IdempotencyResult::InFlight)
+                }
+                Err(e) => Err(e),
+            }
+        })
+    }
+
+    /// Stamp the SID on a previously reserved idempotency row so future
+    /// replays can return it. Best-effort: if the row was already
+    /// deleted (e.g. via CASCADE on token revoke), we silently no-op.
+    pub fn complete_idempotency(&self, row_id: i32, sid: &str) -> Result<(), DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::update(
+            webhook_idempotency_keys::table.filter(webhook_idempotency_keys::id.eq(row_id)),
+        )
+        .set(webhook_idempotency_keys::response_sid.eq(sid))
+        .execute(&mut conn)?;
+        Ok(())
+    }
+
+    /// Clear an in-flight reservation when the send fails. Lets the
+    /// client retry with the same key without waiting for the 24h TTL.
+    /// Safe to call multiple times.
+    pub fn clear_idempotency(&self, row_id: i32) -> Result<(), DieselError> {
+        let mut conn = self.pool.get().expect("Failed to get DB connection");
+        diesel::delete(
+            webhook_idempotency_keys::table.filter(webhook_idempotency_keys::id.eq(row_id)),
+        )
+        .execute(&mut conn)?;
+        Ok(())
     }
 }
 

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -114,6 +114,9 @@ pub fn create_test_state() -> Arc<crate::AppState> {
     let ontology_repository = Arc::new(
         crate::repositories::ontology_repository::OntologyRepository::new(pg_pool.clone()),
     );
+    let commitment_repository = Arc::new(
+        crate::repositories::commitment_repository::CommitmentRepository::new(pg_pool.clone()),
+    );
 
     let google_oauth = create_dummy_google_oauth_client();
     let tesla_oauth = create_dummy_tesla_oauth_client();
@@ -170,6 +173,7 @@ pub fn create_test_state() -> Arc<crate::AppState> {
         llm_usage_repository,
         bandwidth_repository,
         ontology_repository,
+        commitment_repository,
         whatsapp_bridge_repository: None,
         telegram_bridge_repository: None,
         ontology_registry: crate::ontology::registry::OntologyRegistry::build(),

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -105,6 +105,16 @@ pub fn create_test_state() -> Arc<crate::AppState> {
             pg_pool.clone(),
         ),
     );
+    let pending_reply_watches_repository = Arc::new(
+        crate::repositories::pending_reply_watches_repository::PendingReplyWatchesRepository::new(
+            pg_pool.clone(),
+        ),
+    );
+    let webhook_tokens_repository = Arc::new(
+        crate::repositories::webhook_tokens_repository::WebhookTokensRepository::new(
+            pg_pool.clone(),
+        ),
+    );
     let llm_usage_repository = Arc::new(
         crate::repositories::llm_usage_repository::LlmUsageRepository::new(pg_pool.clone()),
     );
@@ -165,6 +175,8 @@ pub fn create_test_state() -> Arc<crate::AppState> {
         admin_alert_repository,
         metrics_repository,
         provider_routes_repository,
+        pending_reply_watches_repository,
+        webhook_tokens_repository,
         pending_totp_logins: DashMap::new(),
         pending_password_resets: DashMap::new(),
         session_to_token: DashMap::new(),

--- a/backend/src/test_utils.rs
+++ b/backend/src/test_utils.rs
@@ -100,6 +100,11 @@ pub fn create_test_state() -> Arc<crate::AppState> {
     );
     let metrics_repository =
         Arc::new(crate::repositories::metrics_repository::MetricsRepository::new(pg_pool.clone()));
+    let provider_routes_repository = Arc::new(
+        crate::repositories::provider_routes_repository::ProviderRoutesRepository::new(
+            pg_pool.clone(),
+        ),
+    );
     let llm_usage_repository = Arc::new(
         crate::repositories::llm_usage_repository::LlmUsageRepository::new(pg_pool.clone()),
     );
@@ -156,6 +161,7 @@ pub fn create_test_state() -> Arc<crate::AppState> {
         webauthn_repository,
         admin_alert_repository,
         metrics_repository,
+        provider_routes_repository,
         pending_totp_logins: DashMap::new(),
         pending_password_resets: DashMap::new(),
         session_to_token: DashMap::new(),

--- a/backend/src/tool_call_utils/bridge.rs
+++ b/backend/src/tool_call_utils/bridge.rs
@@ -33,6 +33,16 @@ pub fn get_send_chat_message_tool() -> openai_api_rs::v1::chat_completion::Tool 
             ..Default::default()
         }),
     );
+    properties.insert(
+        "notify_on_reply".to_string(),
+        Box::new(types::JSONSchemaDefine {
+            schema_type: Some(types::JSONSchemaType::Boolean),
+            description: Some(
+                "Optional. Defaults to false. Set to true ONLY when the user explicitly asks to be told when the recipient replies (e.g. \"text John and let me know what he says\"). When true, the first message from the recipient in the next 24 hours is forwarded to the user via SMS. After that one reply, the watch ends automatically.".to_string()
+            ),
+            ..Default::default()
+        }),
+    );
     chat_completion::Tool {
         r#type: chat_completion::ToolType::Function,
         function: types::Function {
@@ -63,6 +73,8 @@ struct SendChatMessageArgs {
     platform: String,
     chat_name: String,
     message: String,
+    #[serde(default)]
+    notify_on_reply: bool,
 }
 /// Resolved chat target for the send path.
 ///
@@ -758,6 +770,7 @@ pub async fn handle_send_chat_message(
 
     let cloned_image_url = image_url.map(|s| s.to_string());
     let cloned_skip_sms = skip_sms;
+    let cloned_notify_on_reply = args.notify_on_reply;
     tracing::info!(
         "SEND_FLOW About to tokio::spawn delayed send task for user={}, room_id={:?}, chat_id={:?}",
         user_id,
@@ -809,6 +822,38 @@ pub async fn handle_send_chat_message(
                         cloned_user_id,
                         msg.room_id
                     );
+                    if cloned_notify_on_reply {
+                        let watch_room = msg.room_id.clone().or_else(|| cloned_room_id.clone());
+                        match watch_room {
+                            Some(room) => {
+                                let identifier = cloned_chat_id
+                                    .clone()
+                                    .unwrap_or_else(|| cloned_exact_name.clone());
+                                match cloned_state.pending_reply_watches_repository.arm_bridge(
+                                    cloned_user_id,
+                                    &room,
+                                    &identifier,
+                                    &cloned_exact_name,
+                                ) {
+                                    Ok(_) => {
+                                        tracing::info!(
+                                        "REPLY_WATCH armed bridge watch user={} room={} contact={}",
+                                        cloned_user_id, room, cloned_exact_name
+                                    )
+                                    }
+                                    Err(e) => tracing::warn!(
+                                        "REPLY_WATCH failed to arm bridge watch user={}: {}",
+                                        cloned_user_id,
+                                        e
+                                    ),
+                                }
+                            }
+                            None => tracing::warn!(
+                                "REPLY_WATCH cannot arm bridge watch user={}: no room_id available",
+                                cloned_user_id
+                            ),
+                        }
+                    }
                 }
                 Err(e) => {
                     tracing::error!(

--- a/backend/src/tool_call_utils/email.rs
+++ b/backend/src/tool_call_utils/email.rs
@@ -48,6 +48,16 @@ pub fn get_send_email_tool_for_user(emails: &[String]) -> openai_api_rs::v1::cha
             }),
         );
     }
+    properties.insert(
+        "notify_on_reply".to_string(),
+        Box::new(types::JSONSchemaDefine {
+            schema_type: Some(types::JSONSchemaType::Boolean),
+            description: Some(
+                "Optional. Defaults to false. Set to true ONLY when the user explicitly asks to be told when the recipient replies (e.g. \"email Sara and let me know what she says\"). When true, the first email from that recipient to the same account in the next 24 hours is forwarded to the user via SMS. After that one reply, the watch ends automatically.".to_string()
+            ),
+            ..Default::default()
+        }),
+    );
     chat_completion::Tool {
         r#type: chat_completion::ToolType::Function,
         function: types::Function {
@@ -109,6 +119,16 @@ pub fn get_respond_to_email_tool_for_user(
             }),
         );
     }
+    properties.insert(
+        "notify_on_reply".to_string(),
+        Box::new(types::JSONSchemaDefine {
+            schema_type: Some(types::JSONSchemaType::Boolean),
+            description: Some(
+                "Optional. Defaults to false. Set to true ONLY when the user explicitly asks to be told when the recipient replies back. When true, the first email from that recipient to the same account in the next 24 hours is forwarded to the user via SMS. After that one reply, the watch ends automatically.".to_string()
+            ),
+            ..Default::default()
+        }),
+    );
     chat_completion::Tool {
         r#type: chat_completion::ToolType::Function,
         function: types::Function {
@@ -166,6 +186,8 @@ pub struct SendEmailArgs {
     pub subject: String,
     pub body: String,
     pub from: Option<String>,
+    #[serde(default)]
+    pub notify_on_reply: bool,
 }
 pub async fn handle_send_email(
     state: &Arc<AppState>,
@@ -278,6 +300,13 @@ pub async fn handle_send_email(
     let cloned_body = args.body.clone();
     let cloned_from = Some(from_email);
     let cloned_skip_sms = skip_sms;
+    let cloned_notify_on_reply = args.notify_on_reply;
+    let cloned_imap_connection_id = sender_account.id;
+    let cloned_recipient_display = if args.to.contains('@') {
+        recipient_email.clone()
+    } else {
+        args.to.clone()
+    };
     tokio::spawn(async move {
         let reason = tokio::select! {
             _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => "timeout",
@@ -285,7 +314,7 @@ pub async fn handle_send_email(
         };
         if reason == "timeout" {
             let email_request = crate::handlers::imap_handlers::SendEmailRequest {
-                to: cloned_to,
+                to: cloned_to.clone(),
                 subject: cloned_subject,
                 body: cloned_body,
                 from: cloned_from,
@@ -301,7 +330,35 @@ pub async fn handle_send_email(
             .await
             {
                 Ok(_) => {
-                    // No need to send success message
+                    if cloned_notify_on_reply {
+                        if let Some(key) =
+                            crate::handlers::imap_handlers::normalize_email_sender_key(&cloned_to)
+                        {
+                            match cloned_state.pending_reply_watches_repository.arm_email(
+                                cloned_user_id,
+                                cloned_imap_connection_id,
+                                &key,
+                                &cloned_recipient_display,
+                            ) {
+                                Ok(_) => {
+                                    tracing::info!(
+                                    "REPLY_WATCH armed email watch user={} account={} recipient={}",
+                                    cloned_user_id, cloned_imap_connection_id, key
+                                )
+                                }
+                                Err(e) => tracing::warn!(
+                                    "REPLY_WATCH failed to arm email watch user={}: {}",
+                                    cloned_user_id,
+                                    e
+                                ),
+                            }
+                        } else {
+                            tracing::warn!(
+                                "REPLY_WATCH skipping email watch user={}: recipient '{}' did not normalize",
+                                cloned_user_id, cloned_to
+                            );
+                        }
+                    }
                 }
                 Err((_, error_json)) => {
                     let error_msg = format!(
@@ -351,6 +408,8 @@ pub struct RespondToEmailArgs {
     pub email_id: String,
     pub response_text: String,
     pub from: Option<String>,
+    #[serde(default)]
+    pub notify_on_reply: bool,
 }
 pub async fn handle_respond_to_email(
     state: &Arc<AppState>,
@@ -431,6 +490,20 @@ pub async fn handle_respond_to_email(
         .and_then(|s| s.as_str())
         .unwrap_or("Unknown subject")
         .to_string();
+    let original_from_email = email_details
+        .0
+        .get("email")
+        .and_then(|e| e.get("from_email"))
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string());
+    let original_from_display = email_details
+        .0
+        .get("email")
+        .and_then(|e| e.get("from"))
+        .and_then(|s| s.as_str())
+        .map(|s| s.to_string())
+        .or_else(|| original_from_email.clone())
+        .unwrap_or_else(|| "Unknown sender".to_string());
     // Format the queued message using the subject
     let queued_msg = format!(
         "Will respond to email '{}' with '{}' in 60s. Reply 'C' to discard.",
@@ -469,6 +542,10 @@ pub async fn handle_respond_to_email(
     let cloned_response_text = args.response_text.clone();
     let cloned_from = Some(from_email);
     let cloned_skip_sms = skip_sms;
+    let cloned_notify_on_reply = args.notify_on_reply;
+    let cloned_imap_connection_id = sender_account.id;
+    let cloned_original_from_email = original_from_email;
+    let cloned_original_from_display = original_from_display;
     tokio::spawn(async move {
         let reason = tokio::select! {
             _ = tokio::time::sleep(std::time::Duration::from_secs(60)) => "timeout",
@@ -491,7 +568,33 @@ pub async fn handle_respond_to_email(
             .await
             {
                 Ok(_) => {
-                    // No need to send success message
+                    if cloned_notify_on_reply {
+                        match cloned_original_from_email.as_deref().and_then(
+                            crate::handlers::imap_handlers::normalize_email_sender_key,
+                        ) {
+                            Some(key) => {
+                                match cloned_state.pending_reply_watches_repository.arm_email(
+                                    cloned_user_id,
+                                    cloned_imap_connection_id,
+                                    &key,
+                                    &cloned_original_from_display,
+                                ) {
+                                    Ok(_) => tracing::info!(
+                                        "REPLY_WATCH armed email watch user={} account={} recipient={}",
+                                        cloned_user_id, cloned_imap_connection_id, key
+                                    ),
+                                    Err(e) => tracing::warn!(
+                                        "REPLY_WATCH failed to arm email watch user={}: {}",
+                                        cloned_user_id, e
+                                    ),
+                                }
+                            }
+                            None => tracing::warn!(
+                                "REPLY_WATCH skipping email watch user={}: no sender email for replied email",
+                                cloned_user_id
+                            ),
+                        }
+                    }
                 }
                 Err((_, error_json)) => {
                     let error_msg = format!(

--- a/backend/src/utils/bridge.rs
+++ b/backend/src/utils/bridge.rs
@@ -2271,6 +2271,13 @@ pub async fn handle_bridge_message(
     let chat_name = remove_bridge_suffix(room_name.as_str());
     let current_room_id = room.room_id().to_string();
 
+    // Skip WhatsApp "Status Broadcast" (the disappearing-stories pseudo-chat
+    // mautrix-whatsapp creates for status@broadcast). Every status post from
+    // any contact lands here and is noise for digests/notifications.
+    if service == "whatsapp" && chat_name.to_lowercase().contains("status broadcast") {
+        return;
+    }
+
     // Skip bridge-generated error notices so they are logged but never treated
     // as user messages for notification/proactive rules.
     if is_error_message(&content) {

--- a/backend/src/utils/bridge.rs
+++ b/backend/src/utils/bridge.rs
@@ -2346,12 +2346,17 @@ pub async fn handle_bridge_message(
     let person_name: Option<String> = matching_person
         .as_ref()
         .map(|p| p.display_name().to_string());
+    // Use the bridged sender's matrix user id as the stable per-sender key.
+    // Bridge ghosts have a canonical form like @_telegram_<id>:homeserver, so
+    // the full mxid is unique per external sender and survives display-name
+    // changes. Falls back to None when localpart is unavailable.
+    let sender_key_value = Some(event.sender.to_string());
     let msg = crate::models::ontology_models::NewOntMessage {
         user_id,
         room_id: current_room_id.clone(),
         platform: service.clone(),
         sender_name: chat_name.clone(),
-        sender_key: None,
+        sender_key: sender_key_value,
         content: content.clone(),
         person_id,
         created_at: std::time::SystemTime::now()
@@ -2375,6 +2380,7 @@ pub async fn handle_bridge_message(
                     "platform": msg.platform,
                     "sender": msg.sender_name,
                     "sender_name": msg.sender_name,
+                    "sender_key": msg.sender_key,
                     "content": msg.content,
                     "room_id": msg.room_id,
                     "is_group": is_group,

--- a/backend/src/utils/bridge.rs
+++ b/backend/src/utils/bridge.rs
@@ -2192,6 +2192,74 @@ pub async fn handle_bridge_message(
         return;
     }
 
+    // Pending reply watch: if the user armed one for this room, SMS them
+    // the first inbound message from the recipient and clear the watch.
+    // Runs before the tier-2/auto-features gates because the user has
+    // already paid for SMS and explicitly asked to be told.
+    {
+        let watch_content = match &event.content.msgtype {
+            MessageType::Text(t) => t.body.clone(),
+            MessageType::Notice(n) => n.body.clone(),
+            MessageType::Emote(t) => t.body.clone(),
+            MessageType::Image(_) => "[image]".to_string(),
+            MessageType::Video(_) => "[video]".to_string(),
+            MessageType::File(_) => "[file]".to_string(),
+            MessageType::Audio(_) => "[audio]".to_string(),
+            MessageType::Location(_) => "[location]".to_string(),
+            _ => String::new(),
+        };
+        let room_id_for_watch = room.room_id().to_string();
+        match state
+            .pending_reply_watches_repository
+            .find_active_bridge(user_id, &room_id_for_watch)
+        {
+            Ok(Some(watch)) => {
+                let body = if watch_content.is_empty() {
+                    format!("Reply from {}: (no text)", watch.contact_display_name)
+                } else {
+                    format!(
+                        "Reply from {}: {}",
+                        watch.contact_display_name, watch_content
+                    )
+                };
+                // Only clear the watch once we've successfully notified the
+                // user. If the SMS fails (e.g. transient Twilio outage), leave
+                // the watch armed so the next inbound message retries.
+                match state.channel_router.send_to_user(&user, &body, None).await {
+                    Ok(_) => {
+                        if let Err(e) = state.pending_reply_watches_repository.delete(watch.id) {
+                            tracing::warn!(
+                                "REPLY_WATCH failed to delete fired watch id={}: {}",
+                                watch.id,
+                                e
+                            );
+                        } else {
+                            tracing::info!(
+                                "REPLY_WATCH fired+cleared bridge watch id={} user={} room={}",
+                                watch.id,
+                                user_id,
+                                room_id_for_watch
+                            );
+                        }
+                    }
+                    Err(e) => tracing::warn!(
+                        "REPLY_WATCH SMS failed user={} watch={}, leaving armed for retry: {}",
+                        user_id,
+                        watch.id,
+                        e
+                    ),
+                }
+            }
+            Ok(None) => {}
+            Err(e) => tracing::warn!(
+                "REPLY_WATCH lookup failed user={} room={}: {}",
+                user_id,
+                room_id_for_watch,
+                e
+            ),
+        }
+    }
+
     // Check subscription
     let has_valid_sub = state
         .user_repository

--- a/backend/src/utils/embedding_service.rs
+++ b/backend/src/utils/embedding_service.rs
@@ -1,0 +1,89 @@
+//! Thin embedding client for commitment similarity memory.
+//!
+//! Hits an OpenAI-compatible `/v1/embeddings` endpoint via the same Tinfoil /
+//! OpenRouter setup the rest of the AI pipeline uses. Defaults to Tinfoil's
+//! `nomic-embed-text` so user content stays inside the same verified-inference
+//! trust boundary as the chat completion path. Override via env:
+//!
+//!   COMMITMENT_EMBEDDING_PROVIDER  one of "tinfoil" | "openrouter" | "none"
+//!                                  (default: "tinfoil")
+//!   COMMITMENT_EMBEDDING_MODEL     model name passed to /v1/embeddings
+//!                                  (default: "nomic-embed-text" on tinfoil,
+//!                                  required for non-tinfoil providers)
+//!
+//! Setting `COMMITMENT_EMBEDDING_PROVIDER=none` disables the feature -
+//! `generate_embedding` returns `Ok(None)` and callers gracefully skip the
+//! similarity check.
+
+use openai_api_rs::v1::embedding::EmbeddingRequest;
+
+use crate::AiConfig;
+
+/// Tinfoil's verified-inference embedding model. Selected as default because
+/// it's open-weight (nomic-ai/nomic-embed-text-v1.5), produces compact 768-d
+/// vectors, and runs in the same Tinfoil trust boundary as the chat models.
+const DEFAULT_TINFOIL_EMBEDDING_MODEL: &str = "nomic-embed-text";
+
+enum ProviderChoice {
+    Tinfoil,
+    OpenRouter,
+    Disabled,
+}
+
+/// Resolve the embedding provider from env. Falls back to Tinfoil.
+fn provider_from_env() -> ProviderChoice {
+    match std::env::var("COMMITMENT_EMBEDDING_PROVIDER")
+        .ok()
+        .as_deref()
+        .map(str::trim)
+    {
+        Some("none") => ProviderChoice::Disabled,
+        Some("openrouter") => ProviderChoice::OpenRouter,
+        _ => ProviderChoice::Tinfoil,
+    }
+}
+
+/// Generate an embedding for `text`. Returns `Ok(None)` when the feature is
+/// explicitly disabled or no model can be resolved (e.g. a non-tinfoil
+/// provider without `COMMITMENT_EMBEDDING_MODEL` set) so callers can branch
+/// off without an error path. Returns `Err` only when the provider call
+/// actually fails - the caller should log and continue without similarity.
+pub async fn generate_embedding(
+    ai_config: &AiConfig,
+    text: &str,
+) -> Result<Option<Vec<f32>>, String> {
+    let provider = match provider_from_env() {
+        ProviderChoice::Disabled => return Ok(None),
+        ProviderChoice::Tinfoil => crate::AiProvider::Tinfoil,
+        ProviderChoice::OpenRouter => crate::AiProvider::OpenRouter,
+    };
+
+    let env_model = std::env::var("COMMITMENT_EMBEDDING_MODEL")
+        .ok()
+        .filter(|m| !m.trim().is_empty());
+
+    let model = match (env_model, provider) {
+        (Some(m), _) => m,
+        (None, crate::AiProvider::Tinfoil) => DEFAULT_TINFOIL_EMBEDDING_MODEL.to_string(),
+        (None, _) => return Ok(None),
+    };
+    let client = ai_config
+        .create_client(provider)
+        .map_err(|e| format!("embedding client build failed: {}", e))?;
+
+    let req = EmbeddingRequest::new(model, vec![text.to_string()]);
+
+    let response = client
+        .embedding(req)
+        .await
+        .map_err(|e| format!("embedding request failed: {}", e))?;
+
+    let embedding = response
+        .data
+        .into_iter()
+        .next()
+        .map(|d| d.embedding)
+        .ok_or_else(|| "embedding response had no data".to_string())?;
+
+    Ok(Some(embedding))
+}

--- a/backend/src/utils/embedding_similarity.rs
+++ b/backend/src/utils/embedding_similarity.rs
@@ -20,7 +20,7 @@ pub fn pack_embedding(embedding: &[f32]) -> Vec<u8> {
 /// Unpack a BYTEA-stored embedding back into f32 values. Returns None when the
 /// byte length is not a multiple of 4.
 pub fn unpack_embedding(bytes: &[u8]) -> Option<Vec<f32>> {
-    if bytes.len() % 4 != 0 {
+    if !bytes.len().is_multiple_of(4) {
         return None;
     }
     let mut out = Vec::with_capacity(bytes.len() / 4);

--- a/backend/src/utils/embedding_similarity.rs
+++ b/backend/src/utils/embedding_similarity.rs
@@ -1,0 +1,124 @@
+//! Embedding similarity helpers for the commitment detection signal memory.
+//!
+//! Embeddings are persisted as raw little-endian f32 bytes in
+//! `commitment_label_embeddings.embedding`. These helpers convert between the
+//! BYTEA representation and an `f32` slice, and provide brute-force cosine
+//! similarity against a candidate set. Brute force is fine at the per-user
+//! scale (hundreds of vectors at most). If/when it isn't, swap the backing
+//! store for pgvector and use this module only for tests.
+
+/// Pack an embedding (slice of f32) into a little-endian byte buffer suitable
+/// for storage in a BYTEA column.
+pub fn pack_embedding(embedding: &[f32]) -> Vec<u8> {
+    let mut out = Vec::with_capacity(embedding.len() * 4);
+    for v in embedding {
+        out.extend_from_slice(&v.to_le_bytes());
+    }
+    out
+}
+
+/// Unpack a BYTEA-stored embedding back into f32 values. Returns None when the
+/// byte length is not a multiple of 4.
+pub fn unpack_embedding(bytes: &[u8]) -> Option<Vec<f32>> {
+    if bytes.len() % 4 != 0 {
+        return None;
+    }
+    let mut out = Vec::with_capacity(bytes.len() / 4);
+    for chunk in bytes.chunks_exact(4) {
+        let arr: [u8; 4] = [chunk[0], chunk[1], chunk[2], chunk[3]];
+        out.push(f32::from_le_bytes(arr));
+    }
+    Some(out)
+}
+
+/// Cosine similarity between two equal-length f32 vectors. Returns 0.0 when
+/// either vector is the zero vector (no meaningful similarity).
+pub fn cosine_similarity(a: &[f32], b: &[f32]) -> f32 {
+    if a.len() != b.len() {
+        return 0.0;
+    }
+    let mut dot = 0.0f32;
+    let mut na = 0.0f32;
+    let mut nb = 0.0f32;
+    for (x, y) in a.iter().zip(b.iter()) {
+        dot += x * y;
+        na += x * x;
+        nb += y * y;
+    }
+    if na == 0.0 || nb == 0.0 {
+        return 0.0;
+    }
+    dot / (na.sqrt() * nb.sqrt())
+}
+
+/// Return the highest cosine similarity between `query` and any vector in
+/// `candidates`. Returns 0.0 when `candidates` is empty. Skips candidates of
+/// the wrong dimension rather than erroring - in practice this shouldn't
+/// happen, but a model swap could leave older rows of a different size.
+pub fn max_similarity(query: &[f32], candidates: &[Vec<f32>]) -> f32 {
+    candidates
+        .iter()
+        .filter(|c| c.len() == query.len())
+        .map(|c| cosine_similarity(query, c))
+        .fold(0.0f32, |best, s| if s > best { s } else { best })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pack_unpack_roundtrip() {
+        let original = vec![0.1f32, -0.2, 0.3, 0.4];
+        let packed = pack_embedding(&original);
+        let unpacked = unpack_embedding(&packed).unwrap();
+        for (a, b) in original.iter().zip(unpacked.iter()) {
+            assert!((a - b).abs() < f32::EPSILON);
+        }
+    }
+
+    #[test]
+    fn cosine_identical_is_one() {
+        let v = vec![1.0, 2.0, 3.0];
+        assert!((cosine_similarity(&v, &v) - 1.0).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_orthogonal_is_zero() {
+        let a = vec![1.0, 0.0];
+        let b = vec![0.0, 1.0];
+        assert!(cosine_similarity(&a, &b).abs() < 1e-6);
+    }
+
+    #[test]
+    fn cosine_zero_vector_returns_zero() {
+        let z = vec![0.0, 0.0, 0.0];
+        let v = vec![1.0, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&z, &v), 0.0);
+    }
+
+    #[test]
+    fn cosine_mismatched_length_returns_zero() {
+        let a = vec![1.0, 2.0];
+        let b = vec![1.0, 2.0, 3.0];
+        assert_eq!(cosine_similarity(&a, &b), 0.0);
+    }
+
+    #[test]
+    fn unpack_invalid_length_returns_none() {
+        assert!(unpack_embedding(&[1, 2, 3]).is_none());
+    }
+
+    #[test]
+    fn max_similarity_picks_best_match() {
+        let query = vec![1.0, 0.0, 0.0];
+        let candidates = vec![
+            vec![0.0, 1.0, 0.0], // orthogonal
+            vec![0.5, 0.5, 0.0], // 45-degree
+            vec![0.9, 0.1, 0.0], // close to query
+        ];
+        let best = max_similarity(&query, &candidates);
+        // Closest is candidate[2], cosine ~0.994
+        assert!(best > 0.99);
+    }
+}

--- a/backend/src/utils/twilio_error_codes.rs
+++ b/backend/src/utils/twilio_error_codes.rs
@@ -1,11 +1,11 @@
-/// Twilio SMS error code decoder.
-///
-/// Maps Twilio error codes to a human-readable title, likely cause, and
-/// suggested action. Used to enrich the failed-SMS admin alerts so a code
-/// like "30007" turns into "Carrier filtering (10DLC compliance issue)"
-/// with an actionable next step.
-///
-/// Source: https://www.twilio.com/docs/api/errors
+//! Twilio SMS error code decoder.
+//!
+//! Maps Twilio error codes to a human-readable title, likely cause, and
+//! suggested action. Used to enrich the failed-SMS admin alerts so a code
+//! like "30007" turns into "Carrier filtering (10DLC compliance issue)"
+//! with an actionable next step.
+//!
+//! Source: https://www.twilio.com/docs/api/errors
 
 /// Whether the failure is something we can act on or routine carrier noise.
 ///

--- a/backend/tests/channels_router_test.rs
+++ b/backend/tests/channels_router_test.rs
@@ -372,3 +372,154 @@ fn pick_channel_us_falls_back_to_telnyx_when_twilio_missing() {
         "telnyx"
     );
 }
+
+// ===== Provider-routes fallback tests =====
+//
+// A channel that fails on demand so we can simulate "primary carrier
+// dropped this message" and assert that the router falls through to
+// the next provider with the [Lightfriend backup] prefix.
+struct FailingChannel {
+    id: &'static str,
+    fail_until_attempt: AtomicUsize,
+    attempts: AtomicUsize,
+    last_body: std::sync::Mutex<String>,
+}
+
+impl FailingChannel {
+    fn new(id: &'static str, fail_n_times: usize) -> Self {
+        Self {
+            id,
+            fail_until_attempt: AtomicUsize::new(fail_n_times),
+            attempts: AtomicUsize::new(0),
+            last_body: std::sync::Mutex::new(String::new()),
+        }
+    }
+}
+
+#[async_trait]
+impl MessageChannel for FailingChannel {
+    fn id(&self) -> &'static str {
+        self.id
+    }
+    async fn send(
+        &self,
+        _user: &User,
+        _address: &str,
+        body: &str,
+        _media: Option<MediaRef>,
+    ) -> Result<ChannelMessageId, ChannelError> {
+        let attempt = self.attempts.fetch_add(1, Ordering::SeqCst) + 1;
+        *self.last_body.lock().unwrap() = body.to_string();
+        if attempt <= self.fail_until_attempt.load(Ordering::SeqCst) {
+            Err(ChannelError::SendFailed(format!(
+                "simulated fail {}",
+                attempt
+            )))
+        } else {
+            Ok(ChannelMessageId(format!("{}-{}", self.id, attempt)))
+        }
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn route_drives_provider_order() {
+    // Admin set US to telnyx-first, twilio-fallback. Router must honor it
+    // even though the hardcoded default would pick twilio.
+    let twilio = Arc::new(RecordingChannel::new("twilio"));
+    let telnyx = Arc::new(RecordingChannel::new("telnyx"));
+    let mut router = ChannelRouter::new();
+    router.register(twilio.clone());
+    router.register(telnyx.clone());
+    router.set_route("US", vec!["telnyx".to_string(), "twilio".to_string()]);
+
+    let user = user_with_phone("+12025551234");
+    let result = router.send_to_user(&user, "hello", None).await.unwrap();
+
+    assert_eq!(result.as_str(), "telnyx-1");
+    assert_eq!(telnyx.send_count(), 1);
+    assert_eq!(twilio.send_count(), 0);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn falls_through_to_next_provider_on_error() {
+    // Twilio fails the first attempt. Telnyx should be tried with the
+    // [Lightfriend backup] prefix and the message reaches the user.
+    let failing_twilio = Arc::new(FailingChannel::new("twilio", 1));
+    let telnyx = Arc::new(RecordingChannel::new("telnyx"));
+    let mut router = ChannelRouter::new();
+    router.register(failing_twilio.clone());
+    router.register(telnyx.clone());
+    router.set_route("US", vec!["twilio".to_string(), "telnyx".to_string()]);
+
+    let user = user_with_phone("+12025551234");
+    let result = router.send_to_user(&user, "hello", None).await.unwrap();
+
+    assert_eq!(result.as_str(), "telnyx-1");
+    assert_eq!(failing_twilio.attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(telnyx.send_count(), 1);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn fallback_body_has_lightfriend_backup_prefix() {
+    // Capture body each provider receives. First attempt unchanged, second
+    // attempt prefixed so the recipient knows it's still legit Lightfriend.
+    use backend::channels::router::FALLBACK_PREFIX;
+
+    let failing_twilio = Arc::new(FailingChannel::new("twilio", 1));
+    let telnyx = Arc::new(FailingChannel::new("telnyx", 0));
+    let mut router = ChannelRouter::new();
+    router.register(failing_twilio.clone());
+    router.register(telnyx.clone());
+    router.set_route("US", vec!["twilio".to_string(), "telnyx".to_string()]);
+
+    let user = user_with_phone("+12025551234");
+    router.send_to_user(&user, "hello", None).await.unwrap();
+
+    let twilio_body = failing_twilio.last_body.lock().unwrap().clone();
+    let telnyx_body = telnyx.last_body.lock().unwrap().clone();
+    assert_eq!(twilio_body, "hello");
+    assert_eq!(telnyx_body, format!("{}hello", FALLBACK_PREFIX));
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn all_providers_failing_returns_last_error() {
+    // Every provider in the chain errors. send_to_user surfaces the last
+    // error rather than silently succeeding.
+    let twilio = Arc::new(FailingChannel::new("twilio", 999));
+    let telnyx = Arc::new(FailingChannel::new("telnyx", 999));
+    let mut router = ChannelRouter::new();
+    router.register(twilio.clone());
+    router.register(telnyx.clone());
+    router.set_route("US", vec!["twilio".to_string(), "telnyx".to_string()]);
+
+    let user = user_with_phone("+12025551234");
+    let err = router.send_to_user(&user, "hello", None).await.unwrap_err();
+
+    assert!(matches!(err, ChannelError::SendFailed(_)));
+    assert_eq!(twilio.attempts.load(Ordering::SeqCst), 1);
+    assert_eq!(telnyx.attempts.load(Ordering::SeqCst), 1);
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn clear_route_reverts_to_default() {
+    let twilio = Arc::new(RecordingChannel::new("twilio"));
+    let telnyx = Arc::new(RecordingChannel::new("telnyx"));
+    let mut router = ChannelRouter::new();
+    router.register(twilio.clone());
+    router.register(telnyx.clone());
+
+    router.set_route("US", vec!["telnyx".to_string()]);
+    router.clear_route("US");
+
+    let user = user_with_phone("+12025551234");
+    router.send_to_user(&user, "hello", None).await.unwrap();
+
+    // Cleared → default picks twilio.
+    assert_eq!(twilio.send_count(), 1);
+    assert_eq!(telnyx.send_count(), 0);
+}

--- a/backend/tests/imap_idle_test.rs
+++ b/backend/tests/imap_idle_test.rs
@@ -43,7 +43,7 @@ async fn test_insert_email_creates_ont_message() {
         .get_persons_with_channels(user.id, 500, 0)
         .unwrap_or_default();
 
-    let id = insert_email_into_ontology(&state, user.id, &preview, &persons)
+    let id = insert_email_into_ontology(&state, user.id, &preview, &persons, None)
         .await
         .expect("insertion should succeed");
 
@@ -74,10 +74,10 @@ async fn test_insert_email_is_idempotent() {
     let preview = make_preview("42", "bob@example.com", "subject");
     let persons = Vec::new();
 
-    let id1 = insert_email_into_ontology(&state, user.id, &preview, &persons)
+    let id1 = insert_email_into_ontology(&state, user.id, &preview, &persons, None)
         .await
         .unwrap();
-    let id2 = insert_email_into_ontology(&state, user.id, &preview, &persons)
+    let id2 = insert_email_into_ontology(&state, user.id, &preview, &persons, None)
         .await
         .unwrap();
 
@@ -126,7 +126,7 @@ async fn test_insert_email_dedup_against_preexisting_row() {
     let preview = make_preview("99", "carol@example.com", "idle subject");
     let persons = Vec::new();
 
-    let returned_id = insert_email_into_ontology(&state, user.id, &preview, &persons)
+    let returned_id = insert_email_into_ontology(&state, user.id, &preview, &persons, None)
         .await
         .unwrap();
 
@@ -161,10 +161,10 @@ async fn test_insert_email_isolates_users() {
     let preview = make_preview("7", "dave@example.com", "cross-user");
     let persons = Vec::new();
 
-    let id_a = insert_email_into_ontology(&state, user_a.id, &preview, &persons)
+    let id_a = insert_email_into_ontology(&state, user_a.id, &preview, &persons, None)
         .await
         .unwrap();
-    let id_b = insert_email_into_ontology(&state, user_b.id, &preview, &persons)
+    let id_b = insert_email_into_ontology(&state, user_b.id, &preview, &persons, None)
         .await
         .unwrap();
 
@@ -212,7 +212,7 @@ async fn test_insert_email_matches_person_by_email_channel() {
 
     let preview = make_preview("100", "Dave@Example.COM", "mixed case test");
 
-    let id = insert_email_into_ontology(&state, user.id, &preview, &persons)
+    let id = insert_email_into_ontology(&state, user.id, &preview, &persons, None)
         .await
         .unwrap();
 

--- a/backend/tests/kani_signature_proofs.rs
+++ b/backend/tests/kani_signature_proofs.rs
@@ -1,0 +1,143 @@
+//! Kani proofs for webhook signature verification.
+//!
+//! Unlike fuzz harnesses (probabilistic, finite-time), Kani uses symbolic
+//! execution via CBMC to prove a property holds for ALL inputs within
+//! the stated bounds. A proof that finishes is a real mathematical result.
+//!
+//! Scope: we target the pre-crypto input handling. Kani cannot practically
+//! symbolically execute SHA-1's compression function or Ed25519's scalar
+//! multiplication in bounded time, so proofs about HMAC/Ed25519 internals
+//! belong to the underlying audited crypto libraries (or to a dedicated
+//! verified crypto stack like HACL*). What WE wrote is the validation
+//! wrapper around those primitives - and that's what we prove here.
+//!
+//! Run with: `cargo kani --tests --harness <harness_name>`
+//! Or all proofs in this file: `cargo kani --tests`
+//!
+//! Kani is gated behind `#[cfg(kani)]` so this file is invisible to
+//! `cargo test` and `cargo check`. It only compiles when Kani is driving
+//! the build.
+
+#![cfg(kani)]
+
+use backend::api::telnyx_utils::verify_telnyx_signature;
+use backend::api::twilio_utils::verify_twilio_signature;
+use std::collections::BTreeMap;
+
+// =============================================================================
+// Telnyx: pre-crypto validation paths
+// =============================================================================
+
+/// PROOF: a public key shorter than 32 bytes is always rejected with an
+/// Err whose message starts with "public key". Holds for ANY signature
+/// bytes, ANY timestamp, ANY body of bounded size. No panic possible.
+#[kani::proof]
+#[kani::unwind(4)]
+fn proof_telnyx_short_public_key_rejected() {
+    let key_len: usize = kani::any();
+    kani::assume(key_len < 32);
+    kani::assume(key_len <= 8); // bound input space
+
+    let key: [u8; 8] = kani::any();
+    let sig: [u8; 64] = kani::any();
+    let body: [u8; 4] = kani::any();
+    let ts = "1";
+
+    let result = verify_telnyx_signature(&key[..key_len], &sig, ts, &body);
+    let err = result.unwrap_err();
+    assert!(err.starts_with("public key"));
+}
+
+/// PROOF: a public key longer than 32 bytes is always rejected. Pairs
+/// with the short-key proof to fully cover the length-check branch.
+#[kani::proof]
+#[kani::unwind(4)]
+fn proof_telnyx_long_public_key_rejected() {
+    let key: [u8; 64] = kani::any();
+    let key_len: usize = kani::any();
+    kani::assume(key_len > 32 && key_len <= 64);
+
+    let sig: [u8; 64] = kani::any();
+    let body: [u8; 4] = kani::any();
+    let ts = "1";
+
+    let result = verify_telnyx_signature(&key[..key_len], &sig, ts, &body);
+    let err = result.unwrap_err();
+    assert!(err.starts_with("public key"));
+}
+
+/// PROOF: a signature whose byte length is anything other than 64 is
+/// rejected with a signature-length error. Holds even when the public
+/// key is the right length (so we get past the first check).
+#[kani::proof]
+#[kani::unwind(4)]
+fn proof_telnyx_wrong_signature_length_rejected() {
+    let key: [u8; 32] = kani::any();
+    let sig: [u8; 128] = kani::any();
+    let sig_len: usize = kani::any();
+    kani::assume(sig_len != 64 && sig_len <= 128);
+
+    let body: [u8; 4] = kani::any();
+    let ts = "1";
+
+    let result = verify_telnyx_signature(&key, &sig[..sig_len], ts, &body);
+    // Either the public key fails to parse (rare random key) or the
+    // signature length check fires. Both must be Err - never Ok, never panic.
+    assert!(result.is_err());
+}
+
+// =============================================================================
+// Twilio: input handling paths
+// =============================================================================
+//
+// We can prove Twilio rejects malformed base64 without invoking HMAC,
+// because base64 decode happens before mac.verify_slice. Anything that
+// reaches mac.verify_slice would require symbolically executing SHA-1,
+// which CBMC will not finish in reasonable time. That property is what
+// the fuzz harness in backend/fuzz/ covers instead.
+
+/// PROOF: any signature string containing a byte that is invalid base64
+/// produces an Err (never a panic, never an Ok). We use a single non-
+/// base64 byte at a known position to keep the input space small enough
+/// for Kani to enumerate.
+#[kani::proof]
+#[kani::unwind(8)]
+fn proof_twilio_invalid_base64_signature_rejected() {
+    // ASCII '!' (0x21) is not in the base64 alphabet. Any signature
+    // string containing it must be rejected by the base64 decoder.
+    let token: [u8; 4] = kani::any();
+    let token_str = match std::str::from_utf8(&token) {
+        Ok(s) => s,
+        Err(_) => return, // skip non-UTF-8; not the property under test
+    };
+
+    let params = BTreeMap::new();
+    let result = verify_twilio_signature("u", &params, "!!!!", token_str);
+    assert!(result.is_err());
+}
+
+/// PROOF: when params is empty, the function still terminates without
+/// panic for any URL, signature, and token of bounded size. (Empty
+/// BTreeMap iteration is the trivial case Kani CAN check; symbolic
+/// BTreeMap contents would not finish.)
+#[kani::proof]
+#[kani::unwind(8)]
+fn proof_twilio_empty_params_no_panic() {
+    let url_bytes: [u8; 4] = kani::any();
+    let token_bytes: [u8; 4] = kani::any();
+
+    let url = match std::str::from_utf8(&url_bytes) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+    let token = match std::str::from_utf8(&token_bytes) {
+        Ok(s) => s,
+        Err(_) => return,
+    };
+
+    let params = BTreeMap::new();
+    // Use a fixed, valid-base64 signature so we exercise the full path
+    // but keep symbolic load away from the SHA-1 compression function.
+    let _ = verify_twilio_signature(url, &params, "AAAA", token);
+    // Reaching here means no panic. Kani checks this implicitly.
+}

--- a/backend/tests/webhook_sms_test.rs
+++ b/backend/tests/webhook_sms_test.rs
@@ -1,0 +1,354 @@
+//! Repository-level tests for the webhook-triggered SMS feature.
+//!
+//! These tests exercise the cap-claim transaction, the idempotency
+//! reservation, and revoke semantics directly through the repository —
+//! the HTTP handler is a thin wrapper that maps these outcomes to
+//! status codes, so covering the repository covers the dangerous logic.
+
+use backend::models::user_models::NewWebhookToken;
+use backend::repositories::webhook_tokens_repository::{ClaimResult, IdempotencyResult};
+use backend::test_utils::{create_test_state, create_test_user, TestUserParams};
+use serial_test::serial;
+use sha2::{Digest, Sha256};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+fn now_unix() -> i32 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i32
+}
+
+fn next_utc_midnight(now: i32) -> i32 {
+    let day = 86_400;
+    ((now / day) + 1) * day
+}
+
+fn hash(raw: &str) -> String {
+    let mut h = Sha256::new();
+    h.update(raw.as_bytes());
+    hex::encode(h.finalize())
+}
+
+/// Helper: insert a token with the given cap and return (raw, row).
+fn mint(
+    state: &std::sync::Arc<backend::AppState>,
+    user_id: i32,
+    label: &str,
+    cap: i32,
+) -> (String, backend::models::user_models::WebhookToken) {
+    let raw = format!("lf_{}", "a".repeat(32));
+    let token_hash = hash(&raw);
+    let now = now_unix();
+    let row = state
+        .webhook_tokens_repository
+        .create(&NewWebhookToken {
+            user_id,
+            token_hash,
+            token_prefix: raw.chars().take(8).collect(),
+            label: label.to_string(),
+            daily_cap: cap,
+            daily_sent: 0,
+            daily_reset_at: next_utc_midnight(now),
+            created_at: now,
+        })
+        .expect("create webhook token");
+    (raw, row)
+}
+
+#[tokio::test]
+#[serial]
+async fn create_and_lookup_token() {
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+
+    let (raw, row) = mint(&state, user.id, "deploy alerts", 50);
+
+    let found = state
+        .webhook_tokens_repository
+        .find_by_hash(&hash(&raw))
+        .unwrap();
+    assert!(found.is_some());
+    let found = found.unwrap();
+    assert_eq!(found.id, row.id);
+    assert_eq!(found.label, "deploy alerts");
+    assert_eq!(found.daily_cap, 50);
+    assert_eq!(found.daily_sent, 0);
+}
+
+#[tokio::test]
+#[serial]
+async fn unknown_token_hash_returns_none() {
+    let state = create_test_state();
+    let _user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+
+    let res = state
+        .webhook_tokens_repository
+        .find_by_hash(&hash("lf_nonexistent"))
+        .unwrap();
+    assert!(res.is_none());
+}
+
+#[tokio::test]
+#[serial]
+async fn claim_increments_until_cap_then_overcaps() {
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+    let (raw, _row) = mint(&state, user.id, "cap test", 3);
+    let h = hash(&raw);
+
+    for expected_sent in 1..=3 {
+        let res = state.webhook_tokens_repository.claim_send_slot(&h).unwrap();
+        match res {
+            ClaimResult::Ok { token } => assert_eq!(token.daily_sent, expected_sent),
+            other => panic!("expected Ok, got {:?}", other),
+        }
+    }
+
+    // 4th attempt: cap reached.
+    let res = state.webhook_tokens_repository.claim_send_slot(&h).unwrap();
+    match res {
+        ClaimResult::OverCap {
+            daily_cap,
+            daily_sent,
+        } => {
+            assert_eq!(daily_cap, 3);
+            assert_eq!(daily_sent, 3);
+        }
+        other => panic!("expected OverCap, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn revoke_then_claim_returns_revoked() {
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+    let (raw, row) = mint(&state, user.id, "to be revoked", 5);
+
+    let ok = state
+        .webhook_tokens_repository
+        .revoke(user.id, row.id)
+        .unwrap();
+    assert!(ok);
+
+    let res = state
+        .webhook_tokens_repository
+        .claim_send_slot(&hash(&raw))
+        .unwrap();
+    assert!(matches!(res, ClaimResult::Revoked));
+}
+
+#[tokio::test]
+#[serial]
+async fn revoke_is_idempotent_for_same_owner() {
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+    let (_raw, row) = mint(&state, user.id, "double revoke", 5);
+
+    let first = state
+        .webhook_tokens_repository
+        .revoke(user.id, row.id)
+        .unwrap();
+    let second = state
+        .webhook_tokens_repository
+        .revoke(user.id, row.id)
+        .unwrap();
+    assert!(first, "first revoke should succeed");
+    assert!(
+        second,
+        "second revoke should still report success (idempotent)"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn revoke_of_other_users_token_returns_false() {
+    let state = create_test_state();
+    let owner = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+    let attacker = create_test_user(
+        &state,
+        &TestUserParams {
+            email: "attacker@example.com".to_string(),
+            phone_number: "+14155550199".to_string(),
+            credits: 0.0,
+            credits_left: 0.0,
+            sub_tier: Some("tier 2".to_string()),
+        },
+    );
+    let (_raw, row) = mint(&state, owner.id, "owner token", 5);
+
+    let revoked = state
+        .webhook_tokens_repository
+        .revoke(attacker.id, row.id)
+        .unwrap();
+    assert!(!revoked, "attacker must not revoke another user's token");
+}
+
+#[tokio::test]
+#[serial]
+async fn idempotency_fresh_then_inflight_then_replay() {
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+    let (_raw, row) = mint(&state, user.id, "idempotency test", 50);
+
+    // First request: fresh.
+    let first = state
+        .webhook_tokens_repository
+        .reserve_idempotency_key(row.id, "key-1")
+        .unwrap();
+    let row_id = match first {
+        IdempotencyResult::Fresh { id } => id,
+        other => panic!("expected Fresh, got {:?}", other),
+    };
+
+    // Concurrent retry while still in-flight.
+    let second = state
+        .webhook_tokens_repository
+        .reserve_idempotency_key(row.id, "key-1")
+        .unwrap();
+    assert!(
+        matches!(second, IdempotencyResult::InFlight),
+        "second call before complete should be InFlight"
+    );
+
+    // Complete with a fake SID.
+    state
+        .webhook_tokens_repository
+        .complete_idempotency(row_id, "SMxxxx")
+        .unwrap();
+
+    // Third request: replays the cached SID.
+    let third = state
+        .webhook_tokens_repository
+        .reserve_idempotency_key(row.id, "key-1")
+        .unwrap();
+    match third {
+        IdempotencyResult::Replayed { sid } => assert_eq!(sid, "SMxxxx"),
+        other => panic!("expected Replayed, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+#[serial]
+async fn idempotency_clear_lets_retry_succeed() {
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+    let (_raw, row) = mint(&state, user.id, "clear retry", 50);
+
+    let first = state
+        .webhook_tokens_repository
+        .reserve_idempotency_key(row.id, "key-clear")
+        .unwrap();
+    let row_id = match first {
+        IdempotencyResult::Fresh { id } => id,
+        other => panic!("expected Fresh, got {:?}", other),
+    };
+
+    // Send failed; release the in-flight row.
+    state
+        .webhook_tokens_repository
+        .clear_idempotency(row_id)
+        .unwrap();
+
+    // Retry with the same key: should be Fresh again.
+    let second = state
+        .webhook_tokens_repository
+        .reserve_idempotency_key(row.id, "key-clear")
+        .unwrap();
+    assert!(
+        matches!(second, IdempotencyResult::Fresh { .. }),
+        "after clear, retry should be Fresh"
+    );
+}
+
+#[tokio::test]
+#[serial]
+async fn idempotency_keys_are_scoped_per_token() {
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+
+    // Two different tokens for the same user.
+    let raw_a = format!("lf_{}", "a".repeat(32));
+    let raw_b = format!("lf_{}", "b".repeat(32));
+    let now = now_unix();
+    let token_a = state
+        .webhook_tokens_repository
+        .create(&NewWebhookToken {
+            user_id: user.id,
+            token_hash: hash(&raw_a),
+            token_prefix: raw_a.chars().take(8).collect(),
+            label: "alpha".to_string(),
+            daily_cap: 50,
+            daily_sent: 0,
+            daily_reset_at: next_utc_midnight(now),
+            created_at: now,
+        })
+        .unwrap();
+    let token_b = state
+        .webhook_tokens_repository
+        .create(&NewWebhookToken {
+            user_id: user.id,
+            token_hash: hash(&raw_b),
+            token_prefix: raw_b.chars().take(8).collect(),
+            label: "beta".to_string(),
+            daily_cap: 50,
+            daily_sent: 0,
+            daily_reset_at: next_utc_midnight(now),
+            created_at: now,
+        })
+        .unwrap();
+
+    // Same key, different token IDs: both should be Fresh.
+    let res_a = state
+        .webhook_tokens_repository
+        .reserve_idempotency_key(token_a.id, "shared-key")
+        .unwrap();
+    let res_b = state
+        .webhook_tokens_repository
+        .reserve_idempotency_key(token_b.id, "shared-key")
+        .unwrap();
+    assert!(matches!(res_a, IdempotencyResult::Fresh { .. }));
+    assert!(matches!(res_b, IdempotencyResult::Fresh { .. }));
+}
+
+#[tokio::test]
+#[serial]
+async fn claim_after_window_resets_counter() {
+    // Mint a token whose daily_reset_at is already in the past and
+    // daily_sent is at cap. The next claim should reset to 0 then
+    // succeed with daily_sent=1.
+    let state = create_test_state();
+    let user = create_test_user(&state, &TestUserParams::us_user(10.0, 5.0));
+
+    let raw = format!("lf_{}", "c".repeat(32));
+    let token_hash = hash(&raw);
+    let _row = state
+        .webhook_tokens_repository
+        .create(&NewWebhookToken {
+            user_id: user.id,
+            token_hash: token_hash.clone(),
+            token_prefix: raw.chars().take(8).collect(),
+            label: "expired window".to_string(),
+            daily_cap: 1,
+            daily_sent: 1,             // already at cap
+            daily_reset_at: 1_000_000, // long ago
+            created_at: now_unix(),
+        })
+        .unwrap();
+
+    let res = state
+        .webhook_tokens_repository
+        .claim_send_slot(&token_hash)
+        .unwrap();
+    match res {
+        ClaimResult::Ok { token } => {
+            assert_eq!(token.daily_sent, 1, "reset to 0 then incremented");
+            assert!(
+                token.daily_reset_at > now_unix(),
+                "daily_reset_at moved into the future"
+            );
+        }
+        other => panic!("expected Ok after window reset, got {:?}", other),
+    }
+}

--- a/frontend/src/connections/tesla.rs
+++ b/frontend/src/connections/tesla.rs
@@ -76,8 +76,9 @@ pub fn tesla_connect(props: &TeslaConnectProps) -> Html {
                                         ));
                                     }
                                 } else if tesla_status == "success" {
-                                    command_result
-                                        .set(Some("Tesla connected successfully!".to_string()));
+                                    command_result.set(Some(
+                                        "Tesla account connected. To enable vehicle commands (lock, climate, etc.), click 'Setup Virtual Key' below and approve the pairing in your Tesla app.".to_string(),
+                                    ));
                                 }
                                 // Clear URL params after reading
                                 let _ = window.history().and_then(|h| {

--- a/frontend/src/dashboard/settings_panel.rs
+++ b/frontend/src/dashboard/settings_panel.rs
@@ -1,4 +1,5 @@
 use super::people_list::PeopleList;
+use super::webhooks_panel::WebhooksPanel;
 use crate::auth::connect::Connect;
 use crate::profile::billing_credits::BillingPage;
 use crate::profile::billing_models::UserProfile;
@@ -100,6 +101,7 @@ pub enum SettingsTab {
     People,
     Account,
     Billing,
+    Webhooks,
 }
 
 #[derive(Properties, PartialEq, Clone)]
@@ -232,6 +234,14 @@ pub fn settings_panel(props: &SettingsPanelProps) -> Html {
                 html! { <div class="settings-content"><div class="loading-spinner-inline"></div></div> }
             }
         }
+        SettingsTab::Webhooks => {
+            html! {
+                <div class="settings-content">
+                    <h3>{"Webhooks"}</h3>
+                    <WebhooksPanel />
+                </div>
+            }
+        }
     };
 
     let overlay_click = {
@@ -298,6 +308,15 @@ pub fn settings_panel(props: &SettingsPanelProps) -> Html {
                         }}
                     >
                         {"Billing"}
+                    </button>
+                    <button
+                        class={classes!("settings-tab", (*active_tab == SettingsTab::Webhooks).then(|| "active"))}
+                        onclick={{
+                            let active_tab = active_tab.clone();
+                            Callback::from(move |_| active_tab.set(SettingsTab::Webhooks))
+                        }}
+                    >
+                        {"Webhooks"}
                     </button>
                 </div>
                 <div class="settings-body">

--- a/frontend/src/dashboard/webhooks_panel.rs
+++ b/frontend/src/dashboard/webhooks_panel.rs
@@ -15,6 +15,19 @@ const WEBHOOKS_STYLES: &str = r#"
     background: rgba(255,255,255,0.06); padding: 0.05rem 0.3rem;
     border-radius: 3px; font-size: 0.72rem;
 }
+.webhooks-help-block { margin-top: 0.55rem; }
+.webhooks-help pre {
+    background: rgba(0,0,0,0.4);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: 4px;
+    padding: 0.55rem 0.7rem;
+    margin: 0.4rem 0 0 0;
+    font-size: 0.72rem;
+    color: #ddd;
+    overflow-x: auto;
+    white-space: pre;
+    line-height: 1.45;
+}
 .webhooks-list { display: flex; flex-direction: column; gap: 0.4rem; }
 .webhook-row {
     display: flex; align-items: center; justify-content: space-between;
@@ -34,7 +47,8 @@ const WEBHOOKS_STYLES: &str = r#"
     border-radius: 4px; padding: 0.3rem 0.55rem;
     font-size: 0.72rem; cursor: pointer;
 }
-.webhook-revoke:hover { background: rgba(220,50,50,0.25); }
+.webhook-revoke:hover:not(:disabled) { background: rgba(220,50,50,0.25); }
+.webhook-revoke:disabled { opacity: 0.4; cursor: wait; }
 .webhook-create-form { display: flex; gap: 0.4rem; align-items: center; }
 .webhook-create-form input {
     flex: 1; background: rgba(255,255,255,0.04);
@@ -60,6 +74,18 @@ const WEBHOOKS_STYLES: &str = r#"
     border-radius: 4px; word-break: break-all;
 }
 .webhook-empty { font-size: 0.78rem; color: #777; font-style: italic; }
+.webhook-error {
+    font-size: 0.75rem; color: #f88;
+    background: rgba(220,50,50,0.08);
+    border: 1px solid rgba(220,50,50,0.2);
+    border-radius: 4px; padding: 0.45rem 0.6rem;
+}
+.webhook-upgrade {
+    font-size: 0.78rem; color: #fc8;
+    background: rgba(255,200,80,0.06);
+    border: 1px solid rgba(255,200,80,0.2);
+    border-radius: 4px; padding: 0.5rem 0.6rem;
+}
 "#;
 
 #[derive(Deserialize, Clone, PartialEq, Debug)]
@@ -71,6 +97,7 @@ struct WebhookTokenSummary {
     daily_sent: i32,
     daily_reset_at: i32,
     last_used_at: Option<i32>,
+    #[allow(dead_code)]
     created_at: i32,
 }
 
@@ -78,6 +105,11 @@ struct WebhookTokenSummary {
 struct CreateTokenResponse {
     token: String,
     label: String,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct ErrorBody {
+    error: String,
 }
 
 #[derive(Serialize)]
@@ -89,26 +121,44 @@ struct CreateTokenRequest {
 pub fn webhooks_panel() -> Html {
     let tokens = use_state(Vec::<WebhookTokenSummary>::new);
     let loading = use_state(|| true);
+    let load_error = use_state(|| None::<String>);
     let new_label = use_state(String::new);
     let creating = use_state(|| false);
+    let create_error = use_state(|| None::<String>);
+    let revoke_in_flight = use_state(|| None::<i32>);
+    let revoke_error = use_state(|| None::<String>);
     let just_minted = use_state(|| None::<CreateTokenResponse>);
+    let needs_subscription = use_state(|| false);
     let refresh_seq = use_state(|| 0u32);
 
     // Load tokens on mount and when refresh_seq bumps.
     {
         let tokens = tokens.clone();
         let loading = loading.clone();
+        let load_error = load_error.clone();
         let refresh_seq = refresh_seq.clone();
         use_effect_with_deps(
             move |_| {
                 loading.set(true);
+                load_error.set(None);
                 spawn_local(async move {
-                    if let Ok(r) = Api::get("/api/me/webhook-tokens").send().await {
-                        if r.ok() {
-                            if let Ok(list) = r.json::<Vec<WebhookTokenSummary>>().await {
-                                tokens.set(list);
-                            }
+                    match Api::get("/api/me/webhook-tokens").send().await {
+                        Ok(r) if r.ok() => match r.json::<Vec<WebhookTokenSummary>>().await {
+                            Ok(list) => tokens.set(list),
+                            Err(_) => load_error.set(Some(
+                                "Could not parse server response.".to_string(),
+                            )),
+                        },
+                        Ok(r) => {
+                            let status = r.status();
+                            let msg = parse_error_body(r)
+                                .await
+                                .unwrap_or_else(|| format!("Load failed ({}).", status));
+                            load_error.set(Some(msg));
                         }
+                        Err(_) => load_error.set(Some(
+                            "Network error loading tokens.".to_string(),
+                        )),
                     }
                     loading.set(false);
                 });
@@ -120,9 +170,12 @@ pub fn webhooks_panel() -> Html {
 
     let on_label_input = {
         let new_label = new_label.clone();
+        let create_error = create_error.clone();
         Callback::from(move |e: InputEvent| {
-            let target = e.target_dyn_into::<HtmlInputElement>();
-            if let Some(input) = target {
+            // Typing clears the previous create error so the user
+            // doesn't see stale feedback while editing.
+            create_error.set(None);
+            if let Some(input) = e.target_dyn_into::<HtmlInputElement>() {
                 new_label.set(input.value());
             }
         })
@@ -131,7 +184,9 @@ pub fn webhooks_panel() -> Html {
     let on_create = {
         let new_label = new_label.clone();
         let creating = creating.clone();
+        let create_error = create_error.clone();
         let just_minted = just_minted.clone();
+        let needs_subscription = needs_subscription.clone();
         let refresh_seq = refresh_seq.clone();
         Callback::from(move |_: MouseEvent| {
             let label = (*new_label).trim().to_string();
@@ -139,36 +194,75 @@ pub fn webhooks_panel() -> Html {
                 return;
             }
             creating.set(true);
+            create_error.set(None);
             let body = CreateTokenRequest { label };
             let new_label = new_label.clone();
             let creating = creating.clone();
+            let create_error = create_error.clone();
             let just_minted = just_minted.clone();
+            let needs_subscription = needs_subscription.clone();
             let refresh_seq = refresh_seq.clone();
             spawn_local(async move {
-                if let Ok(req) = Api::post("/api/me/webhook-tokens").json(&body) {
-                    if let Ok(r) = req.send().await {
-                        if r.ok() {
+                match Api::post("/api/me/webhook-tokens").json(&body) {
+                    Ok(req) => match req.send().await {
+                        Ok(r) if r.ok() => {
                             if let Ok(resp) = r.json::<CreateTokenResponse>().await {
                                 just_minted.set(Some(resp));
                             }
                             new_label.set(String::new());
                             refresh_seq.set(js_sys::Date::now() as u32);
                         }
-                    }
+                        Ok(r) => {
+                            let status = r.status();
+                            if status == 403 {
+                                needs_subscription.set(true);
+                            }
+                            let msg = parse_error_body(r)
+                                .await
+                                .unwrap_or_else(|| format!("Create failed ({}).", status));
+                            create_error.set(Some(msg));
+                        }
+                        Err(_) => create_error.set(Some("Network error.".to_string())),
+                    },
+                    Err(_) => create_error.set(Some("Could not encode request.".to_string())),
                 }
                 creating.set(false);
             });
         })
     };
 
-    let render_revoke = |id: i32, refresh_seq: UseStateHandle<u32>| -> Callback<MouseEvent> {
+    let render_revoke = |id: i32,
+                         refresh_seq: UseStateHandle<u32>,
+                         in_flight: UseStateHandle<Option<i32>>,
+                         err: UseStateHandle<Option<String>>|
+     -> Callback<MouseEvent> {
         Callback::from(move |_: MouseEvent| {
+            if in_flight.is_some() {
+                return;
+            }
+            in_flight.set(Some(id));
+            err.set(None);
             let refresh_seq = refresh_seq.clone();
+            let in_flight = in_flight.clone();
+            let err = err.clone();
             spawn_local(async move {
-                let _ = Api::delete(&format!("/api/me/webhook-tokens/{}", id))
+                match Api::delete(&format!("/api/me/webhook-tokens/{}", id))
                     .send()
-                    .await;
-                refresh_seq.set(js_sys::Date::now() as u32);
+                    .await
+                {
+                    Ok(r) if r.ok() => {
+                        refresh_seq.set(js_sys::Date::now() as u32);
+                    }
+                    Ok(r) => {
+                        let status = r.status();
+                        let msg = parse_error_body(r)
+                            .await
+                            .unwrap_or_else(|| format!("Revoke failed ({}).", status));
+                        err.set(Some(msg));
+                    }
+                    Err(_) => err.set(Some("Network error revoking token.".to_string())),
+                }
+                in_flight.set(None);
             });
         })
     };
@@ -178,14 +272,37 @@ pub fn webhooks_panel() -> Html {
             <style>{WEBHOOKS_STYLES}</style>
             <div class="webhooks-section">
                 <div class="webhooks-help">
-                    {"Send a text to your phone from anywhere. POST to "}
-                    <code>{"/api/webhook/sms"}</code>
-                    {" with header "}
-                    <code>{"Authorization: Bearer <token>"}</code>
-                    {" and body "}
-                    <code>{r#"{"message":"..."}"#}</code>
-                    {". Default daily cap: 50 messages."}
+                    {"Send a text to your own phone from anywhere — cron jobs, CI alerts, IFTTT, your own scripts:"}
+                    <pre>{format!(
+"curl -X POST {url} \\
+  -H \"Authorization: Bearer <your-token>\" \\
+  -H \"Content-Type: application/json\" \\
+  -d '{{\"message\":\"deploy finished\"}}'",
+                        url = webhook_endpoint_url()
+                    )}</pre>
+                    <div class="webhooks-help-block">
+                        {"Optional: add "}
+                        <code>{"-H \"Idempotency-Key: <unique-id>\""}</code>
+                        {" to dedupe retried requests within 24h. Daily cap resets at UTC midnight. Successful responses return "}
+                        <code>{r#"{"status":"sent","sid":"..."}"#}</code>{"."}
+                    </div>
                 </div>
+
+                {
+                    if *needs_subscription {
+                        html! {
+                            <div class="webhook-upgrade">
+                                {"Webhooks require an active subscription. Subscribe under the Billing tab to enable."}
+                            </div>
+                        }
+                    } else { html! {} }
+                }
+
+                {
+                    if let Some(err) = (*load_error).clone() {
+                        html! { <div class="webhook-error">{ err }</div> }
+                    } else { html! {} }
+                }
 
                 {
                     if let Some(minted) = (*just_minted).clone() {
@@ -217,15 +334,34 @@ pub fn webhooks_panel() -> Html {
                     </button>
                 </div>
 
+                {
+                    if let Some(err) = (*create_error).clone() {
+                        html! { <div class="webhook-error">{ err }</div> }
+                    } else { html! {} }
+                }
+
+                {
+                    if let Some(err) = (*revoke_error).clone() {
+                        html! { <div class="webhook-error">{ err }</div> }
+                    } else { html! {} }
+                }
+
                 <div class="webhooks-list">
                     {
                         if *loading {
                             html! { <div class="webhook-empty">{"Loading..."}</div> }
-                        } else if tokens.is_empty() {
+                        } else if tokens.is_empty() && load_error.is_none() {
                             html! { <div class="webhook-empty">{"No tokens yet."}</div> }
                         } else {
                             tokens.iter().map(|t| {
-                                let revoke_cb = render_revoke(t.id, refresh_seq.clone());
+                                let in_flight = revoke_in_flight.clone();
+                                let revoke_cb = render_revoke(
+                                    t.id,
+                                    refresh_seq.clone(),
+                                    revoke_in_flight.clone(),
+                                    revoke_error.clone(),
+                                );
+                                let is_revoking = (*in_flight) == Some(t.id);
                                 html! {
                                     <div class="webhook-row" key={t.id}>
                                         <div class="webhook-meta">
@@ -233,6 +369,7 @@ pub fn webhooks_panel() -> Html {
                                             <div class="webhook-sub">
                                                 <code>{ format!("{}…", t.token_prefix) }</code>
                                                 { format!(" · {}/{} today", t.daily_sent, t.daily_cap) }
+                                                { format!(" · resets {}", format_future(t.daily_reset_at)) }
                                                 {
                                                     if let Some(ts) = t.last_used_at {
                                                         format!(" · last used {}", format_relative(ts))
@@ -242,7 +379,9 @@ pub fn webhooks_panel() -> Html {
                                                 }
                                             </div>
                                         </div>
-                                        <button class="webhook-revoke" onclick={revoke_cb}>{"Revoke"}</button>
+                                        <button class="webhook-revoke" onclick={revoke_cb} disabled={is_revoking}>
+                                            { if is_revoking { "Revoking..." } else { "Revoke" } }
+                                        </button>
                                     </div>
                                 }
                             }).collect::<Html>()
@@ -252,6 +391,28 @@ pub fn webhooks_panel() -> Html {
             </div>
         </>
     }
+}
+
+async fn parse_error_body(resp: gloo_net::http::Response) -> Option<String> {
+    resp.json::<ErrorBody>().await.ok().map(|b| b.error)
+}
+
+/// The absolute URL clients should POST to. We deliberately hardcode the
+/// production host here rather than using `config::get_backend_url()`
+/// because we want the docs to show what the user pastes into their own
+/// scripts — not what the WASM bundle happens to be calling from the
+/// browser. In dev that means showing `http://localhost:3000` so the
+/// developer's curl actually hits their local backend; in release we
+/// always show the canonical prod host even if the bundle is loaded
+/// from a staging URL.
+#[cfg(debug_assertions)]
+fn webhook_endpoint_url() -> &'static str {
+    "http://localhost:3000/api/webhook/sms"
+}
+
+#[cfg(not(debug_assertions))]
+fn webhook_endpoint_url() -> &'static str {
+    "https://lightfriend.ai/api/webhook/sms"
 }
 
 fn format_relative(unix_ts: i32) -> String {
@@ -265,5 +426,21 @@ fn format_relative(unix_ts: i32) -> String {
         format!("{}h ago", diff / 3600)
     } else {
         format!("{}d ago", diff / 86_400)
+    }
+}
+
+fn format_future(unix_ts: i32) -> String {
+    let now = (js_sys::Date::now() / 1000.0) as i64;
+    let diff = unix_ts as i64 - now;
+    if diff <= 0 {
+        "soon".to_string()
+    } else if diff < 60 {
+        "in <1m".to_string()
+    } else if diff < 3600 {
+        format!("in {}m", diff / 60)
+    } else if diff < 86_400 {
+        format!("in {}h", diff / 3600)
+    } else {
+        format!("in {}d", diff / 86_400)
     }
 }

--- a/frontend/src/dashboard/webhooks_panel.rs
+++ b/frontend/src/dashboard/webhooks_panel.rs
@@ -1,0 +1,269 @@
+use crate::utils::api::Api;
+use serde::{Deserialize, Serialize};
+use wasm_bindgen_futures::spawn_local;
+use web_sys::HtmlInputElement;
+use yew::prelude::*;
+
+const WEBHOOKS_STYLES: &str = r#"
+.webhooks-section { display: flex; flex-direction: column; gap: 0.75rem; }
+.webhooks-help {
+    font-size: 0.78rem; color: #888; line-height: 1.5;
+    background: rgba(255,255,255,0.03); border-radius: 6px;
+    padding: 0.65rem 0.75rem;
+}
+.webhooks-help code {
+    background: rgba(255,255,255,0.06); padding: 0.05rem 0.3rem;
+    border-radius: 3px; font-size: 0.72rem;
+}
+.webhooks-list { display: flex; flex-direction: column; gap: 0.4rem; }
+.webhook-row {
+    display: flex; align-items: center; justify-content: space-between;
+    padding: 0.55rem 0.7rem; background: rgba(255,255,255,0.03);
+    border-radius: 6px; gap: 0.5rem;
+}
+.webhook-meta { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.webhook-label { font-size: 0.85rem; color: #ddd; font-weight: 500; }
+.webhook-sub { font-size: 0.72rem; color: #888; margin-top: 0.15rem; }
+.webhook-sub code {
+    background: rgba(255,255,255,0.06); padding: 0.02rem 0.3rem;
+    border-radius: 3px; font-size: 0.7rem;
+}
+.webhook-revoke {
+    background: rgba(220,50,50,0.15); color: #f88;
+    border: 1px solid rgba(220,50,50,0.3);
+    border-radius: 4px; padding: 0.3rem 0.55rem;
+    font-size: 0.72rem; cursor: pointer;
+}
+.webhook-revoke:hover { background: rgba(220,50,50,0.25); }
+.webhook-create-form { display: flex; gap: 0.4rem; align-items: center; }
+.webhook-create-form input {
+    flex: 1; background: rgba(255,255,255,0.04);
+    border: 1px solid rgba(255,255,255,0.1); color: #ddd;
+    border-radius: 4px; padding: 0.4rem 0.55rem; font-size: 0.8rem;
+}
+.webhook-create-form button {
+    background: rgba(100,180,255,0.15); color: #9cf;
+    border: 1px solid rgba(100,180,255,0.3);
+    border-radius: 4px; padding: 0.4rem 0.7rem;
+    font-size: 0.8rem; cursor: pointer;
+}
+.webhook-create-form button:disabled { opacity: 0.4; cursor: wait; }
+.webhook-new-token {
+    background: rgba(255,200,80,0.08); border: 1px solid rgba(255,200,80,0.25);
+    border-radius: 6px; padding: 0.6rem 0.7rem;
+    display: flex; flex-direction: column; gap: 0.35rem;
+}
+.webhook-new-token-warn { font-size: 0.72rem; color: #fc8; }
+.webhook-new-token-value {
+    font-family: monospace; font-size: 0.78rem; color: #ffd980;
+    background: rgba(0,0,0,0.3); padding: 0.4rem 0.55rem;
+    border-radius: 4px; word-break: break-all;
+}
+.webhook-empty { font-size: 0.78rem; color: #777; font-style: italic; }
+"#;
+
+#[derive(Deserialize, Clone, PartialEq, Debug)]
+struct WebhookTokenSummary {
+    id: i32,
+    label: String,
+    token_prefix: String,
+    daily_cap: i32,
+    daily_sent: i32,
+    daily_reset_at: i32,
+    last_used_at: Option<i32>,
+    created_at: i32,
+}
+
+#[derive(Deserialize, Clone, Debug)]
+struct CreateTokenResponse {
+    token: String,
+    label: String,
+}
+
+#[derive(Serialize)]
+struct CreateTokenRequest {
+    label: String,
+}
+
+#[function_component(WebhooksPanel)]
+pub fn webhooks_panel() -> Html {
+    let tokens = use_state(Vec::<WebhookTokenSummary>::new);
+    let loading = use_state(|| true);
+    let new_label = use_state(String::new);
+    let creating = use_state(|| false);
+    let just_minted = use_state(|| None::<CreateTokenResponse>);
+    let refresh_seq = use_state(|| 0u32);
+
+    // Load tokens on mount and when refresh_seq bumps.
+    {
+        let tokens = tokens.clone();
+        let loading = loading.clone();
+        let refresh_seq = refresh_seq.clone();
+        use_effect_with_deps(
+            move |_| {
+                loading.set(true);
+                spawn_local(async move {
+                    if let Ok(r) = Api::get("/api/me/webhook-tokens").send().await {
+                        if r.ok() {
+                            if let Ok(list) = r.json::<Vec<WebhookTokenSummary>>().await {
+                                tokens.set(list);
+                            }
+                        }
+                    }
+                    loading.set(false);
+                });
+                || ()
+            },
+            (*refresh_seq,),
+        );
+    }
+
+    let on_label_input = {
+        let new_label = new_label.clone();
+        Callback::from(move |e: InputEvent| {
+            let target = e.target_dyn_into::<HtmlInputElement>();
+            if let Some(input) = target {
+                new_label.set(input.value());
+            }
+        })
+    };
+
+    let on_create = {
+        let new_label = new_label.clone();
+        let creating = creating.clone();
+        let just_minted = just_minted.clone();
+        let refresh_seq = refresh_seq.clone();
+        Callback::from(move |_: MouseEvent| {
+            let label = (*new_label).trim().to_string();
+            if label.is_empty() || *creating {
+                return;
+            }
+            creating.set(true);
+            let body = CreateTokenRequest { label };
+            let new_label = new_label.clone();
+            let creating = creating.clone();
+            let just_minted = just_minted.clone();
+            let refresh_seq = refresh_seq.clone();
+            spawn_local(async move {
+                if let Ok(req) = Api::post("/api/me/webhook-tokens").json(&body) {
+                    if let Ok(r) = req.send().await {
+                        if r.ok() {
+                            if let Ok(resp) = r.json::<CreateTokenResponse>().await {
+                                just_minted.set(Some(resp));
+                            }
+                            new_label.set(String::new());
+                            refresh_seq.set(js_sys::Date::now() as u32);
+                        }
+                    }
+                }
+                creating.set(false);
+            });
+        })
+    };
+
+    let render_revoke = |id: i32, refresh_seq: UseStateHandle<u32>| -> Callback<MouseEvent> {
+        Callback::from(move |_: MouseEvent| {
+            let refresh_seq = refresh_seq.clone();
+            spawn_local(async move {
+                let _ = Api::delete(&format!("/api/me/webhook-tokens/{}", id))
+                    .send()
+                    .await;
+                refresh_seq.set(js_sys::Date::now() as u32);
+            });
+        })
+    };
+
+    html! {
+        <>
+            <style>{WEBHOOKS_STYLES}</style>
+            <div class="webhooks-section">
+                <div class="webhooks-help">
+                    {"Send a text to your phone from anywhere. POST to "}
+                    <code>{"/api/webhook/sms"}</code>
+                    {" with header "}
+                    <code>{"Authorization: Bearer <token>"}</code>
+                    {" and body "}
+                    <code>{r#"{"message":"..."}"#}</code>
+                    {". Default daily cap: 50 messages."}
+                </div>
+
+                {
+                    if let Some(minted) = (*just_minted).clone() {
+                        let dismiss = {
+                            let just_minted = just_minted.clone();
+                            Callback::from(move |_: MouseEvent| just_minted.set(None))
+                        };
+                        html! {
+                            <div class="webhook-new-token">
+                                <div class="webhook-new-token-warn">
+                                    {format!("New token for \"{}\" — copy now, it won't be shown again:", minted.label)}
+                                </div>
+                                <div class="webhook-new-token-value">{minted.token.clone()}</div>
+                                <button class="webhook-revoke" onclick={dismiss}>{"Dismiss"}</button>
+                            </div>
+                        }
+                    } else { html! {} }
+                }
+
+                <div class="webhook-create-form">
+                    <input
+                        type="text"
+                        placeholder="Label (e.g. \"deploy alerts\")"
+                        value={(*new_label).clone()}
+                        oninput={on_label_input}
+                    />
+                    <button onclick={on_create} disabled={*creating || (*new_label).trim().is_empty()}>
+                        { if *creating { "Creating..." } else { "Create" } }
+                    </button>
+                </div>
+
+                <div class="webhooks-list">
+                    {
+                        if *loading {
+                            html! { <div class="webhook-empty">{"Loading..."}</div> }
+                        } else if tokens.is_empty() {
+                            html! { <div class="webhook-empty">{"No tokens yet."}</div> }
+                        } else {
+                            tokens.iter().map(|t| {
+                                let revoke_cb = render_revoke(t.id, refresh_seq.clone());
+                                html! {
+                                    <div class="webhook-row" key={t.id}>
+                                        <div class="webhook-meta">
+                                            <div class="webhook-label">{ &t.label }</div>
+                                            <div class="webhook-sub">
+                                                <code>{ format!("{}…", t.token_prefix) }</code>
+                                                { format!(" · {}/{} today", t.daily_sent, t.daily_cap) }
+                                                {
+                                                    if let Some(ts) = t.last_used_at {
+                                                        format!(" · last used {}", format_relative(ts))
+                                                    } else {
+                                                        " · never used".to_string()
+                                                    }
+                                                }
+                                            </div>
+                                        </div>
+                                        <button class="webhook-revoke" onclick={revoke_cb}>{"Revoke"}</button>
+                                    </div>
+                                }
+                            }).collect::<Html>()
+                        }
+                    }
+                </div>
+            </div>
+        </>
+    }
+}
+
+fn format_relative(unix_ts: i32) -> String {
+    let now = (js_sys::Date::now() / 1000.0) as i64;
+    let diff = now - unix_ts as i64;
+    if diff < 60 {
+        "just now".to_string()
+    } else if diff < 3600 {
+        format!("{}m ago", diff / 60)
+    } else if diff < 86_400 {
+        format!("{}h ago", diff / 3600)
+    } else {
+        format!("{}d ago", diff / 86_400)
+    }
+}

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -65,6 +65,7 @@ mod dashboard {
     pub mod tesla_quick_panel;
     pub mod timeline_view;
     pub mod triage_indicator;
+    pub mod webhooks_panel;
     pub mod youtube_quick_panel;
 }
 mod proactive {

--- a/frontend/src/main.rs
+++ b/frontend/src/main.rs
@@ -22,6 +22,7 @@ mod utils {
 mod profile {
     pub mod billing_credits;
     pub mod billing_models;
+    pub mod commitment_dashboard;
     pub mod danger_zone;
     pub mod profile;
     pub mod security;

--- a/frontend/src/profile/commitment_dashboard.rs
+++ b/frontend/src/profile/commitment_dashboard.rs
@@ -1,0 +1,298 @@
+//! Dashboard section for managing commitment detection signal state.
+//! Lists muted senders, always-track senders, and recent SMS-prompt history.
+//! Shown as a collapsible panel below the Auto-track Commitments toggle in
+//! settings — there's no value in surfacing it before the user has opted in.
+
+use serde::Deserialize;
+use wasm_bindgen_futures::spawn_local;
+use web_sys::js_sys;
+use yew::prelude::*;
+
+use crate::utils::api::Api;
+
+#[derive(Clone, PartialEq, Deserialize, Debug)]
+struct SenderRuleView {
+    id: i32,
+    platform: String,
+    sender_key: String,
+    #[serde(default)]
+    rule_type: String,
+    #[serde(default)]
+    source: String,
+    created_at: i32,
+}
+
+#[derive(Clone, PartialEq, Deserialize, Debug, Default)]
+struct SenderRulesResponse {
+    #[serde(default)]
+    muted: Vec<SenderRuleView>,
+    #[serde(default)]
+    always_track: Vec<SenderRuleView>,
+}
+
+#[derive(Clone, PartialEq, Deserialize, Debug)]
+struct PromptView {
+    #[allow(dead_code)]
+    id: i32,
+    platform: String,
+    sender_display_name: String,
+    commitment_description: String,
+    sent_at: i32,
+    user_label: Option<String>,
+    #[serde(default)]
+    resulting_event_id: Option<i32>,
+}
+
+#[derive(PartialEq)]
+enum LoadState {
+    Loading,
+    Ready,
+    Failed(String),
+}
+
+#[function_component(CommitmentDashboard)]
+pub fn commitment_dashboard() -> Html {
+    let rules = use_state(SenderRulesResponse::default);
+    let prompts = use_state(Vec::<PromptView>::new);
+    let load_state = use_state(|| LoadState::Loading);
+    let expanded = use_state(|| false);
+
+    // Initial fetch on mount, and refetch when the user expands the panel
+    // (lets them see fresh data when they come back to it later).
+    {
+        let rules = rules.clone();
+        let prompts = prompts.clone();
+        let load_state = load_state.clone();
+        let expanded_v = *expanded;
+        use_effect_with_deps(
+            move |_| {
+                if expanded_v {
+                    load_state.set(LoadState::Loading);
+                    let rules = rules.clone();
+                    let prompts = prompts.clone();
+                    let load_state = load_state.clone();
+                    spawn_local(async move {
+                        let rules_result = match Api::get("/api/commitment/sender-rules")
+                            .send()
+                            .await
+                        {
+                            Ok(resp) if resp.ok() => resp.json::<SenderRulesResponse>().await.ok(),
+                            _ => None,
+                        };
+                        let prompts_result = match Api::get("/api/commitment/recent-prompts")
+                            .send()
+                            .await
+                        {
+                            Ok(resp) if resp.ok() => resp.json::<Vec<PromptView>>().await.ok(),
+                            _ => None,
+                        };
+                        match (rules_result, prompts_result) {
+                            (Some(r), Some(p)) => {
+                                rules.set(r);
+                                prompts.set(p);
+                                load_state.set(LoadState::Ready);
+                            }
+                            _ => load_state.set(LoadState::Failed(
+                                "Couldn't load commitment data.".to_string(),
+                            )),
+                        }
+                    });
+                }
+                || ()
+            },
+            expanded_v,
+        );
+    }
+
+    let toggle_expanded = {
+        let expanded = expanded.clone();
+        Callback::from(move |_| expanded.set(!*expanded))
+    };
+
+    let remove_rule = {
+        let rules = rules.clone();
+        Callback::from(move |rule_id: i32| {
+            let rules = rules.clone();
+            spawn_local(async move {
+                let url = format!("/api/commitment/sender-rules/{}", rule_id);
+                let _ = Api::delete(&url).send().await;
+                // Optimistic update: drop the rule from local state without a
+                // full refetch. If the backend call failed the UI will be
+                // inconsistent until next expand, which is acceptable for v1.
+                let mut current = (*rules).clone();
+                current.muted.retain(|r| r.id != rule_id);
+                current.always_track.retain(|r| r.id != rule_id);
+                rules.set(current);
+            })
+        })
+    };
+
+    let muted_count = rules.muted.len();
+    let always_track_count = rules.always_track.len();
+
+    html! {
+        <div class="profile-field" style="flex-direction: column; align-items: stretch;">
+            <div class="field-label-group" style="display: flex; justify-content: space-between; align-items: center; cursor: pointer;" onclick={toggle_expanded.clone()}>
+                <span class="field-label">
+                    {"Commitment detection rules"}
+                    <span style="margin-left: 6px; font-size: 0.75rem; color: #888;">
+                        { format!("({} muted, {} always-track)", muted_count, always_track_count) }
+                    </span>
+                </span>
+                <span style="font-size: 0.85rem; color: #7EB2FF;">
+                    { if *expanded { "Hide" } else { "Show" } }
+                </span>
+            </div>
+            { if *expanded {
+                html! {
+                    <div style="margin-top: 12px; display: flex; flex-direction: column; gap: 16px;">
+                        { render_load_state(&load_state) }
+                        { if matches!(*load_state, LoadState::Ready) {
+                            html! {
+                                <>
+                                    { render_rule_section("Muted senders", &rules.muted, "These senders won't trigger commitment SMS prompts.", remove_rule.clone()) }
+                                    { render_rule_section("Always-track senders", &rules.always_track, "Commitments from these senders are tracked without asking.", remove_rule.clone()) }
+                                    { render_prompts_section(&prompts) }
+                                </>
+                            }
+                        } else {
+                            html! {}
+                        } }
+                    </div>
+                }
+            } else {
+                html! {}
+            } }
+        </div>
+    }
+}
+
+fn render_load_state(state: &LoadState) -> Html {
+    match state {
+        LoadState::Loading => html! {
+            <div style="color: #888; font-size: 0.9rem;">{"Loading..."}</div>
+        },
+        LoadState::Failed(msg) => html! {
+            <div style="color: #FF7E7E; font-size: 0.9rem;">{ msg.clone() }</div>
+        },
+        LoadState::Ready => html! {},
+    }
+}
+
+fn render_rule_section(
+    title: &str,
+    rules: &[SenderRuleView],
+    description: &str,
+    on_remove: Callback<i32>,
+) -> Html {
+    html! {
+        <div>
+            <div style="font-weight: 600; font-size: 0.9rem; margin-bottom: 4px;">{ title.to_string() }</div>
+            <div style="font-size: 0.8rem; color: #999; margin-bottom: 8px;">{ description.to_string() }</div>
+            { if rules.is_empty() {
+                html! {
+                    <div style="font-size: 0.85rem; color: #888; font-style: italic;">{"None yet."}</div>
+                }
+            } else {
+                html! {
+                    <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px;">
+                        { for rules.iter().map(|r| render_rule_row(r, on_remove.clone())) }
+                    </ul>
+                }
+            } }
+        </div>
+    }
+}
+
+fn render_rule_row(rule: &SenderRuleView, on_remove: Callback<i32>) -> Html {
+    let rule_id = rule.id;
+    let onclick = Callback::from(move |_| on_remove.emit(rule_id));
+    html! {
+        <li style="display: flex; justify-content: space-between; align-items: center; padding: 6px 10px; background: rgba(255,255,255,0.03); border-radius: 4px;">
+            <div style="display: flex; flex-direction: column; gap: 2px;">
+                <span style="font-size: 0.9rem;">{ rule.sender_key.clone() }</span>
+                <span style="font-size: 0.7rem; color: #888;">{ rule.platform.clone() }</span>
+            </div>
+            <button
+                onclick={onclick}
+                style="background: transparent; border: 1px solid #555; color: #ccc; padding: 4px 10px; border-radius: 3px; font-size: 0.8rem; cursor: pointer;"
+            >
+                {"Remove"}
+            </button>
+        </li>
+    }
+}
+
+fn render_prompts_section(prompts: &[PromptView]) -> Html {
+    html! {
+        <div>
+            <div style="font-weight: 600; font-size: 0.9rem; margin-bottom: 4px;">{"Recent prompts"}</div>
+            <div style="font-size: 0.8rem; color: #999; margin-bottom: 8px;">
+                {"The last 50 commitment-detection SMS prompts sent to you and how you replied."}
+            </div>
+            { if prompts.is_empty() {
+                html! {
+                    <div style="font-size: 0.85rem; color: #888; font-style: italic;">{"None yet."}</div>
+                }
+            } else {
+                html! {
+                    <ul style="list-style: none; padding: 0; margin: 0; display: flex; flex-direction: column; gap: 6px;">
+                        { for prompts.iter().map(render_prompt_row) }
+                    </ul>
+                }
+            } }
+        </div>
+    }
+}
+
+fn render_prompt_row(prompt: &PromptView) -> Html {
+    let label_text = match prompt.user_label.as_deref() {
+        Some("1") => "Tracked",
+        Some("2") => "Tracked + always-track sender",
+        Some("3") => "Muted sender",
+        Some("4") => "Not a commitment",
+        _ => "Pending",
+    };
+    let label_color = match prompt.user_label.as_deref() {
+        Some("1") | Some("2") => "#7EFF9A",
+        Some("3") => "#FFB97E",
+        Some("4") => "#FF7E7E",
+        _ => "#888",
+    };
+    html! {
+        <li style="padding: 6px 10px; background: rgba(255,255,255,0.03); border-radius: 4px;">
+            <div style="display: flex; justify-content: space-between; align-items: center; gap: 8px;">
+                <span style="font-size: 0.9rem; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap;">
+                    { prompt.commitment_description.clone() }
+                </span>
+                <span style={format!("font-size: 0.75rem; color: {}; flex-shrink: 0;", label_color)}>
+                    { label_text }
+                </span>
+            </div>
+            <div style="font-size: 0.7rem; color: #888; margin-top: 2px;">
+                { format!("{} via {} - {}", prompt.sender_display_name, prompt.platform, format_relative_ts(prompt.sent_at)) }
+                { if let Some(eid) = prompt.resulting_event_id {
+                    format!(" - event #{}", eid)
+                } else {
+                    String::new()
+                } }
+            </div>
+        </li>
+    }
+}
+
+fn format_relative_ts(unix_ts: i32) -> String {
+    let now = js_sys::Date::now() as i64 / 1000;
+    let delta = now - unix_ts as i64;
+    if delta < 60 {
+        "just now".to_string()
+    } else if delta < 3600 {
+        format!("{}m ago", delta / 60)
+    } else if delta < 86400 {
+        format!("{}h ago", delta / 3600)
+    } else if delta < 86400 * 30 {
+        format!("{}d ago", delta / 86400)
+    } else {
+        format!("{}mo ago", delta / (86400 * 30))
+    }
+}

--- a/frontend/src/profile/settings.rs
+++ b/frontend/src/profile/settings.rs
@@ -2664,7 +2664,7 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
                     <div class="tooltip">
                         <span class="tooltip-icon">{"?"}</span>
                         <span class="tooltip-text">
-                            {"Automatically detect and track commitments from your messages (e.g. \"I'll pay the bill by Friday\"). You'll be notified when deadlines change."}
+                            {"When a commitment is detected in your messages, we send you an SMS asking what to do. Reply 1 to track it, 2 to always track this sender, 3 to mute the sender, 4 if it's not a commitment. The system learns from each reply."}
                         </span>
                     </div>
                 </div>
@@ -2681,6 +2681,12 @@ pub fn SettingsPage(props: &SettingsPageProps) -> Html {
                     {render_save_indicator(&*auto_track_system_save_state)}
                 </div>
             </div>
+
+            { if *auto_track_system {
+                html! { <crate::profile::commitment_dashboard::CommitmentDashboard /> }
+            } else {
+                html! {}
+            } }
 
             // Auto-confirm tracked items (only shown when auto-track is enabled)
 

--- a/justfile
+++ b/justfile
@@ -100,3 +100,27 @@ test-backend:
 # Development: Run tests for frontend
 test-frontend:
     cd frontend && cargo test
+
+# ── Fuzzing (security-critical pure functions) ──────────────────────────
+# Requires: rustup install nightly && cargo install cargo-fuzz
+# See backend/fuzz/README.md for what these check and how to triage findings.
+
+# Fuzz the Twilio webhook signature verifier for 60 seconds
+fuzz-twilio:
+    cd backend/fuzz && cargo +nightly fuzz run twilio_signature -- -max_total_time=60
+
+# Fuzz the Telnyx webhook signature verifier for 60 seconds
+fuzz-telnyx:
+    cd backend/fuzz && cargo +nightly fuzz run telnyx_signature -- -max_total_time=60
+
+# Fuzz all webhook signature verifiers (60 seconds each, sequential)
+fuzz-all: fuzz-twilio fuzz-telnyx
+
+# ── Formal verification (Kani bounded model checking) ───────────────────
+# Requires: cargo install --locked kani-verifier && cargo kani setup
+# Proves properties hold for ALL bounded inputs - not just samples.
+# See backend/fuzz/README.md (Kani section) for scope and rationale.
+
+# Run every #[kani::proof] in the backend crate
+kani:
+    cd backend && cargo kani --tests


### PR DESCRIPTION
## Summary

Multi-commit branch landing four loosely related areas. Each commit is independently revertable.

- **SMS provider fallback** (`225cc13b`) — outbound SMS now walks an ordered provider list per country and falls through on send failure. First attempt unmodified; later attempts prepend `[Lightfriend backup] ` so the recipient knows it is still Lightfriend on a different carrier. New `provider_routes` table (migration 36), seeded with `US → [twilio, telnyx]`. `POST /api/admin/provider-routes` updates both DB and in-memory cache without redeploy. 5 new router tests.
- **Commitment detection pipeline** (`8275a3b2`) — sender rules + label-similarity embeddings + live SMS prompts + dashboard page. New tables in migration 35; modules under `commitment_handlers`, `commitment_repository`, `proactive::commitment_replies`. Also pulls in a cargo-fuzz harness and kani formal proofs for the Twilio + Telnyx signature validators.
- **WhatsApp Status Broadcast filter + Tesla virtual-key pairing prompt** (`9e380836`).
- **Pending reply watches + webhook SMS tokens v0** (`23d92151`) — `pending_reply_watches` table (migration 37) for tracking SMS replies to the assistant. First cut of webhook SMS tokens: per-user bearer tokens that let external callers POST a message and have it delivered as SMS to the owning user's phone. New table `webhook_tokens` (migration 38), routes under `/api/me/webhook-tokens`, public endpoint `POST /api/webhook/sms`, dashboard panel.
- **Webhook hardening pass** (`e2de454d`) — codex-review fixes on top of v0:
  - `[label]` provenance prefix on every webhook-triggered SMS so a leaked token can't impersonate the assistant from a Lightfriend number.
  - Route-specific 4 KiB body limit on `/api/webhook/sms` before serde parses anything.
  - `Idempotency-Key` header support backed by a new `webhook_idempotency_keys` table (migration 39, FK CASCADE off `webhook_tokens`, 24h TTL, in-flight/replayed/fresh state machine, released on send failure).
  - `claim_send_slot` wrapped in `conn.transaction()` so the doc-comment race-safety claim matches the code.
  - Revoke is truly idempotent (204 on repeat) and gracefully refuses wrong-owner attempts.
  - Frontend: load/create/revoke error states, daily-cap reset time inline, upgrade banner on 403, copy-pasteable curl example with the absolute production URL.
  - Integration tests in `backend/tests/webhook_sms_test.rs` cover cap exhaustion, revoke idempotency, cross-user revoke protection, idempotency state machine, daily-window reset, and key scoping per token.

## Migrations applied on boot (in order)

1. `35_add_commitment_signal_tables`
2. `36_add_provider_routes`
3. `37_add_pending_reply_watches`
4. `38_add_webhook_tokens`
5. `39_add_webhook_idempotency_keys`

All purely additive (`CREATE TABLE IF NOT EXISTS`, `INSERT ... ON CONFLICT DO NOTHING`), no destructive operations.

## Test plan

- [ ] CI green (clippy, cargo test, frontend wasm build)
- [ ] Migrations 35-39 apply cleanly on a fresh DB
- [ ] `POST /api/webhook/sms` with valid bearer + body returns 200 with SID
- [ ] Same `Idempotency-Key` twice returns the cached SID without ticking the daily cap counter
- [ ] Daily cap exhaustion returns 429 with `daily_cap` / `daily_sent` in body
- [ ] Revoked token returns 401
- [ ] Non-tier-2 user gets 403 on token create, sees the upgrade banner in the UI
- [ ] Sinch/Telnyx fallback still triggers on Twilio failure for routed countries
- [ ] Commitment detection prompts arrive end-to-end for a test sender