### PR TITLE
Enable Light Tool photo messages

### DIFF
--- a/backend/pg_migrations/2026-07-20-180000_add_light_tool_run_image/down.sql
+++ b/backend/pg_migrations/2026-07-20-180000_add_light_tool_run_image/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE light_tool_runs
+DROP COLUMN encrypted_image_data_url;

--- a/backend/pg_migrations/2026-07-20-180000_add_light_tool_run_image/up.sql
+++ b/backend/pg_migrations/2026-07-20-180000_add_light_tool_run_image/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE light_tool_runs
+ADD COLUMN encrypted_image_data_url TEXT;

--- a/backend/src/handlers/light_tool_handlers.rs
+++ b/backend/src/handlers/light_tool_handlers.rs
@@ -27,19 +27,23 @@ use crate::{
     AppState, UserCoreOps,
 };
 use axum::{
-    extract::{Path, State},
+    extract::{Multipart, Path, State},
     http::{HeaderMap, StatusCode},
     Json,
 };
+use base64::{engine::general_purpose::STANDARD, Engine as _};
 use chrono::SecondsFormat;
+use image::{codecs::jpeg::JpegEncoder, io::Limits, io::Reader as ImageReader};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::net::IpAddr;
-use std::sync::Arc;
+use std::{io::Cursor, net::IpAddr, sync::Arc};
 use url::{Host, Url};
 use uuid::Uuid;
 
 const MAX_MESSAGE_TEXT_BYTES: usize = 8_000;
+const MAX_IMAGE_UPLOAD_BYTES: usize = 5 * 1024 * 1024;
+const MAX_IMAGE_DIMENSION: u32 = 8_192;
+const MAX_IMAGE_DECODE_BYTES: u64 = 96 * 1024 * 1024;
 const MESSAGE_HISTORY_RUN_LIMIT: i64 = 50;
 const MAX_PUSH_ENDPOINT_BYTES: usize = 2_048;
 
@@ -406,10 +410,75 @@ pub async fn send_message(
     auth: LightToolDeviceAuth,
     Json(request): Json<SendMessageRequest>,
 ) -> Result<(StatusCode, Json<SendMessageResponse>), ApiError> {
-    let client_message_id = Uuid::parse_str(&request.client_message_id)
+    enqueue_message(state, auth, request.client_message_id, request.text, None)
+}
+
+pub async fn send_image_message(
+    State(state): State<Arc<AppState>>,
+    auth: LightToolDeviceAuth,
+    mut multipart: Multipart,
+) -> Result<(StatusCode, Json<SendMessageResponse>), ApiError> {
+    let mut client_message_id = None;
+    let mut text = None;
+    let mut image_data_url = None;
+
+    while let Some(field) = multipart
+        .next_field()
+        .await
+        .map_err(|_| bad_request("invalid multipart request"))?
+    {
+        match field.name() {
+            Some("client_message_id") if client_message_id.is_none() => {
+                client_message_id = Some(
+                    field
+                        .text()
+                        .await
+                        .map_err(|_| bad_request("invalid client_message_id"))?,
+                );
+            }
+            Some("text") if text.is_none() => {
+                text = Some(
+                    field
+                        .text()
+                        .await
+                        .map_err(|_| bad_request("invalid text"))?,
+                );
+            }
+            Some("image") if image_data_url.is_none() => {
+                let bytes = field
+                    .bytes()
+                    .await
+                    .map_err(|_| bad_request("invalid image"))?;
+                if bytes.is_empty() || bytes.len() > MAX_IMAGE_UPLOAD_BYTES {
+                    return Err(bad_request("image must be between 1 byte and 5 MB"));
+                }
+                image_data_url = Some(normalize_image_data_url(&bytes)?);
+            }
+            Some("client_message_id" | "text" | "image") => {
+                return Err(bad_request("multipart fields must not be repeated"));
+            }
+            _ => {}
+        }
+    }
+
+    let client_message_id =
+        client_message_id.ok_or_else(|| bad_request("client_message_id is required"))?;
+    let text = text.unwrap_or_else(|| "Photo".to_string());
+    let image_data_url = image_data_url.ok_or_else(|| bad_request("image is required"))?;
+    enqueue_message(state, auth, client_message_id, text, Some(image_data_url))
+}
+
+fn enqueue_message(
+    state: Arc<AppState>,
+    auth: LightToolDeviceAuth,
+    client_message_id: String,
+    text: String,
+    image_data_url: Option<String>,
+) -> Result<(StatusCode, Json<SendMessageResponse>), ApiError> {
+    let client_message_id = Uuid::parse_str(&client_message_id)
         .map_err(|_| bad_request("client_message_id must be a UUID"))?
         .to_string();
-    let text = request.text.trim();
+    let text = text.trim();
     if text.is_empty() {
         return Err(bad_request("text cannot be blank"));
     }
@@ -421,7 +490,14 @@ pub async fn send_message(
     let now = chrono::Utc::now().timestamp() as i32;
     let (run, should_dispatch): (LightToolRunRecord, bool) = match auth.device.user_id {
         Some(user_id) => match repository
-            .create_account_run(auth.device.id, user_id, &client_message_id, text, now)
+            .create_account_run_with_image(
+                auth.device.id,
+                user_id,
+                &client_message_id,
+                text,
+                image_data_url.as_deref(),
+                now,
+            )
             .map_err(map_run_repository_error)?
         {
             AccountRunCreation::Created(run) => (run, true),
@@ -434,10 +510,11 @@ pub async fn send_message(
             AccountRunCreation::IdempotencyConflict => return Err(idempotency_conflict()),
         },
         None => match repository
-            .create_anonymous_trial_run(
+            .create_anonymous_trial_run_with_image(
                 auth.device.id,
                 &client_message_id,
                 text,
+                image_data_url.as_deref(),
                 now,
                 TRIAL_MESSAGE_LIMIT,
             )
@@ -497,6 +574,32 @@ pub async fn send_message(
         StatusCode::ACCEPTED,
         Json(SendMessageResponse { run_id: run.id }),
     ))
+}
+
+fn normalize_image_data_url(bytes: &[u8]) -> Result<String, ApiError> {
+    let mut reader = ImageReader::new(Cursor::new(bytes))
+        .with_guessed_format()
+        .map_err(|_| bad_request("image format could not be read"))?;
+    let mut limits = Limits::default();
+    limits.max_image_width = Some(MAX_IMAGE_DIMENSION);
+    limits.max_image_height = Some(MAX_IMAGE_DIMENSION);
+    limits.max_alloc = Some(MAX_IMAGE_DECODE_BYTES);
+    reader.limits(limits);
+    let image = reader
+        .decode()
+        .map_err(|_| bad_request("image must be a valid JPEG, PNG, or WebP file"))?;
+
+    let mut jpeg = Vec::new();
+    JpegEncoder::new_with_quality(&mut jpeg, 82)
+        .encode_image(&image)
+        .map_err(|error| {
+            tracing::error!("Light Tool image normalization failed: {error}");
+            internal_error("image processing failed")
+        })?;
+    if jpeg.len() > MAX_IMAGE_UPLOAD_BYTES {
+        return Err(bad_request("normalized image exceeds 5 MB"));
+    }
+    Ok(format!("data:image/jpeg;base64,{}", STANDARD.encode(jpeg)))
 }
 
 pub async fn get_message_history(
@@ -729,9 +832,7 @@ fn conflict(message: &str) -> ApiError {
 fn idempotency_conflict() -> ApiError {
     (
         StatusCode::CONFLICT,
-        Json(
-            json!({ "error": "client_message_id was already used under a different account state" }),
-        ),
+        Json(json!({ "error": "client_message_id was already used with different content" })),
     )
 }
 

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -750,6 +750,11 @@ async fn main() {
                 .layer(DefaultBodyLimit::max(16 * 1024)),
         )
         .route(
+            "/api/light-tool/messages/image",
+            post(handlers::light_tool_handlers::send_image_message)
+                .layer(DefaultBodyLimit::max(6 * 1024 * 1024)),
+        )
+        .route(
             "/api/light-tool/runs/{run_id}",
             get(handlers::light_tool_handlers::get_run_status),
         )

--- a/backend/src/main.rs
+++ b/backend/src/main.rs
@@ -225,7 +225,7 @@ async fn bootstrap_admin_if_needed(
         credits: 1000.0,
         credits_left: 1000.0,
         charge_when_under: false,
-        sub_tier: Some("2".to_string()), // tier 2 = sentinel (full access)
+        sub_tier: Some("tier 2".to_string()), // hosted subscription (full access)
     };
 
     match user_core.create_user(new_user) {

--- a/backend/src/models/light_tool_models.rs
+++ b/backend/src/models/light_tool_models.rs
@@ -42,6 +42,7 @@ pub struct LightToolRun {
     pub account_user_id: Option<i32>,
     pub client_message_id: String,
     pub encrypted_user_message: String,
+    pub encrypted_image_data_url: Option<String>,
     pub encrypted_activity_text: Option<String>,
     pub encrypted_assistant_message: Option<String>,
     pub encrypted_error_message: Option<String>,
@@ -60,6 +61,7 @@ pub struct NewLightToolRun {
     pub account_user_id: Option<i32>,
     pub client_message_id: String,
     pub encrypted_user_message: String,
+    pub encrypted_image_data_url: Option<String>,
     pub created_at: i32,
     pub updated_at: i32,
 }

--- a/backend/src/pg_schema.rs
+++ b/backend/src/pg_schema.rs
@@ -678,6 +678,7 @@ diesel::table! {
         account_user_id -> Nullable<Int4>,
         client_message_id -> Text,
         encrypted_user_message -> Text,
+        encrypted_image_data_url -> Nullable<Text>,
         encrypted_activity_text -> Nullable<Text>,
         encrypted_assistant_message -> Nullable<Text>,
         encrypted_error_message -> Nullable<Text>,

--- a/backend/src/repositories/light_tool_runs_repository.rs
+++ b/backend/src/repositories/light_tool_runs_repository.rs
@@ -16,6 +16,7 @@ pub struct LightToolRunRecord {
     pub account_user_id: Option<i32>,
     pub client_message_id: String,
     pub user_message: String,
+    pub image_data_url: Option<String>,
     pub activity_text: Option<String>,
     pub assistant_message: Option<String>,
     pub error_message: Option<String>,
@@ -75,6 +76,25 @@ impl LightToolRunsRepository {
         now: i32,
         message_limit: i32,
     ) -> Result<AnonymousTrialRunCreation, LightToolRunsRepositoryError> {
+        self.create_anonymous_trial_run_with_image(
+            device_id,
+            client_message_id,
+            user_message,
+            None,
+            now,
+            message_limit,
+        )
+    }
+
+    pub fn create_anonymous_trial_run_with_image(
+        &self,
+        device_id: i32,
+        client_message_id: &str,
+        user_message: &str,
+        image_data_url: Option<&str>,
+        now: i32,
+        message_limit: i32,
+    ) -> Result<AnonymousTrialRunCreation, LightToolRunsRepositoryError> {
         let mut conn = self.pool.get().expect("Failed to get DB connection");
 
         conn.transaction::<AnonymousTrialRunCreation, LightToolRunsRepositoryError, _>(|conn| {
@@ -105,8 +125,12 @@ impl LightToolRunsRepository {
                 if existing.account_user_id.is_some() {
                     return Ok(AnonymousTrialRunCreation::IdempotencyConflict);
                 }
+                let existing = decrypt_run(existing)?;
+                if existing.image_data_url.as_deref() != image_data_url {
+                    return Ok(AnonymousTrialRunCreation::IdempotencyConflict);
+                }
                 return Ok(AnonymousTrialRunCreation::Existing {
-                    run: decrypt_run(existing)?,
+                    run: existing,
                     messages_remaining: remaining_messages(&device, message_limit),
                 });
             }
@@ -137,6 +161,7 @@ impl LightToolRunsRepository {
                 account_user_id: None,
                 client_message_id: client_message_id.to_string(),
                 encrypted_user_message: encrypt(user_message)?,
+                encrypted_image_data_url: image_data_url.map(encrypt).transpose()?,
                 created_at: now,
                 updated_at: now,
             };
@@ -160,6 +185,25 @@ impl LightToolRunsRepository {
         account_user_id: i32,
         client_message_id: &str,
         user_message: &str,
+        now: i32,
+    ) -> Result<AccountRunCreation, LightToolRunsRepositoryError> {
+        self.create_account_run_with_image(
+            device_id,
+            account_user_id,
+            client_message_id,
+            user_message,
+            None,
+            now,
+        )
+    }
+
+    pub fn create_account_run_with_image(
+        &self,
+        device_id: i32,
+        account_user_id: i32,
+        client_message_id: &str,
+        user_message: &str,
+        image_data_url: Option<&str>,
         now: i32,
     ) -> Result<AccountRunCreation, LightToolRunsRepositoryError> {
         let mut conn = self.pool.get().expect("Failed to get DB connection");
@@ -191,7 +235,11 @@ impl LightToolRunsRepository {
                 if existing.account_user_id != Some(account_user_id) {
                     return Ok(AccountRunCreation::IdempotencyConflict);
                 }
-                return Ok(AccountRunCreation::Existing(decrypt_run(existing)?));
+                let existing = decrypt_run(existing)?;
+                if existing.image_data_url.as_deref() != image_data_url {
+                    return Ok(AccountRunCreation::IdempotencyConflict);
+                }
+                return Ok(AccountRunCreation::Existing(existing));
             }
 
             let new_run = NewLightToolRun {
@@ -200,6 +248,7 @@ impl LightToolRunsRepository {
                 account_user_id: Some(account_user_id),
                 client_message_id: client_message_id.to_string(),
                 encrypted_user_message: encrypt(user_message)?,
+                encrypted_image_data_url: image_data_url.map(encrypt).transpose()?,
                 created_at: now,
                 updated_at: now,
             };
@@ -351,6 +400,7 @@ impl LightToolRunsRepository {
         .set((
             light_tool_runs::status.eq("completed"),
             light_tool_runs::encrypted_activity_text.eq::<Option<String>>(None),
+            light_tool_runs::encrypted_image_data_url.eq::<Option<String>>(None),
             light_tool_runs::encrypted_assistant_message.eq(Some(encrypted_assistant_message)),
             light_tool_runs::encrypted_error_message.eq::<Option<String>>(None),
             light_tool_runs::updated_at.eq(now),
@@ -377,6 +427,7 @@ impl LightToolRunsRepository {
         .set((
             light_tool_runs::status.eq("failed"),
             light_tool_runs::encrypted_activity_text.eq::<Option<String>>(None),
+            light_tool_runs::encrypted_image_data_url.eq::<Option<String>>(None),
             light_tool_runs::encrypted_assistant_message.eq::<Option<String>>(None),
             light_tool_runs::encrypted_error_message.eq(Some(encrypted_error_message)),
             light_tool_runs::updated_at.eq(now),
@@ -405,6 +456,7 @@ impl LightToolRunsRepository {
         .set((
             light_tool_runs::status.eq("failed"),
             light_tool_runs::encrypted_activity_text.eq::<Option<String>>(None),
+            light_tool_runs::encrypted_image_data_url.eq::<Option<String>>(None),
             light_tool_runs::encrypted_assistant_message.eq::<Option<String>>(None),
             light_tool_runs::encrypted_error_message.eq(Some(encrypted_error_message)),
             light_tool_runs::updated_at.eq(now),
@@ -439,6 +491,7 @@ fn decrypt_run(run: LightToolRun) -> Result<LightToolRunRecord, EncryptionError>
         account_user_id: run.account_user_id,
         client_message_id: run.client_message_id,
         user_message: decrypt(&run.encrypted_user_message)?,
+        image_data_url: decrypt_optional(run.encrypted_image_data_url)?,
         activity_text: decrypt_optional(run.encrypted_activity_text)?,
         assistant_message: decrypt_optional(run.encrypted_assistant_message)?,
         error_message: decrypt_optional(run.encrypted_error_message)?,

--- a/backend/src/repositories/tuwunel_cleanup_repository.rs
+++ b/backend/src/repositories/tuwunel_cleanup_repository.rs
@@ -903,12 +903,40 @@ impl TuwunelCleanupRepository {
         candidate: &HistoricalBackfillCandidate,
         audit_summary: &str,
     ) -> Result<()> {
+        self.enqueue_audited_historical_backfill(
+            candidate,
+            STATUS_BACKFILL_AUDIT_VERIFIED,
+            "historical_backfill_verified",
+            audit_summary,
+        )
+    }
+
+    pub fn enqueue_forced_historical_backfill(
+        &self,
+        candidate: &HistoricalBackfillCandidate,
+        audit_summary: &str,
+    ) -> Result<()> {
+        self.enqueue_audited_historical_backfill(
+            candidate,
+            STATUS_BACKFILL_AUDIT_BLOCKED,
+            "historical_backfill_forced_unverified",
+            audit_summary,
+        )
+    }
+
+    fn enqueue_audited_historical_backfill(
+        &self,
+        candidate: &HistoricalBackfillCandidate,
+        required_status: &str,
+        command_kind: &str,
+        audit_summary: &str,
+    ) -> Result<()> {
         let mut conn = self.connection()?;
         let now = now_timestamp();
         let updated = diesel::update(
             tuwunel_cleanup_events::table
                 .filter(tuwunel_cleanup_events::event_id.eq(&candidate.event_id))
-                .filter(tuwunel_cleanup_events::status.eq(STATUS_BACKFILL_AUDIT_VERIFIED)),
+                .filter(tuwunel_cleanup_events::status.eq(required_status)),
         )
         .set((
             tuwunel_cleanup_events::ontology_message_id.eq(candidate.ontology_message_id),
@@ -917,7 +945,7 @@ impl TuwunelCleanupRepository {
             tuwunel_cleanup_events::commands_accepted.eq(0),
             tuwunel_cleanup_events::attempt_count.eq(0),
             tuwunel_cleanup_events::status.eq(STATUS_PENDING_PURGE),
-            tuwunel_cleanup_events::last_command_kind.eq(Some("historical_backfill_verified")),
+            tuwunel_cleanup_events::last_command_kind.eq(Some(command_kind)),
             tuwunel_cleanup_events::last_error.eq(Some(trim_error(audit_summary))),
             tuwunel_cleanup_events::enqueued_at.eq(now),
             tuwunel_cleanup_events::last_attempted_at.eq(None::<i32>),
@@ -927,8 +955,9 @@ impl TuwunelCleanupRepository {
         .execute(&mut conn)?;
         if updated != 1 {
             return Err(anyhow!(
-                "verified historical boundary {} was not in an auditable state",
-                candidate.event_id
+                "historical boundary {} was not in required audit state {}",
+                candidate.event_id,
+                required_status
             ));
         }
         Ok(())

--- a/backend/src/services/light_tool_agent_responder.rs
+++ b/backend/src/services/light_tool_agent_responder.rs
@@ -155,6 +155,7 @@ impl LightToolResponder for LightToolAgentResponder {
         principal: LightToolRunPrincipal,
         history: &[LightToolConversationTurn],
         user_message: &str,
+        image_data_url: Option<&str>,
         activity_tx: mpsc::Sender<String>,
     ) -> Result<String, String> {
         let _ = activity_tx.send(CONTACTING_ACTIVITY.to_string()).await;
@@ -167,6 +168,7 @@ impl LightToolResponder for LightToolAgentResponder {
                     &self.ai_config,
                     anonymous_light_tool_tools(),
                     request.messages,
+                    image_data_url,
                     activity_tx,
                 )
                 .await?;
@@ -195,7 +197,9 @@ impl LightToolResponder for LightToolAgentResponder {
 
                 let input = build_account_agent_input(&state, &user, user_message).await?;
                 persist_account_turn(&state, user.id, "user", user_message, input.current_time);
-                let reply = execute_account_agent(&state, &user, input, activity_tx).await?;
+                let reply =
+                    execute_account_agent(&state, &user, input, image_data_url, activity_tx)
+                        .await?;
                 if crate::services::metronome_billing::metronome_enabled() {
                     let billed_cost = crate::services::usage_pricing::billable_customer_cost_usd(
                         reply.provider_cost_usd,
@@ -246,6 +250,7 @@ async fn execute_anonymous_agent(
     ai_config: &AiConfig,
     tools: Vec<chat_completion::Tool>,
     completion_messages: Vec<chat_completion::ChatCompletionMessage>,
+    image_data_url: Option<&str>,
     activity_tx: mpsc::Sender<String>,
 ) -> Result<PreparedAgentReply, String> {
     let (reasoning_tx, reasoning_rx) = mpsc::channel::<String>(8);
@@ -261,7 +266,7 @@ async fn execute_anonymous_agent(
             },
             model_purpose: ModelPurpose::Default,
             user_given_info: "",
-            image_url: None,
+            image_url: image_data_url,
             tools: &tools,
             completion_messages,
             skip_sms: true,
@@ -287,6 +292,7 @@ async fn execute_account_agent(
     state: &Arc<AppState>,
     user: &User,
     input: AccountLightToolAgentInput,
+    image_data_url: Option<&str>,
     activity_tx: mpsc::Sender<String>,
 ) -> Result<PreparedAgentReply, String> {
     let (reasoning_tx, reasoning_rx) = mpsc::channel::<String>(8);
@@ -299,7 +305,7 @@ async fn execute_account_agent(
             principal: AgentPrincipal::Account { state, user },
             model_purpose: input.model_purpose,
             user_given_info: &input.user_given_info,
-            image_url: None,
+            image_url: image_data_url,
             tools: &input.tools,
             completion_messages: input.completion_messages,
             skip_sms: true,

--- a/backend/src/services/light_tool_run_dispatcher.rs
+++ b/backend/src/services/light_tool_run_dispatcher.rs
@@ -36,6 +36,7 @@ pub trait LightToolResponder: Send + Sync {
         principal: LightToolRunPrincipal,
         history: &[LightToolConversationTurn],
         user_message: &str,
+        image_data_url: Option<&str>,
         activity_tx: mpsc::Sender<String>,
     ) -> Result<String, String>;
 }
@@ -98,7 +99,13 @@ pub async fn dispatch_light_tool_run(
             device_id: run.device_id,
         },
     };
-    let response = responder.respond(principal, &history, &run.user_message, activity_tx);
+    let response = responder.respond(
+        principal,
+        &history,
+        &run.user_message,
+        run.image_data_url.as_deref(),
+        activity_tx,
+    );
     tokio::pin!(response);
     let mut activity_closed = false;
 

--- a/backend/src/utils/tuwunel_event_cleanup.rs
+++ b/backend/src/utils/tuwunel_event_cleanup.rs
@@ -46,6 +46,7 @@ struct EventPurgeConfig {
     backfill_enabled: bool,
     backfill_audit_enabled: bool,
     backfill_execute_verified_enabled: bool,
+    backfill_execute_blocked_enabled: bool,
     backfill_batch_size: usize,
     backfill_scan_secs: u64,
     backfill_min_age_secs: u64,
@@ -59,6 +60,7 @@ struct EventPurgeConfig {
 #[derive(Debug, Default)]
 struct PurgeCycleOutcome {
     backfilled: usize,
+    forced_backfilled: usize,
     audited: usize,
 }
 
@@ -317,6 +319,7 @@ pub async fn start_tuwunel_event_purge_worker(state: Arc<AppState>) {
                 backfill_enabled = config.backfill_enabled,
                 backfill_audit_enabled = config.backfill_audit_enabled,
                 backfill_execute_verified_enabled = config.backfill_execute_verified_enabled,
+                backfill_execute_blocked_enabled = config.backfill_execute_blocked_enabled,
                 backfill_batch_size = config.backfill_batch_size,
                 backfill_scan_secs = config.backfill_scan_secs,
                 backfill_min_age_secs = config.backfill_min_age_secs,
@@ -329,8 +332,9 @@ pub async fn start_tuwunel_event_purge_worker(state: Arc<AppState>) {
             );
         }
         let now = now_timestamp();
-        let destructive_backfill_enabled =
-            config.backfill_enabled && config.backfill_execute_verified_enabled;
+        let destructive_backfill_enabled = config.backfill_enabled
+            && (config.backfill_execute_verified_enabled
+                || config.backfill_execute_blocked_enabled);
         let run_backfill = (config.backfill_audit_enabled || destructive_backfill_enabled)
             && now >= next_backfill_scan_at;
         match run_purge_cycle(&state, &config, run_backfill).await {
@@ -349,6 +353,7 @@ pub async fn start_tuwunel_event_purge_worker(state: Arc<AppState>) {
                 tracing::info!(
                     audited = outcome.audited,
                     enqueued = outcome.backfilled,
+                    forced_enqueued = outcome.forced_backfilled,
                     next_backfill_scan_at,
                     destructive_backfill_enabled,
                     "Tuwunel historical audit cycle scheduled"
@@ -419,10 +424,10 @@ async fn run_purge_cycle(
         );
     }
 
-    let (audited, backfilled) = if run_backfill {
+    let (audited, backfilled, forced_backfilled) = if run_backfill {
         run_historical_backfill_audit(state, config, now).await?
     } else {
-        (0, 0)
+        (0, 0, 0)
     };
 
     log_stale_blockers(state, stale_ingest_cutoff, now)?;
@@ -446,6 +451,7 @@ async fn run_purge_cycle(
         }
         return Ok(PurgeCycleOutcome {
             backfilled,
+            forced_backfilled,
             audited,
         });
     }
@@ -453,6 +459,7 @@ async fn run_purge_cycle(
     if due.is_empty() && submitted.is_empty() {
         return Ok(PurgeCycleOutcome {
             backfilled,
+            forced_backfilled,
             audited,
         });
     }
@@ -472,6 +479,7 @@ async fn run_purge_cycle(
 
     Ok(PurgeCycleOutcome {
         backfilled,
+        forced_backfilled,
         audited,
     })
 }
@@ -480,13 +488,16 @@ async fn run_historical_backfill_audit(
     state: &Arc<AppState>,
     config: &EventPurgeConfig,
     now: i32,
-) -> Result<(usize, usize)> {
+) -> Result<(usize, usize, usize)> {
     let boundary_cutoff =
         now.saturating_sub(config.backfill_min_age_secs.min(i32::MAX as u64) as i32);
-    let audit_recheck_cutoff =
-        now.saturating_sub(config.backfill_audit_recheck_secs.min(i32::MAX as u64) as i32);
-    let destructive_backfill_enabled =
-        config.backfill_enabled && config.backfill_execute_verified_enabled;
+    let destructive_backfill_enabled = config.backfill_enabled
+        && (config.backfill_execute_verified_enabled || config.backfill_execute_blocked_enabled);
+    let audit_recheck_cutoff = if destructive_backfill_enabled {
+        now
+    } else {
+        now.saturating_sub(config.backfill_audit_recheck_secs.min(i32::MAX as u64) as i32)
+    };
     let batch_size = if destructive_backfill_enabled {
         config.backfill_batch_size
     } else {
@@ -498,6 +509,7 @@ async fn run_historical_backfill_audit(
 
     let mut audited = 0;
     let mut enqueued = 0;
+    let mut forced_enqueued = 0;
     for candidate in candidates {
         let audit = match audit_historical_backfill_candidate(state, config, &candidate).await {
             Ok(audit) => audit,
@@ -511,27 +523,64 @@ async fn run_historical_backfill_audit(
             .record_historical_backfill_audit(&candidate, audit.verified, &audit.summary)?;
         audited += 1;
 
-        if audit.verified && destructive_backfill_enabled {
-            state
-                .tuwunel_cleanup_repository
-                .enqueue_verified_historical_backfill(&candidate, &audit.summary)?;
-            enqueued += 1;
+        let execution_kind = historical_backfill_execution_kind(
+            audit.verified,
+            config.backfill_enabled,
+            config.backfill_execute_verified_enabled,
+            config.backfill_execute_blocked_enabled,
+        );
+        match execution_kind {
+            Some("historical_backfill_verified") => {
+                state
+                    .tuwunel_cleanup_repository
+                    .enqueue_verified_historical_backfill(&candidate, &audit.summary)?;
+                enqueued += 1;
+            }
+            Some("historical_backfill_forced_unverified") => {
+                state
+                    .tuwunel_cleanup_repository
+                    .enqueue_forced_historical_backfill(&candidate, &audit.summary)?;
+                enqueued += 1;
+                forced_enqueued += 1;
+            }
+            Some(_) | None => {}
         }
 
-        tracing::info!(
+        let forced = execution_kind == Some("historical_backfill_forced_unverified");
+        tracing::warn!(
             user_id = candidate.user_id,
             service = candidate.service,
             room_id = candidate.room_id,
             boundary_event_id = candidate.event_id,
             boundary_created_at = candidate.created_at,
             verified = audit.verified,
-            enqueued = audit.verified && destructive_backfill_enabled,
+            enqueued = execution_kind.is_some(),
+            forced,
+            execution_kind = execution_kind.unwrap_or("audit_only"),
             audit = audit.summary,
             "Tuwunel historical room audit completed"
         );
     }
 
-    Ok((audited, enqueued))
+    Ok((audited, enqueued, forced_enqueued))
+}
+
+pub fn historical_backfill_execution_kind(
+    verified: bool,
+    backfill_enabled: bool,
+    execute_verified_enabled: bool,
+    execute_blocked_enabled: bool,
+) -> Option<&'static str> {
+    if !backfill_enabled {
+        return None;
+    }
+    if verified && execute_verified_enabled {
+        return Some("historical_backfill_verified");
+    }
+    if !verified && execute_blocked_enabled {
+        return Some("historical_backfill_forced_unverified");
+    }
+    None
 }
 
 async fn audit_historical_backfill_candidate(
@@ -1031,11 +1080,15 @@ impl EventPurgeConfig {
                 1,
             )
             .min(100) as usize,
-            backfill_enabled: env_flag("TUWUNEL_EVENT_PURGE_BACKFILL_ENABLED", false),
+            backfill_enabled: env_flag("TUWUNEL_EVENT_PURGE_BACKFILL_ENABLED", true),
             backfill_audit_enabled: env_flag("TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_ENABLED", true),
             backfill_execute_verified_enabled: env_flag(
                 "TUWUNEL_EVENT_PURGE_BACKFILL_EXECUTE_VERIFIED_ENABLED",
-                false,
+                true,
+            ),
+            backfill_execute_blocked_enabled: env_flag(
+                "TUWUNEL_EVENT_PURGE_BACKFILL_EXECUTE_BLOCKED_ENABLED",
+                true,
             ),
             backfill_batch_size: env_u64(
                 "TUWUNEL_EVENT_PURGE_BACKFILL_BATCH_SIZE",

--- a/backend/tests/light_tool_messages_handler_test.rs
+++ b/backend/tests/light_tool_messages_handler_test.rs
@@ -22,7 +22,10 @@ use backend::{
 };
 use diesel::prelude::*;
 use serde_json::{json, Value};
-use std::sync::{Arc, Mutex};
+use std::{
+    io::Cursor,
+    sync::{Arc, Mutex},
+};
 use tokio::sync::mpsc;
 use tower::ServiceExt;
 use uuid::Uuid;
@@ -170,6 +173,7 @@ impl LightToolResponder for ImmediateFakeResponder {
         _principal: LightToolRunPrincipal,
         _history: &[backend::services::light_tool_run_dispatcher::LightToolConversationTurn],
         _user_message: &str,
+        _image_data_url: Option<&str>,
         activity_tx: mpsc::Sender<String>,
     ) -> Result<String, String> {
         activity_tx.send("ANSWERING".to_string()).await.unwrap();
@@ -181,6 +185,25 @@ struct PrincipalCapturingResponder {
     principal: Arc<Mutex<Option<LightToolRunPrincipal>>>,
 }
 
+struct ImageCapturingResponder {
+    image_data_url: Arc<Mutex<Option<String>>>,
+}
+
+#[async_trait]
+impl LightToolResponder for ImageCapturingResponder {
+    async fn respond(
+        &self,
+        _principal: LightToolRunPrincipal,
+        _history: &[backend::services::light_tool_run_dispatcher::LightToolConversationTurn],
+        _user_message: &str,
+        image_data_url: Option<&str>,
+        _activity_tx: mpsc::Sender<String>,
+    ) -> Result<String, String> {
+        *self.image_data_url.lock().unwrap() = image_data_url.map(str::to_string);
+        Ok("I received the photo.".to_string())
+    }
+}
+
 #[async_trait]
 impl LightToolResponder for PrincipalCapturingResponder {
     async fn respond(
@@ -188,11 +211,72 @@ impl LightToolResponder for PrincipalCapturingResponder {
         principal: LightToolRunPrincipal,
         _history: &[backend::services::light_tool_run_dispatcher::LightToolConversationTurn],
         _user_message: &str,
+        _image_data_url: Option<&str>,
         _activity_tx: mpsc::Sender<String>,
     ) -> Result<String, String> {
         *self.principal.lock().unwrap() = Some(principal);
         Ok("Connected reply".to_string())
     }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn image_message_is_normalized_dispatched_and_removed_after_completion() {
+    std::env::set_var("ENCRYPTION_KEY", TEST_ENCRYPTION_KEY);
+    let captured_image = Arc::new(Mutex::new(None));
+    let mut state = create_test_state();
+    Arc::get_mut(&mut state).unwrap().light_tool_responder =
+        Some(Arc::new(ImageCapturingResponder {
+            image_data_url: captured_image.clone(),
+        }));
+    let now = chrono::Utc::now().timestamp() as i32;
+    let session =
+        LightToolBootstrapService::new(LightToolDevicesRepository::new(state.pg_pool.clone()))
+            .bootstrap(INSTALLATION_ID, None, now)
+            .unwrap();
+    let device = LightToolDevicesRepository::new(state.pg_pool.clone())
+        .find_active_by_token_hash(&hash_device_token(&session.device_token).unwrap())
+        .unwrap()
+        .unwrap();
+    let app = light_tool_router(state.clone());
+    let client_message_id = Uuid::new_v4().to_string();
+    let mut png = Cursor::new(Vec::new());
+    image::DynamicImage::new_rgb8(2, 2)
+        .write_to(&mut png, image::ImageOutputFormat::Png)
+        .unwrap();
+
+    let response = send_image_request(
+        &app,
+        &session.device_token,
+        &client_message_id,
+        png.get_ref(),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+    let run_id = response_json(response).await["run_id"]
+        .as_str()
+        .unwrap()
+        .to_string();
+
+    let mut completed = false;
+    for _ in 0..100 {
+        let run = LightToolRunsRepository::new(state.pg_pool.clone())
+            .find_by_id_for_device(&run_id, device.id)
+            .unwrap()
+            .unwrap();
+        if run.status == "completed" {
+            assert_eq!(run.image_data_url, None);
+            completed = true;
+            break;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    assert!(completed, "image run did not complete");
+    assert!(captured_image
+        .lock()
+        .unwrap()
+        .as_deref()
+        .is_some_and(|value| value.starts_with("data:image/jpeg;base64,")));
 }
 
 #[tokio::test]
@@ -508,6 +592,10 @@ fn light_tool_router(state: std::sync::Arc<backend::AppState>) -> Router {
             post(light_tool_handlers::send_message).get(light_tool_handlers::get_message_history),
         )
         .route(
+            "/api/light-tool/messages/image",
+            post(light_tool_handlers::send_image_message),
+        )
+        .route(
             "/api/light-tool/runs/{run_id}",
             get(light_tool_handlers::get_run_status),
         )
@@ -546,6 +634,50 @@ async fn send_request(
                     })
                     .to_string(),
                 ))
+                .unwrap(),
+        )
+        .await
+        .unwrap()
+}
+
+async fn send_image_request(
+    app: &Router,
+    device_token: &str,
+    client_message_id: &str,
+    image: &[u8],
+) -> axum::response::Response {
+    let boundary = "lightfriend-test-boundary";
+    let mut body = Vec::new();
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"client_message_id\"\r\n\r\n{client_message_id}\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(
+        format!("--{boundary}\r\nContent-Disposition: form-data; name=\"text\"\r\n\r\nPhoto\r\n")
+            .as_bytes(),
+    );
+    body.extend_from_slice(
+        format!(
+            "--{boundary}\r\nContent-Disposition: form-data; name=\"image\"; filename=\"photo.png\"\r\nContent-Type: image/png\r\n\r\n"
+        )
+        .as_bytes(),
+    );
+    body.extend_from_slice(image);
+    body.extend_from_slice(format!("\r\n--{boundary}--\r\n").as_bytes());
+
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/api/light-tool/messages/image")
+                .header("authorization", format!("Bearer {device_token}"))
+                .header(
+                    "content-type",
+                    format!("multipart/form-data; boundary={boundary}"),
+                )
+                .body(Body::from(body))
                 .unwrap(),
         )
         .await

--- a/backend/tests/light_tool_runs_repository_test.rs
+++ b/backend/tests/light_tool_runs_repository_test.rs
@@ -353,6 +353,7 @@ async fn account_responder_returns_subscription_guidance_without_calling_the_mod
             },
             &[],
             "Check my email",
+            None,
             activity_tx,
         )
         .await
@@ -837,6 +838,7 @@ impl LightToolResponder for FakeResponder {
         _principal: LightToolRunPrincipal,
         history: &[LightToolConversationTurn],
         _user_message: &str,
+        _image_data_url: Option<&str>,
         activity_tx: mpsc::Sender<String>,
     ) -> Result<String, String> {
         assert_eq!(history, self.expected_history);

--- a/backend/tests/tuwunel_event_cleanup_test.rs
+++ b/backend/tests/tuwunel_event_cleanup_test.rs
@@ -2,9 +2,9 @@ use backend::utils::disconnected_bridge_cleanup::{
     bridge_cleanup_execution_allowed, build_delete_room_url, build_room_members_url,
 };
 use backend::utils::tuwunel_event_cleanup::{
-    build_purge_history_url, build_purge_status_url, historical_event_requires_proof,
-    is_matrix_event_id, is_tuwunel_admin_redaction_reason, next_backfill_scan_timestamp,
-    purge_history_request,
+    build_purge_history_url, build_purge_status_url, historical_backfill_execution_kind,
+    historical_event_requires_proof, is_matrix_event_id, is_tuwunel_admin_redaction_reason,
+    next_backfill_scan_timestamp, purge_history_request,
 };
 use serde_json::json;
 
@@ -137,4 +137,24 @@ fn historical_audit_allows_state_and_non_payload_housekeeping() {
     assert!(!historical_event_requires_proof("m.room.member", true));
     assert!(!historical_event_requires_proof("m.reaction", false));
     assert!(!historical_event_requires_proof("m.room.redaction", false));
+}
+
+#[test]
+fn historical_backfill_keeps_verified_and_forced_paths_distinct() {
+    assert_eq!(
+        historical_backfill_execution_kind(true, true, true, true),
+        Some("historical_backfill_verified")
+    );
+    assert_eq!(
+        historical_backfill_execution_kind(false, true, true, true),
+        Some("historical_backfill_forced_unverified")
+    );
+    assert_eq!(
+        historical_backfill_execution_kind(false, true, true, false),
+        None
+    );
+    assert_eq!(
+        historical_backfill_execution_kind(false, false, true, true),
+        None
+    );
 }

--- a/enclave/storage-health.sh
+++ b/enclave/storage-health.sh
@@ -332,7 +332,7 @@ print_deleted_open_file_accounting() {
 
 print_tuwunel_purge_audit() {
     echo "--- Tuwunel purge compact audit ---"
-    echo "historical_audit_policy backfill_enabled=${TUWUNEL_EVENT_PURGE_BACKFILL_ENABLED:-false} audit_enabled=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_ENABLED:-true} execute_verified_enabled=${TUWUNEL_EVENT_PURGE_BACKFILL_EXECUTE_VERIFIED_ENABLED:-false} batch_size=${TUWUNEL_EVENT_PURGE_BACKFILL_BATCH_SIZE:-25} scan_secs=${TUWUNEL_EVENT_PURGE_BACKFILL_SCAN_SECS:-3600} min_age_secs=${TUWUNEL_EVENT_PURGE_BACKFILL_MIN_AGE_SECS:-86400} recheck_secs=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_RECHECK_SECS:-86400} max_pages=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_MAX_PAGES:-100} page_size=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_PAGE_SIZE:-100}"
+    echo "historical_audit_policy backfill_enabled=${TUWUNEL_EVENT_PURGE_BACKFILL_ENABLED:-true} audit_enabled=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_ENABLED:-true} execute_verified_enabled=${TUWUNEL_EVENT_PURGE_BACKFILL_EXECUTE_VERIFIED_ENABLED:-true} execute_blocked_enabled=${TUWUNEL_EVENT_PURGE_BACKFILL_EXECUTE_BLOCKED_ENABLED:-true} batch_size=${TUWUNEL_EVENT_PURGE_BACKFILL_BATCH_SIZE:-25} scan_secs=${TUWUNEL_EVENT_PURGE_BACKFILL_SCAN_SECS:-3600} min_age_secs=${TUWUNEL_EVENT_PURGE_BACKFILL_MIN_AGE_SECS:-86400} recheck_secs=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_RECHECK_SECS:-86400} max_pages=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_MAX_PAGES:-100} page_size=${TUWUNEL_EVENT_PURGE_BACKFILL_AUDIT_PAGE_SIZE:-100}"
     echo "disconnected_bridge_policy audit_enabled=${TUWUNEL_DISCONNECTED_BRIDGE_PURGE_AUDIT_ENABLED:-true} execute_enabled=${TUWUNEL_DISCONNECTED_BRIDGE_PURGE_ENABLED:-true} orphan_execute_enabled=${TUWUNEL_DISCONNECTED_BRIDGE_ORPHAN_PURGE_ENABLED:-false} grace_secs=${TUWUNEL_DISCONNECTED_BRIDGE_PURGE_GRACE_SECS:-120} batch_size=${TUWUNEL_DISCONNECTED_BRIDGE_PURGE_BATCH_SIZE:-5} room_delete_limit=${TUWUNEL_DISCONNECTED_BRIDGE_PURGE_ROOM_LIMIT:-1}"
     if ! command -v psql >/dev/null 2>&1 || [ -z "${PG_DATABASE_URL:-}" ]; then
         echo "psql or PG_DATABASE_URL unavailable"
@@ -378,6 +378,19 @@ print_tuwunel_purge_audit() {
          WHERE status IN ('\''backfill_audit_verified'\'', '\''backfill_audit_blocked'\'')
          GROUP BY status, service, split_part(COALESCE(last_error, '\''reason unavailable'\''), '\'' '\'', 1)
          ORDER BY rows DESC, status, service, reason_code;
+
+        SELECT COALESCE(last_command_kind, '\''unknown'\'') AS historical_execution_kind,
+               status,
+               count(*) AS rows,
+               count(DISTINCT room_id) AS rooms,
+               to_char(to_timestamp(max(updated_at)), '\''YYYY-MM-DD"T"HH24:MI:SS"Z"'\'') AS last_updated
+          FROM tuwunel_cleanup_events
+         WHERE last_command_kind IN (
+                   '\''historical_backfill_verified'\'',
+                   '\''historical_backfill_forced_unverified'\''
+               )
+         GROUP BY COALESCE(last_command_kind, '\''unknown'\''), status
+         ORDER BY historical_execution_kind, status;
 
         SELECT cleanup.status,
                cleanup.user_id,

--- a/frontend/src/dashboard/dashboard_view.rs
+++ b/frontend/src/dashboard/dashboard_view.rs
@@ -263,62 +263,6 @@ const DASHBOARD_STYLES: &str = r#"
     margin: 0 0.4rem;
     color: #444;
 }
-.value-stats-card {
-    display: flex;
-    flex-direction: column;
-    gap: 0.55rem;
-    padding: 0.75rem 0.85rem;
-    border-radius: 8px;
-    border: 1px solid rgba(126, 178, 255, 0.16);
-    background: rgba(126, 178, 255, 0.06);
-}
-.value-stats-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 0.75rem;
-}
-.value-stats-kicker {
-    color: #7EB2FF;
-    font-size: 0.72rem;
-    font-weight: 700;
-    text-transform: uppercase;
-}
-.value-stats-sentence {
-    color: #e6e6e6;
-    font-size: 0.92rem;
-    line-height: 1.45;
-}
-.value-stats-grid {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.45rem;
-}
-.value-stat {
-    min-width: 0;
-    padding: 0.45rem 0.5rem;
-    border-radius: 6px;
-    background: rgba(0, 0, 0, 0.18);
-    border: 1px solid rgba(255, 255, 255, 0.07);
-}
-.value-stat-number {
-    color: #fff;
-    font-size: 1.15rem;
-    font-weight: 700;
-    line-height: 1.1;
-}
-.value-stat-label {
-    color: #9ca3af;
-    font-size: 0.68rem;
-    line-height: 1.25;
-    margin-top: 0.25rem;
-}
-.value-stats-feedback {
-    color: #9ca3af;
-    font-size: 0.74rem;
-    line-height: 1.35;
-}
-
 /* ---- Tracked Events ---- */
 .events-section {
     display: flex;
@@ -540,8 +484,14 @@ const DASHBOARD_STYLES: &str = r#"
 .sidebar-footer .sidebar-footer-links {
     margin-top: 0.25rem;
 }
+.monthly-stats-line {
+    margin-bottom: 0.3rem;
+    color: rgba(255, 255, 255, 0.48);
+    font-variant-numeric: tabular-nums;
+}
 @media (prefers-color-scheme: light) {
     .sidebar-footer { color: rgba(0, 0, 0, 0.35); }
+    .monthly-stats-line { color: rgba(0, 0, 0, 0.5); }
     .sidebar-footer a { color: rgba(0, 0, 0, 0.45); }
     .sidebar-footer a:hover { color: #1E90FF; }
 }
@@ -802,11 +752,6 @@ const DASHBOARD_STYLES: &str = r#"
     .monitoring-status { color: #16a34a; }
     .monitoring-dot { background: #16a34a; }
     .assistant-plan-note { color: #666; background: rgba(0,0,0,0.02); border-color: rgba(0,0,0,0.08); }
-    .value-stats-card { background: rgba(30, 100, 220, 0.05); border-color: rgba(30, 100, 220, 0.14); }
-    .value-stats-sentence { color: #333; }
-    .value-stat { background: rgba(255,255,255,0.8); border-color: rgba(0,0,0,0.08); }
-    .value-stat-number { color: #1f2937; }
-    .value-stat-label, .value-stats-feedback { color: #666; }
     .rules-compact-bar { border-bottom-color: rgba(0,0,0,0.06); color: #888; }
     .rules-expandable.expanded { border-bottom-color: rgba(0,0,0,0.06); }
 }
@@ -832,14 +777,9 @@ struct DashboardSummaryResponse {
 #[derive(Clone, PartialEq, Deserialize)]
 struct DashboardValueStatsResponse {
     period_label: String,
-    watched_messages: i64,
     quieted_messages: i64,
     interruptions_sent: i64,
     quiet_percent: Option<i64>,
-    feedback_total: i64,
-    feedback_worth_it: i64,
-    feedback_should_wait: i64,
-    value_sentence: String,
 }
 
 #[derive(Clone, PartialEq, Deserialize)]
@@ -1503,7 +1443,6 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
         let chat_prefill = chat_prefill.clone();
         Callback::from(move |_: ()| chat_prefill.set(None))
     };
-
     // Build visible action items
     let visible_action_items: Vec<&ActionItemResponse> = (*summary)
         .as_ref()
@@ -1547,40 +1486,30 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
             .unwrap_or_else(|| timestamp.to_string())
     };
 
-    let value_stats_card = (*summary)
+    let value_stats_line = (*summary)
         .as_ref()
         .map(|s| s.value_stats.clone())
         .map(|stats| {
             let quiet_detail = stats
                 .quiet_percent
-                .map(|pct| format!("{}% quiet", pct))
-                .unwrap_or_else(|| "No quiet ratio yet".to_string());
-            let feedback_text = if stats.feedback_total > 0 {
-                format!(
-                    "{} alert ratings: {} worth it, {} should have waited.",
-                    stats.feedback_total, stats.feedback_worth_it, stats.feedback_should_wait
-                )
+                .map(|pct| format!(" ({}%)", pct))
+                .unwrap_or_default();
+            let interruption_label = if stats.interruptions_sent == 1 {
+                "interruption"
             } else {
-                "After an important alert, reply 1 if it was worth it or 2 if it should have waited.".to_string()
+                "interruptions"
             };
 
             html! {
-                <div class="value-stats-card">
-                    <div class="value-stats-header">
-                        <div class="value-stats-kicker">{stats.period_label.clone()}</div>
-                    </div>
-                    <div class="value-stats-sentence">{stats.value_sentence.clone()}</div>
-                    <div class="value-stats-grid">
-                        <div class="value-stat">
-                            <div class="value-stat-number">{stats.quieted_messages}</div>
-                            <div class="value-stat-label">{format!("let wait - {}", quiet_detail)}</div>
-                        </div>
-                        <div class="value-stat">
-                            <div class="value-stat-number">{stats.interruptions_sent}</div>
-                            <div class="value-stat-label">{"interruptions"}</div>
-                        </div>
-                    </div>
-                    <div class="value-stats-feedback">{feedback_text}</div>
+                <div class="monthly-stats-line">
+                    {format!(
+                        "{}: {} messages left quiet{} and {} {}.",
+                        stats.period_label,
+                        stats.quieted_messages,
+                        quiet_detail,
+                        stats.interruptions_sent,
+                        interruption_label,
+                    )}
                 </div>
             }
         })
@@ -1964,8 +1893,6 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
                         </div>
                     }
 
-                    {value_stats_card}
-
                     // ChatBox
                     <div>
                         if let Some(ref num) = props.user_profile.sms_from_number {
@@ -2275,6 +2202,7 @@ pub fn dashboard_view(props: &DashboardViewProps) -> Html {
 
                 // ---- Footer links ----
                 <div class="sidebar-footer">
+                    {value_stats_line}
                     <div>{"Source code on "}
                         <a href="https://github.com/ahtavarasmus/lightfriend" target="_blank" rel="noopener noreferrer">{"GitHub"}</a>
                     </div>


### PR DESCRIPTION
## Summary
- add authenticated multipart photo-message endpoint
- encrypt queued image payloads and delete them after run completion
- pass normalized JPEG data to Light Tool agents

## Validation
- cargo fmt --all -- --check
- cargo test --test light_tool_messages_handler_test --test light_tool_runs_repository_test (30 passed)