### PR TITLE
Send Light Tool photos to the vision model

### DIFF
--- a/backend/src/services/light_tool_agent_responder.rs
+++ b/backend/src/services/light_tool_agent_responder.rs
@@ -123,6 +123,49 @@ pub fn build_anonymous_chat_request(
     chat_completion::ChatCompletionRequest::new(String::new(), messages)
 }
 
+pub fn attach_image_to_latest_user_message(
+    messages: &mut [chat_completion::ChatCompletionMessage],
+    image_data_url: Option<&str>,
+) {
+    let Some(image_data_url) = image_data_url else {
+        return;
+    };
+    let Some(message) = messages
+        .iter_mut()
+        .rev()
+        .find(|message| message.role == chat_completion::MessageRole::user)
+    else {
+        return;
+    };
+
+    let existing_content = std::mem::replace(
+        &mut message.content,
+        chat_completion::Content::Text(String::new()),
+    );
+    let mut parts = match existing_content {
+        chat_completion::Content::Text(text) => {
+            let mut parts = Vec::new();
+            if !text.trim().is_empty() {
+                parts.push(chat_completion::ImageUrl {
+                    r#type: chat_completion::ContentType::text,
+                    text: Some(text),
+                    image_url: None,
+                });
+            }
+            parts
+        }
+        chat_completion::Content::ImageUrl(parts) => parts,
+    };
+    parts.push(chat_completion::ImageUrl {
+        r#type: chat_completion::ContentType::image_url,
+        text: None,
+        image_url: Some(chat_completion::ImageUrlType {
+            url: image_data_url.to_string(),
+        }),
+    });
+    message.content = chat_completion::Content::ImageUrl(parts);
+}
+
 fn chat_message(
     role: chat_completion::MessageRole,
     content: String,
@@ -249,10 +292,11 @@ async fn execute_anonymous_agent(
     device_id: i32,
     ai_config: &AiConfig,
     tools: Vec<chat_completion::Tool>,
-    completion_messages: Vec<chat_completion::ChatCompletionMessage>,
+    mut completion_messages: Vec<chat_completion::ChatCompletionMessage>,
     image_data_url: Option<&str>,
     activity_tx: mpsc::Sender<String>,
 ) -> Result<PreparedAgentReply, String> {
+    attach_image_to_latest_user_message(&mut completion_messages, image_data_url);
     let (reasoning_tx, reasoning_rx) = mpsc::channel::<String>(8);
     let (status_tx, status_rx) = mpsc::channel::<AgentStatus>(8);
     let reasoning_sender = Some(reasoning_tx);
@@ -291,10 +335,11 @@ async fn execute_anonymous_agent(
 async fn execute_account_agent(
     state: &Arc<AppState>,
     user: &User,
-    input: AccountLightToolAgentInput,
+    mut input: AccountLightToolAgentInput,
     image_data_url: Option<&str>,
     activity_tx: mpsc::Sender<String>,
 ) -> Result<PreparedAgentReply, String> {
+    attach_image_to_latest_user_message(&mut input.completion_messages, image_data_url);
     let (reasoning_tx, reasoning_rx) = mpsc::channel::<String>(8);
     let (status_tx, status_rx) = mpsc::channel::<AgentStatus>(8);
     let reasoning_sender = Some(reasoning_tx);

--- a/backend/tests/light_tool_runs_repository_test.rs
+++ b/backend/tests/light_tool_runs_repository_test.rs
@@ -15,7 +15,8 @@ use backend::{
     },
     services::{
         light_tool_agent_responder::{
-            build_account_agent_input, build_anonymous_chat_request, LightToolAgentResponder,
+            attach_image_to_latest_user_message, build_account_agent_input,
+            build_anonymous_chat_request, LightToolAgentResponder,
         },
         light_tool_bootstrap::{
             LightToolBootstrapService, TRIAL_DURATION_SECONDS, TRIAL_MESSAGE_LIMIT,
@@ -85,6 +86,44 @@ fn anonymous_ai_request_contains_only_system_and_user_messages() {
         _ => panic!("expected a text user message"),
     };
     assert_eq!(user_message, "What is my name?");
+}
+
+#[test]
+fn image_attachment_makes_the_latest_user_message_multimodal() {
+    let history = vec![LightToolConversationTurn {
+        user_message: "Earlier question".to_string(),
+        assistant_message: "Earlier answer".to_string(),
+    }];
+    let mut request = build_anonymous_chat_request(&history, "What is in this photo?");
+
+    attach_image_to_latest_user_message(
+        &mut request.messages,
+        Some("data:image/jpeg;base64,dGVzdA=="),
+    );
+
+    assert!(matches!(
+        &request.messages[1].content,
+        openai_api_rs::v1::chat_completion::Content::Text(text)
+            if text == "Earlier question"
+    ));
+    let openai_api_rs::v1::chat_completion::Content::ImageUrl(parts) = &request.messages[3].content
+    else {
+        panic!("expected multimodal user content");
+    };
+    assert_eq!(parts.len(), 2);
+    assert_eq!(
+        parts[0].r#type,
+        openai_api_rs::v1::chat_completion::ContentType::text
+    );
+    assert_eq!(parts[0].text.as_deref(), Some("What is in this photo?"));
+    assert_eq!(
+        parts[1].r#type,
+        openai_api_rs::v1::chat_completion::ContentType::image_url
+    );
+    assert_eq!(
+        parts[1].image_url.as_ref().map(|image| image.url.as_str()),
+        Some("data:image/jpeg;base64,dGVzdA==")
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- attach uploaded Light Tool images to the latest user message as multimodal model input
- preserve the image for tool calls as before
- add regression coverage for the text and image content parts

## Validation
- cargo fmt --all -- --check
- cargo test --test light_tool_runs_repository_test --test light_tool_messages_handler_test (31 passed)